### PR TITLE
test: enhance Valgrind support and update documentation

### DIFF
--- a/include/cvt/crypt/chacha20_cvt.h
+++ b/include/cvt/crypt/chacha20_cvt.h
@@ -43,22 +43,8 @@ public:
     
     chacha20_cvt(const chacha20_cvt&) = delete;
     chacha20_cvt& operator=(const chacha20_cvt&) = delete;
-    
-    chacha20_cvt(chacha20_cvt&& val)
-        : BT(std::move(val))
-        , m_cipher(std::move(val.m_cipher))
-        , m_key(std::move(val.m_key))
-        , m_bos_done(val.m_bos_done)
-    {}
-    
-    chacha20_cvt& operator= (chacha20_cvt&& val)
-    {
-        BT::operator=(std::move(val));
-        m_cipher = std::move(val.m_cipher);
-        m_key = std::move(val.m_key);
-        m_bos_done = val.m_bos_done;
-        return *this;
-    }
+    chacha20_cvt(chacha20_cvt&& val) = default;
+    chacha20_cvt& operator= (chacha20_cvt&& val) = default;
 
 // mandatory methods
 public:

--- a/test/Makefile
+++ b/test/Makefile
@@ -84,6 +84,22 @@ test-locale: locale
 test-io: io
 	@echo "Running $(BIN_DIR)/test_io..."; $(BIN_DIR)/test_io
 
+# Convenience targets for building and running individual modules with valgrind
+valgrind-device: device
+	@echo "Running $(BIN_DIR)/test_device with valgrind..."; valgrind --leak-check=full --max-stackframe=6000000 $(BIN_DIR)/test_device
+
+valgrind-cvt: cvt
+	@echo "Running $(BIN_DIR)/test_cvt with valgrind..."; valgrind --leak-check=full --max-stackframe=6000000 $(BIN_DIR)/test_cvt
+
+valgrind-facet: facet
+	@echo "Running $(BIN_DIR)/test_facet with valgrind..."; valgrind --leak-check=full --max-stackframe=6000000 $(BIN_DIR)/test_facet
+
+valgrind-locale: locale
+	@echo "Running $(BIN_DIR)/test_locale with valgrind..."; valgrind --leak-check=full --max-stackframe=6000000 $(BIN_DIR)/test_locale
+
+valgrind-io: io
+	@echo "Running $(BIN_DIR)/test_io with valgrind..."; valgrind --leak-check=full --max-stackframe=6000000 $(BIN_DIR)/test_io
+
 # Generic compilation rule
 $(OBJ_DIR)/%.o: ./%.cpp
 	@mkdir -p $(dir $@)
@@ -93,7 +109,9 @@ $(OBJ_DIR)/%.o: ./%.cpp
 test: all
 	@for t in $(TARGETS); do echo "Running $$t..."; $$t || exit 1; done
 
-run: test
+# Run all tests with valgrind
+valgrind: all
+	@for t in $(TARGETS); do echo "Running $$t with valgrind..."; valgrind --leak-check=full --max-stackframe=6000000 $$t || exit 1; done
 
 # Clean up
 clean:
@@ -104,21 +122,28 @@ help:
 	@echo "Usage: make [TARGET] [MODE=debug|release]"
 	@echo ""
 	@echo "Targets:"
-	@echo "  all          Build all test binaries (default)"
-	@echo "  test, run    Build and run all tests"
-	@echo "  clean        Remove build artifacts for current MODE"
+	@echo "  all              Build all test binaries (default)"
+	@echo "  test             Build and run all tests"
+	@echo "  valgrind         Build and run all tests with valgrind"
+	@echo "  clean            Remove build artifacts for current MODE"
 	@echo ""
-	@echo "  device       Build device tests"
-	@echo "  cvt          Build cvt tests"
-	@echo "  facet        Build facet tests"
-	@echo "  locale       Build locale tests"
-	@echo "  io           Build io tests"
+	@echo "  device           Build device tests"
+	@echo "  cvt              Build cvt tests"
+	@echo "  facet            Build facet tests"
+	@echo "  locale           Build locale tests"
+	@echo "  io               Build io tests"
 	@echo ""
-	@echo "  test-device  Build and run device tests"
-	@echo "  test-cvt     Build and run cvt tests"
-	@echo "  test-facet   Build and run facet tests"
-	@echo "  test-locale  Build and run locale tests"
-	@echo "  test-io      Build and run io tests"
+	@echo "  test-device      Build and run device tests"
+	@echo "  test-cvt         Build and run cvt tests"
+	@echo "  test-facet       Build and run facet tests"
+	@echo "  test-locale      Build and run locale tests"
+	@echo "  test-io          Build and run io tests"
+	@echo ""
+	@echo "  valgrind-device  Build and run device tests with valgrind"
+	@echo "  valgrind-cvt     Build and run cvt tests with valgrind"
+	@echo "  valgrind-facet   Build and run facet tests with valgrind"
+	@echo "  valgrind-locale  Build and run locale tests with valgrind"
+	@echo "  valgrind-io      Build and run io tests with valgrind"
 	@echo ""
 	@echo "Options:"
 	@echo "  MODE=debug   Build with debug flags (default)"
@@ -131,8 +156,11 @@ help:
 	@echo "  make device              Build device tests only"
 	@echo "  make test-device         Build and run device tests"
 	@echo "  make test                Build and run all tests"
+	@echo "  make valgrind            Build and run all tests with valgrind"
+	@echo "  make valgrind-device     Build and run device tests with valgrind"
 
 # Phony targets
-.PHONY: all clean test run help
+.PHONY: all clean test valgrind help
 .PHONY: device cvt facet locale io
 .PHONY: test-device test-cvt test-facet test-locale test-io
+.PHONY: valgrind-device valgrind-cvt valgrind-facet valgrind-locale valgrind-io

--- a/test/README.md
+++ b/test/README.md
@@ -28,7 +28,8 @@ make test
 | 目标 | 说明 |
 |------|------|
 | `all` | 构建所有测试程序（默认） |
-| `test` / `run` | 构建并运行所有测试 |
+| `test` | 构建并运行所有测试 |
+| `valgrind` | 使用 valgrind 构建并运行所有测试 |
 | `clean` | 清理当前模式的构建产物 |
 
 ### 单模块构建
@@ -50,6 +51,16 @@ make test
 | `test-facet` | 构建并运行 facet 测试 |
 | `test-locale` | 构建并运行 locale 测试 |
 | `test-io` | 构建并运行 io 测试 |
+
+### 单模块内存检测 (Valgrind)
+
+| 目标 | 说明 |
+|------|------|
+| `valgrind-device` | 使用 valgrind 构建并运行 device 测试 |
+| `valgrind-cvt` | 使用 valgrind 构建并运行 cvt 测试 |
+| `valgrind-facet` | 使用 valgrind 构建并运行 facet 测试 |
+| `valgrind-locale` | 使用 valgrind 构建并运行 locale 测试 |
+| `valgrind-io` | 使用 valgrind 构建并运行 io 测试 |
 
 ### 构建模式
 
@@ -77,6 +88,12 @@ make test-device
 
 # Release 模式构建并运行 device 测试
 make MODE=release test-device
+
+# 使用 valgrind 运行所有测试
+make valgrind
+
+# 使用 valgrind 运行 device 测试
+make valgrind-device
 
 # 清理 debug 构建产物
 make clean
@@ -114,7 +131,8 @@ make test
 | Target | Description |
 |--------|-------------|
 | `all` | Build all test programs (default) |
-| `test` / `run` | Build and run all tests |
+| `test` | Build and run all tests |
+| `valgrind` | Build and run all tests with valgrind |
 | `clean` | Remove build artifacts for current mode |
 
 ### Single Module Build
@@ -136,6 +154,16 @@ make test
 | `test-facet` | Build and run facet tests |
 | `test-locale` | Build and run locale tests |
 | `test-io` | Build and run io tests |
+
+### Single Module Run with Valgrind
+
+| Target | Description |
+|--------|-------------|
+| `valgrind-device` | Build and run device tests with valgrind |
+| `valgrind-cvt` | Build and run cvt tests with valgrind |
+| `valgrind-facet` | Build and run facet tests with valgrind |
+| `valgrind-locale` | Build and run locale tests with valgrind |
+| `valgrind-io` | Build and run io tests with valgrind |
 
 ### Build Modes
 
@@ -163,6 +191,12 @@ make test-device
 
 # Build and run device tests in release mode
 make MODE=release test-device
+
+# Run all tests with valgrind
+make valgrind
+
+# Run device tests with valgrind
+make valgrind-device
 
 # Clean debug build artifacts
 make clean


### PR DESCRIPTION
- Added `--max-stackframe=6000000` parameter to all valgrind targets in the Makefile to prevent lost stack traces, especially during io module testing.
- Added `make valgrind` and `make valgrind-device` examples to the `make help` output in the Makefile.
- Updated README.md to remove deprecated `make run` references.
- Added comprehensive descriptions and examples for valgrind-related targets in both the Chinese and English sections of README.md.