### PR TITLE
fix: improve compiler compatibility and fix warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,20 @@
 - **操作系统**：Fedora Linux (或其它 Linux 发行版)
 - **标准**：现代 C++ (C++23 及以上)
 
+### 已测试编译器
+
+| 编译器 | 版本 | 标准库 | 状态 |
+|--------|------|--------|------|
+| GCC | 15.2.0 | libstdc++ | ✅ 通过 |
+| Clang | 18.1.8 | libstdc++ (GCC 13) | ✅ 通过 |
+| Clang | 22.1.3 | libstdc++ (GCC 13) | ⚠️ 编译通过，测试待验证 |
+
 ### 已知编译器问题
 
 | 编译器 | 问题描述 | 状态 |
 |--------|----------|------|
 | GCC 13 | 在 Release 模式下，`-Warray-bounds` 对 `std::copy` 内联展开产生误报警告。当将单个 `wchar_t` 变量的地址传递给 `mem_device::dget()` 时，GCC 错误地认为 `__builtin_memcpy` 可能越界访问。这是 GCC 13 的已知缺陷，代码本身没有问题。 | GCC 15 已修复 |
+| Clang + libc++ | libc++ 22.1.3 尚未完整实现 C++20 chrono 时区功能（`std::chrono::time_zone`、`zoned_time`、`get_tzdb` 等）。IOv2 的时间格式化功能依赖这些特性，因此暂不支持 libc++。请使用 libstdc++ 作为标准库。 | 等待 libc++ 支持 |
 
 ---
 
@@ -64,9 +73,18 @@ Instead of providing partial patches or wrappers for the existing standard libra
 - **OS**: Fedora Linux (Primary platform)
 - **Standard**: Modern C++ (C++23 or later)
 
+### Tested Compilers
+
+| Compiler | Version | Standard Library | Status |
+|----------|---------|------------------|--------|
+| GCC | 15.2.0 | libstdc++ | ✅ Passed |
+| Clang | 18.1.8 | libstdc++ (GCC 13) | ✅ Passed |
+| Clang | 22.1.3 | libstdc++ (GCC 13) | ⚠️ Build passed, tests pending |
+
 ### Known Compiler Issues
 
 | Compiler | Issue | Status |
 |----------|-------|--------|
 | GCC 13 | In Release mode, `-Warray-bounds` produces false positive warnings when `std::copy` is inlined. When passing the address of a single `wchar_t` variable to `mem_device::dget()`, GCC incorrectly reports that `__builtin_memcpy` may access out of bounds. This is a known GCC 13 bug; the code is correct. | Fixed in GCC 15 |
+| Clang + libc++ | libc++ 22.1.3 has not fully implemented C++20 chrono time zone features (`std::chrono::time_zone`, `zoned_time`, `get_tzdb`, etc.). IOv2's time formatting functionality depends on these features, so libc++ is not currently supported. Please use libstdc++ as the standard library. | Waiting for libc++ support |
 

--- a/include/device/file_device.h
+++ b/include/device/file_device.h
@@ -3,8 +3,9 @@
 
 #include <cassert>
 #include <cstdio>
-#include <filesystem>
 #include <cstdint>
+#include <exception>
+#include <filesystem>
 #include <limits>
 #include <optional>
 #include <string>

--- a/include/device/mem_device.h
+++ b/include/device/mem_device.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <iterator>
 #include <memory>
 #include <string>
 #include <type_traits>

--- a/include/facet/facet_helper.h
+++ b/include/facet/facet_helper.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <langinfo.h>
 #include <nl_types.h>
+#include <limits>
 #include <string>
 #include <cvt/cvt_facilities.h>
 #include <facet/ctype_details.h>
@@ -77,7 +78,7 @@ namespace IOv2::FacetHelper
         // grouping (only do the check if the numpunct char is > 0
         // because <= 0 means any size is ok).
         if (static_cast<signed char>(__grouping[__min]) > 0
-            && __grouping[__min] != __gnu_cxx::__numeric_traits<char>::__max)
+            && __grouping[__min] != std::numeric_limits<char>::max())
             __test &= __grouping_tmp[0] <= __grouping[__min];
         return __test;
     }

--- a/include/facet/timeio.h
+++ b/include/facet/timeio.h
@@ -369,7 +369,7 @@ struct time_parse_context
         auto hms = static_cast<std::chrono::hh_mm_ss<std::chrono::seconds>>(*this);
         auto tz = static_cast<const std::chrono::time_zone*>(*this);
 
-        local_time<seconds> lt{ sys_days{ymd} + hms.to_duration() };
+        local_time<seconds> lt{ local_days{ymd} + hms.to_duration() };
         return zoned_time<seconds>{tz, lt};
     }
 

--- a/include/io/io_base.h
+++ b/include/io/io_base.h
@@ -1,13 +1,14 @@
 #pragma once
 #include <atomic>
+#include <exception>
 #include <forward_list>
 #include <functional>
 #include <ios>
+#include <memory>
 #include <mutex>
 #include <stdexcept>
 #include <unordered_map>
 #include <utility>
-#include <memory>
 #include <common/defs.h>
 
 namespace IOv2
@@ -300,8 +301,8 @@ protected:
 
                 if (new_data)
                 {
-                    if (it != m_pwords.end()) it->second = move(new_data);
-                    else m_pwords.insert({id, move(new_data)});
+                    if (it != m_pwords.end()) it->second = std::move(new_data);
+                    else m_pwords.insert({id, std::move(new_data)});
                 }
                 else if (it != m_pwords.end())
                 {

--- a/include/io/utilities/istream_operators.h
+++ b/include/io/utilities/istream_operators.h
@@ -201,17 +201,14 @@ struct istream_operators
     {
         T& obj = static_cast<T&>(*this);
 
-        size_t gcount = 0;
-
         try
         {
             auto ct = obj.m_locale.template get<IOv2::ctype<TChar>>();
             auto c = obj.m_streambuf.sgetc();
-            while (c.has_value() && 
+            while (c.has_value() &&
                     ct->is_any(base_ft<ctype>::space, c.value()))
             {
                 c = obj.m_streambuf.snextc();
-                ++gcount;
             }
 
             if (!c.has_value())

--- a/test/io/istream/extractors_time/test_istream_extractors_time_char.cpp
+++ b/test/io/istream/extractors_time/test_istream_extractors_time_char.cpp
@@ -15,7 +15,7 @@ void test_istream_extractors_time_char_1()
 
     auto helper = []<template <typename, typename> class T>()
     {
-        std::tm tp;
+        std::tm tp{};
         T f(IOv2::mem_device{"09/04/24 13:33:18"}, IOv2::locale<char>("C"));
 
         f >> tp;

--- a/test/io/istream/extractors_time/test_istream_extractors_time_wchar_t.cpp
+++ b/test/io/istream/extractors_time/test_istream_extractors_time_wchar_t.cpp
@@ -15,7 +15,7 @@ void test_istream_extractors_time_wchar_t_1()
 
     auto helper = []<template <typename, typename> class T>()
     {
-        std::tm tp;
+        std::tm tp{};
         T f(IOv2::mem_device{L"09/04/24 13:33:18"}, IOv2::locale<wchar_t>("C"));
 
         f >> tp;


### PR DESCRIPTION
- Add tested compilers documentation (GCC 15, Clang 18/22 with libstdc++)
- Document libc++ 22.1.3 limitation (missing C++20 chrono time zone features)
- Fix GCC 13 libstdc++ compatibility: use local_days instead of sys_days
- Replace GCC-specific __gnu_cxx::__numeric_traits with std::numeric_limits
- Add missing includes for portability: <iterator>, <exception>, <limits>
- Fix unqualified std::move calls in io_base.h
- Remove unused gcount variable in istream_operators.h
- Zero-initialize std::tm structs in tests to fix -Wmaybe-uninitialized