### PR TITLE
test: Implement fail-fast behavior and strict Valgrind checks in test…

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -86,19 +86,19 @@ test-io: io
 
 # Convenience targets for building and running individual modules with valgrind
 valgrind-device: device
-	@echo "Running $(BIN_DIR)/test_device with valgrind..."; valgrind --leak-check=full --max-stackframe=6000000 $(BIN_DIR)/test_device
+	@echo "Running $(BIN_DIR)/test_device with valgrind..."; valgrind --error-exitcode=1 --leak-check=full --max-stackframe=6000000 $(BIN_DIR)/test_device
 
 valgrind-cvt: cvt
-	@echo "Running $(BIN_DIR)/test_cvt with valgrind..."; valgrind --leak-check=full --max-stackframe=6000000 $(BIN_DIR)/test_cvt
+	@echo "Running $(BIN_DIR)/test_cvt with valgrind..."; valgrind --error-exitcode=1 --leak-check=full --max-stackframe=6000000 $(BIN_DIR)/test_cvt
 
 valgrind-facet: facet
-	@echo "Running $(BIN_DIR)/test_facet with valgrind..."; valgrind --leak-check=full --max-stackframe=6000000 $(BIN_DIR)/test_facet
+	@echo "Running $(BIN_DIR)/test_facet with valgrind..."; valgrind --error-exitcode=1 --leak-check=full --max-stackframe=6000000 $(BIN_DIR)/test_facet
 
 valgrind-locale: locale
-	@echo "Running $(BIN_DIR)/test_locale with valgrind..."; valgrind --leak-check=full --max-stackframe=6000000 $(BIN_DIR)/test_locale
+	@echo "Running $(BIN_DIR)/test_locale with valgrind..."; valgrind --error-exitcode=1 --leak-check=full --max-stackframe=6000000 $(BIN_DIR)/test_locale
 
 valgrind-io: io
-	@echo "Running $(BIN_DIR)/test_io with valgrind..."; valgrind --leak-check=full --max-stackframe=6000000 $(BIN_DIR)/test_io
+	@echo "Running $(BIN_DIR)/test_io with valgrind..."; valgrind --error-exitcode=1 --leak-check=full --max-stackframe=6000000 $(BIN_DIR)/test_io
 
 # Generic compilation rule
 $(OBJ_DIR)/%.o: ./%.cpp
@@ -107,11 +107,11 @@ $(OBJ_DIR)/%.o: ./%.cpp
 
 # Run all tests
 test: all
-	@for t in $(TARGETS); do echo "Running $$t..."; $$t || exit 1; done
+	@for t in $(TARGETS); do echo "Running $$t..."; $$t || { echo "[!] Test $$t failed!"; exit 1; }; done
 
 # Run all tests with valgrind
 valgrind: all
-	@for t in $(TARGETS); do echo "Running $$t with valgrind..."; valgrind --leak-check=full --max-stackframe=6000000 $$t || exit 1; done
+	@for t in $(TARGETS); do echo "Running $$t with valgrind..."; valgrind --error-exitcode=1 --leak-check=full --max-stackframe=6000000 $$t || { echo "[!] Test $$t failed!"; exit 1; }; done
 
 # Clean up
 clean:

--- a/test/cvt/test_cvt.cpp
+++ b/test/cvt/test_cvt.cpp
@@ -1,3 +1,7 @@
+#include <exception>
+#include <string>
+#include <common/dump_info.h>
+
 void test_root_cvt();
 void test_code_cvt();
 void test_crypt_cvt();
@@ -9,11 +13,25 @@ void test_cvt_io();
 
 int main()
 {
-    test_root_cvt();
-    test_code_cvt();
-    test_comp_cvt();
-    test_crypt_cvt();
-    test_cvt_pipe_creator();
-    test_runtime_cvt();
-    test_cvt_io();
+    try
+    {
+        test_root_cvt();
+        test_code_cvt();
+        test_comp_cvt();
+        test_crypt_cvt();
+        test_cvt_pipe_creator();
+        test_runtime_cvt();
+        test_cvt_io();
+        return 0;
+    }
+    catch (const std::exception& e)
+    {
+        dump_info((std::string("\n[!] CVT test failed with exception: ") + e.what() + "\n").c_str());
+        return 1;
+    }
+    catch (...)
+    {
+        dump_info("\n[!] CVT test failed with an unknown exception.\n");
+        return 1;
+    }
 }

--- a/test/device/test_device.cpp
+++ b/test/device/test_device.cpp
@@ -1,3 +1,7 @@
+#include <exception>
+#include <string>
+#include <common/dump_info.h>
+
 void test_mem_device_char_gen_1();
 void test_mem_device_char_gen_2();
 void test_mem_device_char_gen_3();
@@ -87,90 +91,105 @@ void test_file_device_char8_t_seek_8();
 
 int main()
 {
-    test_mem_device_char_gen_1();
-    test_mem_device_char_gen_2();
-    test_mem_device_char_gen_3();
-    test_mem_device_char_in_1();
-    test_mem_device_char_in_2();
-    test_mem_device_char_in_3();
-    test_mem_device_char_out_1();
-    test_mem_device_char_out_2();
-    test_mem_device_char_out_3();
-    test_mem_device_char_io_1();
-    test_mem_device_char_io_2();
+    try
+    {
+        test_mem_device_char_gen_1();
+        test_mem_device_char_gen_2();
+        test_mem_device_char_gen_3();
+        test_mem_device_char_in_1();
+        test_mem_device_char_in_2();
+        test_mem_device_char_in_3();
+        test_mem_device_char_out_1();
+        test_mem_device_char_out_2();
+        test_mem_device_char_out_3();
+        test_mem_device_char_io_1();
+        test_mem_device_char_io_2();
 
-    test_mem_device_wchar_t_gen_1();
-    test_mem_device_wchar_t_gen_2();
-    test_mem_device_wchar_t_gen_3();
-    test_mem_device_wchar_t_in_1();
-    test_mem_device_wchar_t_in_2();
-    test_mem_device_wchar_t_in_3();
-    test_mem_device_wchar_t_out_1();
-    test_mem_device_wchar_t_out_2();
-    test_mem_device_wchar_t_out_3();
-    test_mem_device_wchar_t_io_1();
-    test_mem_device_wchar_t_io_2();
+        test_mem_device_wchar_t_gen_1();
+        test_mem_device_wchar_t_gen_2();
+        test_mem_device_wchar_t_gen_3();
+        test_mem_device_wchar_t_in_1();
+        test_mem_device_wchar_t_in_2();
+        test_mem_device_wchar_t_in_3();
+        test_mem_device_wchar_t_out_1();
+        test_mem_device_wchar_t_out_2();
+        test_mem_device_wchar_t_out_3();
+        test_mem_device_wchar_t_io_1();
+        test_mem_device_wchar_t_io_2();
     
-    test_mem_device_char32_t_gen_1();
-    test_mem_device_char32_t_gen_2();
-    test_mem_device_char32_t_gen_3();
-    test_mem_device_char32_t_in_1();
-    test_mem_device_char32_t_in_2();
-    test_mem_device_char32_t_in_3();
-    test_mem_device_char32_t_out_1();
-    test_mem_device_char32_t_out_2();
-    test_mem_device_char32_t_out_3();
-    test_mem_device_char32_t_io_1();
-    test_mem_device_char32_t_io_2();
+        test_mem_device_char32_t_gen_1();
+        test_mem_device_char32_t_gen_2();
+        test_mem_device_char32_t_gen_3();
+        test_mem_device_char32_t_in_1();
+        test_mem_device_char32_t_in_2();
+        test_mem_device_char32_t_in_3();
+        test_mem_device_char32_t_out_1();
+        test_mem_device_char32_t_out_2();
+        test_mem_device_char32_t_out_3();
+        test_mem_device_char32_t_io_1();
+        test_mem_device_char32_t_io_2();
 
-    test_mem_device_char8_t_gen_1();
-    test_mem_device_char8_t_gen_2();
-    test_mem_device_char8_t_gen_3();
-    test_mem_device_char8_t_in_1();
-    test_mem_device_char8_t_in_2();
-    test_mem_device_char8_t_in_3();
-    test_mem_device_char8_t_out_1();
-    test_mem_device_char8_t_out_2();
-    test_mem_device_char8_t_out_3();
-    test_mem_device_char8_t_io_1();
-    test_mem_device_char8_t_io_2();
+        test_mem_device_char8_t_gen_1();
+        test_mem_device_char8_t_gen_2();
+        test_mem_device_char8_t_gen_3();
+        test_mem_device_char8_t_in_1();
+        test_mem_device_char8_t_in_2();
+        test_mem_device_char8_t_in_3();
+        test_mem_device_char8_t_out_1();
+        test_mem_device_char8_t_out_2();
+        test_mem_device_char8_t_out_3();
+        test_mem_device_char8_t_io_1();
+        test_mem_device_char8_t_io_2();
     
-    test_std_device_gen_1();
-    test_std_device_input_1();
-    test_std_device_output_1();
-    test_std_device_output_2();
+        test_std_device_gen_1();
+        test_std_device_input_1();
+        test_std_device_output_1();
+        test_std_device_output_2();
 
-    test_file_device_char_gen_1();
-    test_file_device_char_close_1();
-    test_file_device_char_close_2();
-    test_file_device_char_is_open_1();
-    test_file_device_char_is_open_2();
-    test_file_device_char_get_1();
-    test_file_device_char_get_2();
-    test_file_device_char_get_3();
-    test_file_device_char_seek_1();
-    test_file_device_char_seek_2();
-    test_file_device_char_seek_3();
-    test_file_device_char_seek_4();
-    test_file_device_char_seek_5();
-    test_file_device_char_seek_6();
-    test_file_device_char_seek_7();
-    test_file_device_char_seek_8();
+        test_file_device_char_gen_1();
+        test_file_device_char_close_1();
+        test_file_device_char_close_2();
+        test_file_device_char_is_open_1();
+        test_file_device_char_is_open_2();
+        test_file_device_char_get_1();
+        test_file_device_char_get_2();
+        test_file_device_char_get_3();
+        test_file_device_char_seek_1();
+        test_file_device_char_seek_2();
+        test_file_device_char_seek_3();
+        test_file_device_char_seek_4();
+        test_file_device_char_seek_5();
+        test_file_device_char_seek_6();
+        test_file_device_char_seek_7();
+        test_file_device_char_seek_8();
 
-    test_file_device_char8_t_gen_1();
-    test_file_device_char8_t_close_1();
-    test_file_device_char8_t_close_2();
-    test_file_device_char8_t_is_open_1();
-    test_file_device_char8_t_is_open_2();
-    test_file_device_char8_t_get_1();
-    test_file_device_char8_t_get_2();
-    test_file_device_char8_t_get_3();
-    test_file_device_char8_t_seek_1();
-    test_file_device_char8_t_seek_2();
-    test_file_device_char8_t_seek_3();
-    test_file_device_char8_t_seek_4();
-    test_file_device_char8_t_seek_5();
-    test_file_device_char8_t_seek_6();
-    test_file_device_char8_t_seek_7();
-    test_file_device_char8_t_seek_8();
+        test_file_device_char8_t_gen_1();
+        test_file_device_char8_t_close_1();
+        test_file_device_char8_t_close_2();
+        test_file_device_char8_t_is_open_1();
+        test_file_device_char8_t_is_open_2();
+        test_file_device_char8_t_get_1();
+        test_file_device_char8_t_get_2();
+        test_file_device_char8_t_get_3();
+        test_file_device_char8_t_seek_1();
+        test_file_device_char8_t_seek_2();
+        test_file_device_char8_t_seek_3();
+        test_file_device_char8_t_seek_4();
+        test_file_device_char8_t_seek_5();
+        test_file_device_char8_t_seek_6();
+        test_file_device_char8_t_seek_7();
+        test_file_device_char8_t_seek_8();
+
+        return 0;
+    }
+    catch (const std::exception& e)
+    {
+        dump_info((std::string("\n[!] Device test failed with exception: ") + e.what() + "\n").c_str());
+        return 1;
+    }
+    catch (...)
+    {
+        dump_info("\n[!] Device test failed with an unknown exception.\n");
+        return 1;
+    }
 }

--- a/test/facet/test_facet.cpp
+++ b/test/facet/test_facet.cpp
@@ -1,3 +1,7 @@
+#include <exception>
+#include <string>
+#include <common/dump_info.h>
+
 void test_ctype();
 void test_collate();
 void test_numeric();
@@ -7,10 +11,24 @@ void test_messages();
 
 int main()
 {
-    test_ctype();
-    test_collate();
-    test_numeric();
-    test_monetary();
-    test_timeio();
-    test_messages();
+    try
+    {
+        test_ctype();
+        test_collate();
+        test_numeric();
+        test_monetary();
+        test_timeio();
+        test_messages();
+        return 0;
+    }
+    catch (const std::exception& e)
+    {
+        dump_info((std::string("\n[!] Facet test failed with exception: ") + e.what() + "\n").c_str());
+        return 1;
+    }
+    catch (...)
+    {
+        dump_info("\n[!] Facet test failed with an unknown exception.\n");
+        return 1;
+    }
 }

--- a/test/io/test_io.cpp
+++ b/test/io/test_io.cpp
@@ -1,3 +1,7 @@
+#include <exception>
+#include <string>
+#include <common/dump_info.h>
+
 void test_io_base();
 void test_io_state_and_exp();
 void test_streambuf();
@@ -11,12 +15,26 @@ void test_io_objects();
 
 int main()
 {
-    test_io_base();
-    test_io_state_and_exp();
-    test_streambuf();
-    test_streambuf_iterator();
-    test_istream();
-    test_ostream();
-    test_iostream();
-    test_io_objects();
+    try
+    {
+        test_io_base();
+        test_io_state_and_exp();
+        test_streambuf();
+        test_streambuf_iterator();
+        test_istream();
+        test_ostream();
+        test_iostream();
+        test_io_objects();
+        return 0;
+    }
+    catch (const std::exception& e)
+    {
+        dump_info((std::string("\n[!] IO test failed with exception: ") + e.what() + "\n").c_str());
+        return 1;
+    }
+    catch (...)
+    {
+        dump_info("\n[!] IO test failed with an unknown exception.\n");
+        return 1;
+    }
 }

--- a/test/locale/test_locale.cpp
+++ b/test/locale/test_locale.cpp
@@ -1,3 +1,7 @@
+#include <exception>
+#include <string>
+#include <common/dump_info.h>
+
 void test_locale_char_1();
 void test_locale_char_2();
 void test_locale_char_3();
@@ -43,46 +47,61 @@ void test_locale_char8_t_10();
 
 int main()
 {
-    test_locale_char_1();
-    test_locale_char_2();
-    test_locale_char_3();
-    test_locale_char_4();
-    test_locale_char_5();
-    test_locale_char_6();
-    test_locale_char_7();
-    test_locale_char_8();
-    test_locale_char_9();
+    try
+    {
+        test_locale_char_1();
+        test_locale_char_2();
+        test_locale_char_3();
+        test_locale_char_4();
+        test_locale_char_5();
+        test_locale_char_6();
+        test_locale_char_7();
+        test_locale_char_8();
+        test_locale_char_9();
 
-    test_locale_wchar_t_1();
-    test_locale_wchar_t_2();
-    test_locale_wchar_t_3();
-    test_locale_wchar_t_4();
-    test_locale_wchar_t_5();
-    test_locale_wchar_t_6();
-    test_locale_wchar_t_7();
-    test_locale_wchar_t_8();
-    test_locale_wchar_t_9();
-    test_locale_wchar_t_10();
-    
-    test_locale_char32_t_1();
-    test_locale_char32_t_2();
-    test_locale_char32_t_3();
-    test_locale_char32_t_4();
-    test_locale_char32_t_5();
-    test_locale_char32_t_6();
-    test_locale_char32_t_7();
-    test_locale_char32_t_8();
-    test_locale_char32_t_9();
-    test_locale_char32_t_10();
+        test_locale_wchar_t_1();
+        test_locale_wchar_t_2();
+        test_locale_wchar_t_3();
+        test_locale_wchar_t_4();
+        test_locale_wchar_t_5();
+        test_locale_wchar_t_6();
+        test_locale_wchar_t_7();
+        test_locale_wchar_t_8();
+        test_locale_wchar_t_9();
+        test_locale_wchar_t_10();
+        
+        test_locale_char32_t_1();
+        test_locale_char32_t_2();
+        test_locale_char32_t_3();
+        test_locale_char32_t_4();
+        test_locale_char32_t_5();
+        test_locale_char32_t_6();
+        test_locale_char32_t_7();
+        test_locale_char32_t_8();
+        test_locale_char32_t_9();
+        test_locale_char32_t_10();
 
-    test_locale_char8_t_1();
-    test_locale_char8_t_2();
-    test_locale_char8_t_3();
-    test_locale_char8_t_4();
-    test_locale_char8_t_5();
-    test_locale_char8_t_6();
-    test_locale_char8_t_7();
-    test_locale_char8_t_8();
-    test_locale_char8_t_9();
-    test_locale_char8_t_10();
+        test_locale_char8_t_1();
+        test_locale_char8_t_2();
+        test_locale_char8_t_3();
+        test_locale_char8_t_4();
+        test_locale_char8_t_5();
+        test_locale_char8_t_6();
+        test_locale_char8_t_7();
+        test_locale_char8_t_8();
+        test_locale_char8_t_9();
+        test_locale_char8_t_10();
+
+        return 0;
+    }
+    catch (const std::exception& e)
+    {
+        dump_info((std::string("\n[!] Locale test failed with exception: ") + e.what() + "\n").c_str());
+        return 1;
+    }
+    catch (...)
+    {
+        dump_info("\n[!] Locale test failed with an unknown exception.\n");
+        return 1;
+    }
 }


### PR DESCRIPTION
… suite

- Added top-level `try-catch` blocks to all test runner `main()` functions (`test_cvt`, `test_device`, `test_facet`, `test_io`, `test_locale`).

- Configured tests to catch assertion exceptions, log them using `dump_info`, and return a non-zero exit code (1) upon failure.

- Updated `Makefile` `test` target to intercept non-zero exit codes, print a clear failure message, and immediately halt the test runner loop.

- Added `--error-exitcode=1` to the `Makefile` `valgrind` targets to ensure the pipeline aborts immediately upon detecting memory leaks or invalid memory accesses.