### PR TITLE
refactor: unify variable naming style by removing reserved prefixes

### DIFF
--- a/include/facet/ctype_details.h
+++ b/include/facet/ctype_details.h
@@ -105,8 +105,8 @@ public:
         , m_inter_locale(name.c_str())
     {
         clocale_user guard(m_inter_locale.c_locale);
-        for (size_t __j = 0; __j < sizeof(m_widen) / sizeof(wint_t); ++__j)
-          m_widen[__j] = btowc(__j);
+        for (size_t j = 0; j < sizeof(m_widen) / sizeof(wint_t); ++j)
+          m_widen[j] = btowc(j);
           
         m_wmask_upper  = wctype_l("upper",  m_inter_locale.c_locale);
         m_wmask_lower  = wctype_l("lower",  m_inter_locale.c_locale);

--- a/include/facet/facet_helper.h
+++ b/include/facet/facet_helper.h
@@ -26,61 +26,61 @@ namespace IOv2::FacetHelper
     }
     
     template <typename CharT>
-    inline CharT* add_grouping(CharT* __s, CharT __sep, const std::vector<uint8_t>& grouping,
-                               const CharT* __first, const CharT* __last)
+    inline CharT* add_grouping(CharT* s, CharT sep, const std::vector<uint8_t>& grouping,
+                               const CharT* first, const CharT* last)
     {
-        size_t __idx = 0;
-        size_t __ctr = 0;
-        size_t __gsize = grouping.size();
+        size_t idx = 0;
+        size_t ctr = 0;
+        size_t gsize = grouping.size();
 
-        while (__last - __first > grouping[__idx]
-                && (grouping[__idx] > 0))
+        while (last - first > grouping[idx]
+                && (grouping[idx] > 0))
         {
-            __last -= grouping[__idx];
-            __idx < __gsize - 1 ? ++__idx : ++__ctr;
+            last -= grouping[idx];
+            idx < gsize - 1 ? ++idx : ++ctr;
         }
 
-        while (__first != __last)
-            *__s++ = *__first++;
+        while (first != last)
+            *s++ = *first++;
 
-        while (__ctr--)
+        while (ctr--)
         {
-            *__s++ = __sep;
-            for (char __i = grouping[__idx]; __i > 0; --__i)
-                *__s++ = *__first++;
+            *s++ = sep;
+            for (char i = grouping[idx]; i > 0; --i)
+                *s++ = *first++;
         }
 
-        while (__idx--)
+        while (idx--)
         {
-            *__s++ = __sep;
-            for (char __i = grouping[__idx]; __i > 0; --__i)
-                *__s++ = *__first++;
+            *s++ = sep;
+            for (char i = grouping[idx]; i > 0; --i)
+                *s++ = *first++;
         }
-        return __s;
+        return s;
     }
     
-    inline bool verify_grouping(const std::vector<uint8_t>& __grouping, 
-                                const std::string& __grouping_tmp)
+    inline bool verify_grouping(const std::vector<uint8_t>& grouping,
+                                const std::string& grouping_tmp)
     {
-        const size_t __n = __grouping_tmp.size() - 1;
-        const size_t __min = std::min(__n, size_t(__grouping.size() - 1));
-        size_t __i = __n;
-        bool __test = true;
-    
+        const size_t n = grouping_tmp.size() - 1;
+        const size_t min_val = std::min(n, size_t(grouping.size() - 1));
+        size_t i = n;
+        bool test = true;
+
         // Parsed number groupings have to match the
         // numpunct::grouping string exactly, starting at the
         // right-most point of the parsed sequence of elements ...
-        for (size_t __j = 0; __j < __min && __test; --__i, ++__j)
-            __test = __grouping_tmp[__i] == __grouping[__j];
-        for (; __i && __test; --__i)
-            __test = __grouping_tmp[__i] == __grouping[__min];
+        for (size_t j = 0; j < min_val && test; --i, ++j)
+            test = grouping_tmp[i] == grouping[j];
+        for (; i && test; --i)
+            test = grouping_tmp[i] == grouping[min_val];
         // ... but the first parsed grouping can be <= numpunct
         // grouping (only do the check if the numpunct char is > 0
         // because <= 0 means any size is ok).
-        if (static_cast<signed char>(__grouping[__min]) > 0
-            && __grouping[__min] != std::numeric_limits<char>::max())
-            __test &= __grouping_tmp[0] <= __grouping[__min];
-        return __test;
+        if (static_cast<signed char>(grouping[min_val]) > 0
+            && grouping[min_val] != std::numeric_limits<char>::max())
+            test &= grouping_tmp[0] <= grouping[min_val];
+        return test;
     }
 
     template <typename T>
@@ -94,15 +94,15 @@ namespace IOv2::FacetHelper
     }
     
     template <typename CharT>
-    requires std::is_same_v<CharT, wchar_t> || 
-        (std::is_same_v<CharT, char32_t> && 
-            (sizeof(char32_t) == sizeof(wchar_t)) && 
+    requires std::is_same_v<CharT, wchar_t> ||
+        (std::is_same_v<CharT, char32_t> &&
+            (sizeof(char32_t) == sizeof(wchar_t)) &&
             (static_cast<wchar_t>(U'李') == L'李') &&
             (static_cast<char32_t>(L'伟') == U'伟'))
     inline std::basic_string<CharT> nl_langinfo_w(nl_item item)
     {
-        union { char *__s; wchar_t *__w; } __u;
-        __u.__s = nl_langinfo(item);
-        return (CharT*)(__u.__w);
+        union { char *s; wchar_t *w; } u;
+        u.s = nl_langinfo(item);
+        return (CharT*)(u.w);
     }
 }

--- a/include/facet/monetary.h
+++ b/include/facet/monetary.h
@@ -97,10 +97,10 @@ public:
     }
     
     template <typename TIter>
-    TIter put(TIter __s, bool __intl, ios_base<char_type>& __io, const std::basic_string<char_type>& __digits) const
+    TIter put(TIter s, bool intl, ios_base<char_type>& io, const std::basic_string<char_type>& digits) const
     {
-        return __intl ? insert<true>(__s, __io, __digits)
-                      : insert<false>(__s, __io, __digits);
+        return intl ? insert<true>(s, io, digits)
+                    : insert<false>(s, io, digits);
     }
     
     template <typename TIter, std::sentinel_for<TIter> TSent, std::integral TVal>
@@ -119,29 +119,29 @@ public:
     }
 
     template <typename TIter, std::sentinel_for<TIter> TSent>
-    TIter get(TIter __beg, TSent __end, bool __intl, ios_base<char_type>& __io, std::basic_string<char_type>& __digits) const
+    TIter get(TIter beg, TSent end, bool intl, ios_base<char_type>& io, std::basic_string<char_type>& digits) const
     {
         bool succ = true;
-        
-        std::string __str;
-        std::tie(succ, __beg) = __intl ? extract<true>(__beg, __end, __io, __str)
-                                       : extract<false>(__beg, __end, __io, __str);
-        const auto __len = __str.size();
-        if (__len)
+
+        std::string str;
+        std::tie(succ, beg) = intl ? extract<true>(beg, end, io, str)
+                                   : extract<false>(beg, end, io, str);
+        const auto len = str.size();
+        if (len)
         {
-            __digits.clear();
-            __digits.reserve(__len);
-            for (auto ch : __str)
+            digits.clear();
+            digits.reserve(len);
+            for (auto ch : str)
             {
                 if (ch == '-')
-                    __digits.push_back(s_atoms[0]);
+                    digits.push_back(s_atoms[0]);
                 else if ((ch >= '0') && (ch <= '9'))
-                    __digits.push_back(s_atoms[ch - '0' + 1]);
+                    digits.push_back(s_atoms[ch - '0' + 1]);
             }
         }
         if (!succ)
             throw stream_error("monetary parse fail");
-        return __beg;
+        return beg;
     }
 
 private:
@@ -161,334 +161,334 @@ private:
 
 private:
     template <bool isIntl, typename TIter>
-    TIter insert(TIter __s, ios_base<char_type>& __io, const std::basic_string<char_type>& __digits) const
+    TIter insert(TIter s, ios_base<char_type>& io, const std::basic_string<char_type>& digits) const
     {
         const split_info& info = isIntl ? m_int : m_nat;
         using part = base_ft<monetary>::part;
-        
+
         // Determine if negative or positive formats are to be used, and
         // discard leading negative_sign if it is present.
-        const char_type* __beg = __digits.data();
+        const char_type* beg = digits.data();
 
-        base_ft<monetary>::pattern __p;
-        const std::basic_string<char_type>* __sign;
-        if (!(*__beg == s_atoms[s_minus]))
+        base_ft<monetary>::pattern p;
+        const std::basic_string<char_type>* sign_ptr;
+        if (!(*beg == s_atoms[s_minus]))
         {
-            __p = info.m_pos_format;
-            __sign = &(info.m_positive_sign);
+            p = info.m_pos_format;
+            sign_ptr = &(info.m_positive_sign);
         }
         else
         {
-            __p = info.m_neg_format;
-            __sign = &(info.m_negative_sign);
-            if (__digits.size())
-                ++__beg;
+            p = info.m_neg_format;
+            sign_ptr = &(info.m_negative_sign);
+            if (digits.size())
+                ++beg;
         }
-       
+
         // Look for valid numbers in input digits.
-        int __len = 0;
-        for (auto i = __beg; i != __beg + __digits.size(); ++i)
+        int len = 0;
+        for (auto i = beg; i != beg + digits.size(); ++i)
         {
             char_type ch = *i;
             int j = 1;
             for (; j < 11; ++j)
                 if (ch == s_atoms[j]) break;
-                
+
             if (j == 11) break;
-            ++__len;
+            ++len;
         }
-        
-        if (__len)
+
+        if (len)
         {
             // Assume valid input, and attempt to format.
             // Break down input numbers into base components, as follows:
             //   final_value = grouped units + (decimal point) + (digits)
-            std::basic_string<char_type> __value;
-            __value.reserve(2 * __len);
+            std::basic_string<char_type> value;
+            value.reserve(2 * len);
 
             // Add thousands separators to non-decimal digits, per
             // grouping rules.
-            long __paddec = __len - info.m_frac_digits;
-            if (__paddec > 0)
+            long paddec = len - info.m_frac_digits;
+            if (paddec > 0)
             {
                 if (info.m_frac_digits < 0)
-                    __paddec = __len;
+                    paddec = len;
                 if (!m_grouping.empty())
                 {
-                    __value.assign(2 * __paddec, char_type());
-                    char_type* __vend = FacetHelper::add_grouping(&__value[0], m_thousands_sep, m_grouping, __beg, __beg + __paddec);
-                    __value.erase(__vend - &__value[0]);
+                    value.assign(2 * paddec, char_type());
+                    char_type* vend = FacetHelper::add_grouping(&value[0], m_thousands_sep, m_grouping, beg, beg + paddec);
+                    value.erase(vend - &value[0]);
                 }
                 else
-                    __value.assign(__beg, __paddec);
+                    value.assign(beg, paddec);
             }
 
             // Deal with decimal point, decimal digits.
             if (info.m_frac_digits > 0)
             {
-                __value += m_decimal_point;
-                if (__paddec >= 0)
-                    __value.append(__beg + __paddec, info.m_frac_digits);
+                value += m_decimal_point;
+                if (paddec >= 0)
+                    value.append(beg + paddec, info.m_frac_digits);
                 else
                 {
                     // Have to pad zeros in the decimal position.
-                    __value.append(-__paddec, s_atoms[s_zero]);
-                    __value.append(__beg, __len);
+                    value.append(-paddec, s_atoms[s_zero]);
+                    value.append(beg, len);
                 }
             }
-  
+
             // Calculate length of resulting string.
-            const ios_defs::fmtflags __f = __io.flags() & ios_defs::adjustfield;
-            __len = __value.size() + __sign->size();
-            __len += ((__io.flags() & ios_defs::showbase) ? info.m_curr_symbol.size() : 0);
+            const ios_defs::fmtflags f = io.flags() & ios_defs::adjustfield;
+            len = value.size() + sign_ptr->size();
+            len += ((io.flags() & ios_defs::showbase) ? info.m_curr_symbol.size() : 0);
 
-            std::basic_string<char_type> __res;
-            __res.reserve(2 * __len);
+            std::basic_string<char_type> res;
+            res.reserve(2 * len);
 
-            const int __width = static_cast<int>(__io.width());  
-            const bool __testipad = (__f == ios_defs::internal && __len < __width);
+            const int width = static_cast<int>(io.width());
+            const bool testipad = (f == ios_defs::internal && len < width);
             // Fit formatted digits into the required pattern.
-            for (int __i = 0; __i < 4; ++__i)
+            for (int i = 0; i < 4; ++i)
             {
-                const part __which = static_cast<part>(__p[__i]);
-                switch (__which)
+                const part which = static_cast<part>(p[i]);
+                switch (which)
                 {
                 case base_ft<monetary>::symbol:
-                    if (__io.flags() & ios_defs::showbase)
-                        __res += info.m_curr_symbol;
+                    if (io.flags() & ios_defs::showbase)
+                        res += info.m_curr_symbol;
                     break;
                 case base_ft<monetary>::sign:
                     // Sign might not exist, or be more than one
                     // character long. In that case, add in the rest
                     // below.
-                    if (!__sign->empty())
-                        __res += (*__sign)[0];
+                    if (!sign_ptr->empty())
+                        res += (*sign_ptr)[0];
                     break;
                 case base_ft<monetary>::value:
-                    __res += __value;
+                    res += value;
                     break;
                 case base_ft<monetary>::space:
                     // At least one space is required, but if internal
                     // formatting is required, an arbitrary number of
                     // fill spaces will be necessary.
-                    if (__testipad)
-                        __res.append(__width - __len, __io.fill());
+                    if (testipad)
+                        res.append(width - len, io.fill());
                     else
-                        __res += __io.fill();
+                        res += io.fill();
                     break;
                 case base_ft<monetary>::none:
-                    if (__testipad)
-                        __res.append(__width - __len, __io.fill());
+                    if (testipad)
+                        res.append(width - len, io.fill());
                     break;
                 }
             }
 
             // Special case of multi-part sign parts.
-            if (__sign->size() > 1)
-                __res.append(__sign->c_str() + 1, __sign->size() - 1);
+            if (sign_ptr->size() > 1)
+                res.append(sign_ptr->c_str() + 1, sign_ptr->size() - 1);
 
             // Pad, if still necessary.
-            __len = __res.size();
-            if (__width > __len)
+            len = res.size();
+            if (width > len)
             {
-                if (__f == ios_defs::left) // After.
-                    __res.append(__width - __len, __io.fill());
+                if (f == ios_defs::left) // After.
+                    res.append(width - len, io.fill());
                 else // Before.
-                    __res.insert(0, __width - __len, __io.fill());
-                __len = __width;
+                    res.insert(0, width - len, io.fill());
+                len = width;
             }
 
             // Write resulting, fully-formatted string to output iterator.
-            __s = std::copy(__res.data(), __res.data() + __len, __s);
+            s = std::copy(res.data(), res.data() + len, s);
         }
-        __io.width(0);
-        return __s;
+        io.width(0);
+        return s;
     }
     
     template <bool isIntl, typename TIter, std::sentinel_for<TIter> TSent>
-    std::pair<bool, TIter> extract(TIter __beg, TSent __end, ios_base<char_type>& __io, std::string& __units) const
+    std::pair<bool, TIter> extract(TIter beg, TSent end, ios_base<char_type>& io, std::string& units) const
     {
         const split_info& info = isIntl ? m_int : m_nat;
         using part = base_ft<monetary>::part;
-        
+
         // Deduced sign.
-        bool __negative = false;
+        bool negative = false;
         // Sign size.
-        int __sign_size = 0;
+        int sign_size = 0;
         // True if sign is mandatory.
-        const bool __mandatory_sign = (!info.m_positive_sign.empty() && !info.m_negative_sign.empty());
-        // String of grouping info from thousands_sep plucked from __units.
-        std::string __grouping_tmp;
+        const bool mandatory_sign = (!info.m_positive_sign.empty() && !info.m_negative_sign.empty());
+        // String of grouping info from thousands_sep plucked from units.
+        std::string grouping_tmp;
         if (!m_grouping.empty())
-            __grouping_tmp.reserve(32);
+            grouping_tmp.reserve(32);
         // Last position before the decimal point.
-        int __last_pos = 0;
+        int last_pos = 0;
         // Separator positions, then, possibly, fractional digits.
-        int __n = 0;
+        int n = 0;
         // If input iterator is in a valid state.
-        bool __testvalid = true;
+        bool testvalid = true;
         // Flag marking when a decimal point is found.
-        bool __testdecfound = false;
+        bool testdecfound = false;
 
         // The tentative returned string is stored here.
-        std::string __res; __res.reserve(32);
+        std::string res; res.reserve(32);
 
-        const char_type* __lit_zero = s_atoms + s_zero;
-        const base_ft<monetary>::pattern __p = info.m_neg_format;
+        const char_type* lit_zero = s_atoms + s_zero;
+        const base_ft<monetary>::pattern p = info.m_neg_format;
 
-        for (int __i = 0; __i < 4 && __testvalid; ++__i)
+        for (int i = 0; i < 4 && testvalid; ++i)
         {
-            const part __which = static_cast<part>(__p[__i]);
-            switch (__which)
+            const part which = static_cast<part>(p[i]);
+            switch (which)
             {
             case base_ft<monetary>::symbol:
                 // According to 22.2.6.1.2, p2, symbol is required
-                // if (__io.flags() & ios_base::showbase), otherwise
+                // if (io.flags() & ios_base::showbase), otherwise
                 // is optional and consumed only if other characters
                 // are needed to complete the format.
-                if (__io.flags() & ios_defs::showbase || __sign_size > 1
-                    || __i == 0
-                    || (__i == 1 && (__mandatory_sign
-                        || (static_cast<part>(__p[0])
+                if (io.flags() & ios_defs::showbase || sign_size > 1
+                    || i == 0
+                    || (i == 1 && (mandatory_sign
+                        || (static_cast<part>(p[0])
                         == base_ft<monetary>::sign)
-                        || (static_cast<part>(__p[2])
+                        || (static_cast<part>(p[2])
                         == base_ft<monetary>::space)))
-                    || (__i == 2 && ((static_cast<part>(__p[3])
+                    || (i == 2 && ((static_cast<part>(p[3])
                         == base_ft<monetary>::value)
-                        || (__mandatory_sign
-                        && (static_cast<part>(__p[3])
+                        || (mandatory_sign
+                        && (static_cast<part>(p[3])
                             == base_ft<monetary>::sign)))))
                 {
-                    const int __len = info.m_curr_symbol.size();
-                    int __j = 0;
-                    for (; __beg != __end && __j < __len && *__beg == info.m_curr_symbol[__j]; ++__beg, (void)++__j);
-                    if (__j != __len && (__j || __io.flags() & ios_defs::showbase))
-                        __testvalid = false;
+                    const int len = info.m_curr_symbol.size();
+                    int j = 0;
+                    for (; beg != end && j < len && *beg == info.m_curr_symbol[j]; ++beg, (void)++j);
+                    if (j != len && (j || io.flags() & ios_defs::showbase))
+                        testvalid = false;
                 }
                 break;
             case base_ft<monetary>::sign:
                 // Sign might not exist, or be more than one character long.
-                if (!info.m_positive_sign.empty() && __beg != __end && *__beg == info.m_positive_sign[0])
+                if (!info.m_positive_sign.empty() && beg != end && *beg == info.m_positive_sign[0])
                 {
-                    __sign_size = info.m_positive_sign.size();
-                    ++__beg;
+                    sign_size = info.m_positive_sign.size();
+                    ++beg;
                 }
-                else if (!info.m_negative_sign.empty() && __beg != __end && *__beg == info.m_negative_sign[0])
+                else if (!info.m_negative_sign.empty() && beg != end && *beg == info.m_negative_sign[0])
                 {
-                    __negative = true;
-                    __sign_size = info.m_negative_sign.size();
-                    ++__beg;
+                    negative = true;
+                    sign_size = info.m_negative_sign.size();
+                    ++beg;
                 }
                 else if (!info.m_positive_sign.empty() && info.m_negative_sign.empty())
                 // "... if no sign is detected, the result is given the sign
                 // that corresponds to the source of the empty string"
-                    __negative = true;
-                else if (__mandatory_sign)
-                    __testvalid = false;
+                    negative = true;
+                else if (mandatory_sign)
+                    testvalid = false;
                 break;
             case base_ft<monetary>::value:
                 // Extract digits, remove and stash away the
                 // grouping of found thousands separators.
-                for (; __beg != __end; ++__beg)
+                for (; beg != end; ++beg)
                 {
-                    const char_type __c = *__beg;
-                    const char_type* __q = std::find(__lit_zero, __lit_zero + 10, __c);
-                    if (__q != __lit_zero + 10)
+                    const char_type c = *beg;
+                    const char_type* q = std::find(lit_zero, lit_zero + 10, c);
+                    if (q != lit_zero + 10)
                     {
-                        __res += '0' + (__q - __lit_zero);
-                        ++__n;
+                        res += '0' + (q - lit_zero);
+                        ++n;
                     }
-                    else if (__c == m_decimal_point && !__testdecfound)
+                    else if (c == m_decimal_point && !testdecfound)
                     {
                         if (info.m_frac_digits <= 0)
                             break;
 
-                        __last_pos = __n;
-                        __n = 0;
-                        __testdecfound = true;
+                        last_pos = n;
+                        n = 0;
+                        testdecfound = true;
                     }
-                    else if (!m_grouping.empty() && __c == m_thousands_sep && !__testdecfound)
+                    else if (!m_grouping.empty() && c == m_thousands_sep && !testdecfound)
                     {
-                        if (__n)
+                        if (n)
                         {
                             // Mark position for later analysis.
-                            __grouping_tmp += static_cast<char>(__n);
-                            __n = 0;
+                            grouping_tmp += static_cast<char>(n);
+                            n = 0;
                         }
                         else
                         {
-                            __testvalid = false;
+                            testvalid = false;
                             break;
                         }
                     }
                     else
                         break;
                 }
-                if (__res.empty())
-                    __testvalid = false;
+                if (res.empty())
+                    testvalid = false;
                 break;
             case base_ft<monetary>::space:
                 // At least one space is required.
-                if (__beg != __end && (*__beg == __io.fill()))
-                    ++__beg;
+                if (beg != end && (*beg == io.fill()))
+                    ++beg;
                 else
-                    __testvalid = false;
+                    testvalid = false;
             // fallthrough
             case base_ft<monetary>::none:
                 // Only if not at the end of the pattern.
-                if (__i != 3)
-                for (; __beg != __end && (*__beg == __io.fill()); ++__beg);
+                if (i != 3)
+                for (; beg != end && (*beg == io.fill()); ++beg);
                 break;
             }
         }
 
         // Need to get the rest of the sign characters, if they exist.
-        if (__sign_size > 1 && __testvalid)
+        if (sign_size > 1 && testvalid)
         {
-            const auto& __sign = __negative ? info.m_negative_sign
+            const auto& sign_str = negative ? info.m_negative_sign
                                             : info.m_positive_sign;
-            int __i = 1;
-            for (; __beg != __end && __i < __sign_size && *__beg == __sign[__i]; ++__beg, (void)++__i);
-            if (__i != __sign_size)
-                __testvalid = false;
+            int i = 1;
+            for (; beg != end && i < sign_size && *beg == sign_str[i]; ++beg, (void)++i);
+            if (i != sign_size)
+                testvalid = false;
         }
 
         bool succ = true;
-        if (__testvalid)
+        if (testvalid)
         {
             // Strip leading zeros.
-            if (__res.size() > 1)
+            if (res.size() > 1)
             {
-                const auto __first = __res.find_first_not_of('0');
-                const bool __only_zeros = __first == std::string::npos;
-                if (__first)
-                    __res.erase(0, __only_zeros ? __res.size() - 1 : __first);
+                const auto first = res.find_first_not_of('0');
+                const bool only_zeros = first == std::string::npos;
+                if (first)
+                    res.erase(0, only_zeros ? res.size() - 1 : first);
             }
 
             // 22.2.6.1.2, p4
-            if (__negative && __res[0] != '0')
-                __res.insert(__res.begin(), '-');
-	    
+            if (negative && res[0] != '0')
+                res.insert(res.begin(), '-');
+
             // Test for grouping fidelity.
-            if (__grouping_tmp.size())
+            if (grouping_tmp.size())
             {
                 // Add the ending grouping.
-                __grouping_tmp += static_cast<char>(__testdecfound ? __last_pos : __n);
-                succ = FacetHelper::verify_grouping(m_grouping, __grouping_tmp);
+                grouping_tmp += static_cast<char>(testdecfound ? last_pos : n);
+                succ = FacetHelper::verify_grouping(m_grouping, grouping_tmp);
             }
 
             // Iff not enough digits were supplied after the decimal-point.
-            if (__testdecfound && __n != info.m_frac_digits)
-                __testvalid = false;
+            if (testdecfound && n != info.m_frac_digits)
+                testvalid = false;
         }
 
         // Iff valid sequence is not recognized.
-        if (!__testvalid)
+        if (!testvalid)
             succ = false;
         else
-            __units.swap(__res);
-        
-        return std::pair(succ, __beg);
+            units.swap(res);
+
+        return std::pair(succ, beg);
     }
 
     template <std::integral TVal>

--- a/include/facet/monetary_details.h
+++ b/include/facet/monetary_details.h
@@ -24,165 +24,165 @@ public:
     
 protected:
     inline const static pattern s_default_pattern = {symbol, sign, none, value};
-    static pattern s_construct_pattern(int8_t __precedes, int8_t __space, int8_t __posn)
+    static pattern s_construct_pattern(int8_t precedes, int8_t sp, int8_t posn)
     {
-        pattern __ret;
+        pattern ret;
 
         // This insanely complicated routine attempts to construct a valid
         // pattern for use with monyepunct. A couple of invariants:
-    
-        // if (__precedes) symbol -> value
+
+        // if (precedes) symbol -> value
         // else value -> symbol
-    
-        // if (__space) space
+
+        // if (sp) space
         // else none
-    
+
         // none == never first
         // space never first or last
-        switch (__posn)
+        switch (posn)
         {
         case 0:
         case 1:
             // 1 The sign precedes the value and symbol.
-            __ret[0] = sign;
-            if (__space)
+            ret[0] = sign;
+            if (sp)
             {
                 // Pattern starts with sign.
-                if (__precedes)
+                if (precedes)
                 {
-                    __ret[1] = symbol;
-                    __ret[3] = value;
+                    ret[1] = symbol;
+                    ret[3] = value;
                 }
                 else
                 {
-                    __ret[1] = value;
-                    __ret[3] = symbol;
+                    ret[1] = value;
+                    ret[3] = symbol;
                 }
-                __ret[2] = space;
+                ret[2] = space;
             }
             else
             {
                 // Pattern starts with sign and ends with none.
-                if (__precedes)
+                if (precedes)
                 {
-                    __ret[1] = symbol;
-                    __ret[2] = value;
+                    ret[1] = symbol;
+                    ret[2] = value;
                 }
                 else
                 {
-                    __ret[1] = value;
-                    __ret[2] = symbol;
+                    ret[1] = value;
+                    ret[2] = symbol;
                 }
-                __ret[3] = none;
+                ret[3] = none;
             }
             break;
         case 2:
             // 2 The sign follows the value and symbol.
-            if (__space)
+            if (sp)
             {
                 // Pattern either ends with sign.
-                if (__precedes)
+                if (precedes)
                 {
-                    __ret[0] = symbol;
-                    __ret[2] = value;
+                    ret[0] = symbol;
+                    ret[2] = value;
                 }
                 else
                 {
-                    __ret[0] = value;
-                    __ret[2] = symbol;
+                    ret[0] = value;
+                    ret[2] = symbol;
                 }
-                __ret[1] = space;
-                __ret[3] = sign;
+                ret[1] = space;
+                ret[3] = sign;
             }
             else
             {
                 // Pattern ends with sign then none.
-                if (__precedes)
+                if (precedes)
                 {
-                    __ret[0] = symbol;
-                    __ret[1] = value;
+                    ret[0] = symbol;
+                    ret[1] = value;
                 }
                 else
                 {
-                    __ret[0] = value;
-                    __ret[1] = symbol;
+                    ret[0] = value;
+                    ret[1] = symbol;
                 }
-                __ret[2] = sign;
-                __ret[3] = none;
+                ret[2] = sign;
+                ret[3] = none;
             }
             break;
         case 3:
             // 3 The sign immediately precedes the symbol.
-            if (__precedes)
+            if (precedes)
             {
-                __ret[0] = sign;
-                __ret[1] = symbol;
-                if (__space)
+                ret[0] = sign;
+                ret[1] = symbol;
+                if (sp)
                 {
-                    __ret[2] = space;
-                    __ret[3] = value;
+                    ret[2] = space;
+                    ret[3] = value;
                 }
                 else
                 {
-                    __ret[2] = value;
-                    __ret[3] = none;
+                    ret[2] = value;
+                    ret[3] = none;
                 }
             }
             else
             {
-                __ret[0] = value;
-                if (__space)
+                ret[0] = value;
+                if (sp)
                 {
-                    __ret[1] = space;
-                    __ret[2] = sign;
-                    __ret[3] = symbol;
+                    ret[1] = space;
+                    ret[2] = sign;
+                    ret[3] = symbol;
                 }
                 else
                 {
-                    __ret[1] = sign;
-                    __ret[2] = symbol;
-                    __ret[3] = none;
+                    ret[1] = sign;
+                    ret[2] = symbol;
+                    ret[3] = none;
                 }
             }
             break;
         case 4:
             // 4 The sign immediately follows the symbol.
-            if (__precedes)
+            if (precedes)
             {
-                __ret[0] = symbol;
-                __ret[1] = sign;
-                if (__space)
+                ret[0] = symbol;
+                ret[1] = sign;
+                if (sp)
                 {
-                    __ret[2] = space;
-                    __ret[3] = value;
+                    ret[2] = space;
+                    ret[3] = value;
                 }
                 else
                 {
-                    __ret[2] = value;
-                    __ret[3] = none;
+                    ret[2] = value;
+                    ret[3] = none;
                 }
             }
             else
             {
-                __ret[0] = value;
-                if (__space)
+                ret[0] = value;
+                if (sp)
                 {
-                    __ret[1] = space;
-                    __ret[2] = symbol;
-                    __ret[3] = sign;
+                    ret[1] = space;
+                    ret[2] = symbol;
+                    ret[3] = sign;
                 }
                 else
                 {
-                    __ret[1] = symbol;
-                    __ret[2] = sign;
-                    __ret[3] = none;
+                    ret[1] = symbol;
+                    ret[2] = sign;
+                    ret[3] = none;
                 }
             }
             break;
         default:
-            __ret = s_default_pattern;
+            ret = s_default_pattern;
         }
-        return __ret;
+        return ret;
     }
 };
 
@@ -233,12 +233,12 @@ public:
             if (m_thousands_sep == '\0') m_thousands_sep = ',';
             else
             {
-                const char* __cgroup = nl_langinfo(__MON_GROUPING);
-                size_t len = strlen(__cgroup);
+                const char* cgroup = nl_langinfo(__MON_GROUPING);
+                size_t len = strlen(cgroup);
                 if (len != 0)
                 {
                     m_grouping.resize(len);
-                    for (size_t i = 0; i < len; ++i) m_grouping[i] = __cgroup[i];
+                    for (size_t i = 0; i < len; ++i) m_grouping[i] = cgroup[i];
                 }
             }
             
@@ -349,14 +349,14 @@ public:
         }
         else
         {
-            union { char *__s; wchar_t __w; } __u;
+            union { char *s; wchar_t w; } u;
             clocale_wrapper inter_locale(name.c_str());
             clocale_user guard(inter_locale.c_locale);
-            
-            __u.__s = nl_langinfo(_NL_MONETARY_DECIMAL_POINT_WC);
-            m_decimal_point = __u.__w;
-            __u.__s = nl_langinfo(_NL_MONETARY_THOUSANDS_SEP_WC);
-            m_thousands_sep = __u.__w;
+
+            u.s = nl_langinfo(_NL_MONETARY_DECIMAL_POINT_WC);
+            m_decimal_point = u.w;
+            u.s = nl_langinfo(_NL_MONETARY_THOUSANDS_SEP_WC);
+            m_thousands_sep = u.w;
             
             if (static_cast<int>(m_decimal_point) == 0)
             {
@@ -378,15 +378,15 @@ public:
             }
             else
             {
-                const char* __cgroup = nl_langinfo(__MON_GROUPING);
-                size_t len = strlen(__cgroup);
+                const char* cgroup = nl_langinfo(__MON_GROUPING);
+                size_t len = strlen(cgroup);
                 if (len != 0)
                 {
                     m_grouping.resize(len);
-                    for (size_t i = 0; i < len; ++i) m_grouping[i] = __cgroup[i];
+                    for (size_t i = 0; i < len; ++i) m_grouping[i] = cgroup[i];
                 }
             }
-            
+
             {
                 std::string input = nl_langinfo(__POSITIVE_SIGN);
                 if constexpr(std::is_same_v<CharT, wchar_t>)

--- a/include/facet/numeric.h
+++ b/include/facet/numeric.h
@@ -27,11 +27,11 @@ public:
         m_grouping = p_obj->grouping();
         adjust_grouping();
 
-        char __in_atoms_c[] = "-+xX0123456789abcdefABCDEF";
-        m_ctype->widen_seq(__in_atoms_c, __in_atoms_c + 26, m_in_atoms);
+        char in_atoms_c[] = "-+xX0123456789abcdefABCDEF";
+        m_ctype->widen_seq(in_atoms_c, in_atoms_c + 26, m_in_atoms);
 
-        char __out_atoms_c[] = "-+xX0123456789abcdef0123456789ABCDEF";
-        m_ctype->widen_seq(__out_atoms_c, __out_atoms_c + 36, m_out_atoms);
+        char out_atoms_c[] = "-+xX0123456789abcdef0123456789ABCDEF";
+        m_ctype->widen_seq(out_atoms_c, out_atoms_c + 36, m_out_atoms);
     }
 
 public:
@@ -80,518 +80,518 @@ public:
     
     template <typename TIter, typename TValue>
         requires (std::is_integral_v<TValue> && (!std::is_same_v<TValue, bool>))
-    TIter put(TIter __s, ios_base<char_type>& __io, TValue __v) const { return insert_int(__s, __io, __v); }
-    
+    TIter put(TIter s, ios_base<char_type>& io, TValue v) const { return insert_int(s, io, v); }
+
     template <typename TIter, typename TValue>
         requires (std::is_floating_point_v<TValue>)
-    TIter put(TIter __s, ios_base<char_type>& __io, TValue __v) const
+    TIter put(TIter s, ios_base<char_type>& io, TValue v) const
     {
         if constexpr (std::is_same_v<TValue, long double>)
-            return insert_float(__s, __io, __v, 'L');
+            return insert_float(s, io, v, 'L');
         else
-            return insert_float(__s, __io, __v, char());
+            return insert_float(s, io, v, char());
     }
 
     template <typename TIter>
-    TIter put(TIter __s, ios_base<char_type>& __io, const void* __v) const
+    TIter put(TIter s, ios_base<char_type>& io, const void* v) const
     {
-        const ios_defs::fmtflags __flags = __io.flags();
-        const ios_defs::fmtflags __fmt = ~(ios_defs::basefield | ios_defs::uppercase);
-        __io.flags((__flags & __fmt) | (ios_defs::hex | ios_defs::showbase));
+        const ios_defs::fmtflags flags = io.flags();
+        const ios_defs::fmtflags fmt = ~(ios_defs::basefield | ios_defs::uppercase);
+        io.flags((flags & fmt) | (ios_defs::hex | ios_defs::showbase));
 
         using _UIntPtrType = std::conditional_t<(sizeof(const void*) <= sizeof(unsigned long)),
                                                 unsigned long,
                                                 unsigned long long>;
 
-        __s = insert_int(__s, __io, reinterpret_cast<_UIntPtrType>(__v));
-        __io.flags(__flags);
-        return __s;
+        s = insert_int(s, io, reinterpret_cast<_UIntPtrType>(v));
+        io.flags(flags);
+        return s;
     }
     
     template <typename TIter, std::sentinel_for<TIter> TSent>
-    TIter get(TIter __beg, TSent __end, ios_base<char_type>& __io, bool& __v) const
+    TIter get(TIter beg, TSent end, ios_base<char_type>& io, bool& v) const
     {
         bool success = true;
-        
-        if (!(__io.flags() & ios_defs::boolalpha))
+
+        if (!(io.flags() & ios_defs::boolalpha))
         {
             // Parse bool values as long.
-            long __l = -1;
-            std::tie(success, __beg) = extract_int(__beg, __end, __io, __l);
+            long l = -1;
+            std::tie(success, beg) = extract_int(beg, end, io, l);
 
-            if (__l == 0 || __l == 1) __v = bool(__l);
+            if (l == 0 || l == 1) v = bool(l);
             else
             {
                 // _GLIBCXX_RESOLVE_LIB_DEFECTS
                 // 23. Num_get overflow result.
-                __v = true;
+                v = true;
                 success = false;
             }
         }
         else
         {
             // Parse bool values as alphanumeric.
-            bool __testf = true;
-            bool __testt = true;
-            bool __donef = (m_false_name.empty());
-            bool __donet = (m_true_name.empty());
-            size_t __n = 0;
-            while (!__donef || !__donet)
+            bool testf = true;
+            bool testt = true;
+            bool donef = (m_false_name.empty());
+            bool donet = (m_true_name.empty());
+            size_t n = 0;
+            while (!donef || !donet)
             {
-                if (__beg == __end)
+                if (beg == end)
                     break;
 
-                const CharT __c = *__beg;
+                const CharT c = *beg;
 
-                if (!__donef)
-                    __testf = __c == m_false_name[__n];
+                if (!donef)
+                    testf = c == m_false_name[n];
 
-                if (!__testf && __donet) break;
+                if (!testf && donet) break;
 
-                if (!__donet)
-                    __testt = __c == m_true_name[__n];
+                if (!donet)
+                    testt = c == m_true_name[n];
 
-                if (!__testt && __donef) break;
+                if (!testt && donef) break;
 
-                if (!__testt && !__testf) break;
+                if (!testt && !testf) break;
 
-                ++__n;
-                ++__beg;
+                ++n;
+                ++beg;
 
-                __donef = !__testf || __n >= m_false_name.size();
-                __donet = !__testt || __n >= m_true_name.size();
+                donef = !testf || n >= m_false_name.size();
+                donet = !testt || n >= m_true_name.size();
             }
-            if (__testf && __n == m_false_name.size() && __n)
+            if (testf && n == m_false_name.size() && n)
             {
-                __v = false;
-                if (__testt && __n == m_true_name.size())
+                v = false;
+                if (testt && n == m_true_name.size())
                     success = false;
             }
-            else if (__testt && __n == m_true_name.size() && __n)
+            else if (testt && n == m_true_name.size() && n)
             {
-                __v = true;
+                v = true;
             }
             else
             {
                 // _GLIBCXX_RESOLVE_LIB_DEFECTS
                 // 23. Num_get overflow result.
-                __v = false;
+                v = false;
                 success = false;
             }
         }
-        
+
         if (!success) throw stream_error("numeric::get fail: parse boolean fail");
-        return __beg;
+        return beg;
     }
     
     template <typename TIter, std::sentinel_for<TIter> TSent, typename TValue>
         requires (std::is_integral_v<TValue> && (!std::is_same_v<TValue, bool>))
-    TIter get(TIter __beg, TSent __end, ios_base<char_type>& __io, TValue& __v) const
+    TIter get(TIter beg, TSent end, ios_base<char_type>& io, TValue& v) const
     {
-        auto [succ, res] = extract_int(__beg, __end, __io, __v);
+        auto [succ, res] = extract_int(beg, end, io, v);
         if (!succ) throw stream_error("numeric::get fail: parse integral fail");
         return res;
     }
-    
+
     template <typename TIter, std::sentinel_for<TIter> TSent>
-    TIter get(TIter __beg, TSent __end, ios_base<char_type>& __io, void*& __v) const
+    TIter get(TIter beg, TSent end, ios_base<char_type>& io, void*& v) const
     {
         // Prepare for hex formatted input.
-        const auto __fmt = __io.flags();
-        __io.flags((__fmt & ~ios_defs::basefield) | ios_defs::hex);
+        const auto fmt = io.flags();
+        io.flags((fmt & ~ios_defs::basefield) | ios_defs::hex);
 
         using _UIntPtrType = std::conditional_t<(sizeof(const void*) <= sizeof(unsigned long)),
                                                 unsigned long,
                                                 unsigned long long>;
-        _UIntPtrType __ul;
-        auto [succ, res] = extract_int(__beg, __end, __io, __ul);
+        _UIntPtrType ul;
+        auto [succ, res] = extract_int(beg, end, io, ul);
 
         // Reset from hex formatted input.
-        __io.flags(__fmt);
+        io.flags(fmt);
 
-        __v = reinterpret_cast<void*>(__ul);
+        v = reinterpret_cast<void*>(ul);
 
         if (!succ) throw stream_error("numeric::get fail: parse address fail");
         return res;
     }
-    
+
     template <typename TIter, std::sentinel_for<TIter> TSent, typename TValue>
         requires (std::is_floating_point_v<TValue>)
-    TIter get(TIter __beg, TSent __end, ios_base<char_type>& __io, TValue& __v) const
+    TIter get(TIter beg, TSent end, ios_base<char_type>& io, TValue& v) const
     {
-        std::string __xtrc;
-        __xtrc.reserve(32);
-        auto [succ, __res] = extract_float(__beg, __end, __io, __xtrc);
-        succ &= convert_to_v(__xtrc.c_str(), __v);
-        
+        std::string xtrc;
+        xtrc.reserve(32);
+        auto [succ, res] = extract_float(beg, end, io, xtrc);
+        succ &= convert_to_v(xtrc.c_str(), v);
+
         if (!succ) throw stream_error("numeric::get fail: parse float fail");
-        return __res;
+        return res;
     }
 
 private:
     template <typename TIter, typename TValue>
-    TIter insert_float(TIter __s, ios_base<char_type>& __io, TValue __v, char __mod) const
+    TIter insert_float(TIter s, ios_base<char_type>& io, TValue v, char mod) const
     {
         // Use default precision if out of range.
-        const std::streamsize __prec = __io.precision() < 0 ? 6 : __io.precision();
-        const int __max_digits = std::numeric_limits<TValue>::digits10;
-        
+        const std::streamsize prec = io.precision() < 0 ? 6 : io.precision();
+        const int max_digits = std::numeric_limits<TValue>::digits10;
+
         // [22.2.2.2.2] Stage 1, numeric conversion to character.
-        int __len;
+        int len;
         // Long enough for the max format spec.
-        char __fbuf[16];
-        _S_format_float(__io.flags(), __fbuf, __mod);
-        
+        char fbuf[16];
+        _S_format_float(io.flags(), fbuf, mod);
+
         // Consider the possibility of long ios_base::fixed outputs
-        const bool __fixed = __io.flags() & ios_defs::fixed;
-        const int __max_exp = std::numeric_limits<TValue>::max_exponent10;
+        const bool fixed = io.flags() & ios_defs::fixed;
+        const int max_exp = std::numeric_limits<TValue>::max_exponent10;
 
         // The size of the output string is computed as follows.
-        // ios_base::fixed outputs may need up to __max_exp + 1 chars
-        // for the integer part + __prec chars for the fractional part
+        // ios_base::fixed outputs may need up to max_exp + 1 chars
+        // for the integer part + prec chars for the fractional part
         // + 3 chars for sign, decimal point, '\0'. On the other hand,
-        // for non-fixed outputs __max_digits * 2 + __prec chars are
+        // for non-fixed outputs max_digits * 2 + prec chars are
         // largely sufficient.
-        const int __cs_size = __fixed ? __max_exp + __prec + 4
-                                      : __max_digits * 2 + __prec;
-        std::vector<char> vec_cs(__cs_size);
-        char* __cs = vec_cs.data();
-        
+        const int cs_size = fixed ? max_exp + prec + 4
+                                  : max_digits * 2 + prec;
+        std::vector<char> vec_cs(cs_size);
+        char* cs = vec_cs.data();
+
         {
             clocale_wrapper inter_locale("C");
             clocale_user guard(inter_locale.c_locale);
-            __len = sprintf(__cs, __fbuf, __prec, __v);
+            len = sprintf(cs, fbuf, prec, v);
         }
-        
+
         // [22.2.2.2.2] Stage 2, convert to char_type, using correct
         // numpunct.decimal_point() values for '.' and adding grouping.
-        std::vector<CharT> vec_ws(__len);
-        CharT* __ws = vec_ws.data();
-        m_ctype->widen_seq(__cs, __cs + __len, __ws);
+        std::vector<CharT> vec_ws(len);
+        CharT* ws = vec_ws.data();
+        m_ctype->widen_seq(cs, cs + len, ws);
 
         // Replace decimal point.
-        const char* __p = std::find(__cs, __cs + __len, '.');
-        CharT* __wp = 0;
-        if (__p != __cs + __len)
+        const char* p = std::find(cs, cs + len, '.');
+        CharT* wp = 0;
+        if (p != cs + len)
         {
-            __wp = __ws + (__p - __cs);
-            *__wp = m_decimal_point;
+            wp = ws + (p - cs);
+            *wp = m_decimal_point;
         }
-        
+
         // Add grouping, if necessary.
         if ((!m_grouping.empty())
-            && (__wp || __len < 3 || (__cs[1] <= '9' && __cs[2] <= '9' && __cs[1] >= '0' && __cs[2] >= '0')))
+            && (wp || len < 3 || (cs[1] <= '9' && cs[2] <= '9' && cs[1] >= '0' && cs[2] >= '0')))
         {
             // Grouping can add (almost) as many separators as the
             // number of digits, but no more.
-            std::vector<CharT> vec_ws2(__len * 2);
-            CharT* __ws2 = vec_ws2.data();
+            std::vector<CharT> vec_ws2(len * 2);
+            CharT* ws2 = vec_ws2.data();
 
-            std::streamsize __off = 0;
-            if (__cs[0] == '-' || __cs[0] == '+')
+            std::streamsize off = 0;
+            if (cs[0] == '-' || cs[0] == '+')
             {
-                __off = 1;
-                __ws2[0] = __ws[0];
-                __len -= 1;
+                off = 1;
+                ws2[0] = ws[0];
+                len -= 1;
             }
 
-            group_float(m_grouping, m_thousands_sep, __wp,
-                        __ws2 + __off, __ws + __off, __len);
-            __len += __off;
+            group_float(m_grouping, m_thousands_sep, wp,
+                        ws2 + off, ws + off, len);
+            len += off;
             std::swap(vec_ws, vec_ws2);
-            __ws = vec_ws.data();
+            ws = vec_ws.data();
         }
-        
+
         // Pad.
-        const std::streamsize __w = __io.width();
-        if (__w > static_cast<std::streamsize>(__len))
+        const std::streamsize w = io.width();
+        if (w > static_cast<std::streamsize>(len))
         {
-            std::vector<CharT> vec_ws3(__w);
-            CharT* __ws3 = vec_ws3.data();
-            bool startSign = (__ws[0] == m_out_atoms[s_ominus]) || (__ws[0] == m_out_atoms[s_oplus]);
-            bool start0x = (__ws[0] == m_out_atoms[s_odigits]) && (__len > 1) && 
-                           ((__ws[1] == m_out_atoms[s_ox]) || (__ws[1] == m_out_atoms[s_oX]));
-            const ios_defs::fmtflags __adjust = __io.flags() & ios_defs::adjustfield;
-            pad(__io.fill(), __w, __adjust, __ws3, __ws, __len, startSign, start0x);
-            
+            std::vector<CharT> vec_ws3(w);
+            CharT* ws3 = vec_ws3.data();
+            bool startSign = (ws[0] == m_out_atoms[s_ominus]) || (ws[0] == m_out_atoms[s_oplus]);
+            bool start0x = (ws[0] == m_out_atoms[s_odigits]) && (len > 1) &&
+                           ((ws[1] == m_out_atoms[s_ox]) || (ws[1] == m_out_atoms[s_oX]));
+            const ios_defs::fmtflags adjust = io.flags() & ios_defs::adjustfield;
+            pad(io.fill(), w, adjust, ws3, ws, len, startSign, start0x);
+
             std::swap(vec_ws, vec_ws3);
-            __ws = vec_ws.data();
+            ws = vec_ws.data();
         }
-        __io.width(0);
+        io.width(0);
 
         // [22.2.2.2.2] Stage 4.
         // Write resulting, fully-formatted string to output iterator.
-        return std::copy(__ws, __ws + __len, __s);
+        return std::copy(ws, ws + len, s);
     }
     
     template <typename TIter, typename TValue>
-    TIter insert_int(TIter __s, ios_base<char_type>& __io, TValue __v) const
+    TIter insert_int(TIter s, ios_base<char_type>& io, TValue v) const
     {
-        using __unsigned_type = std::make_unsigned_t<TValue>;
-        
-        const ios_defs::fmtflags __flags = __io.flags();
+        using unsigned_type = std::make_unsigned_t<TValue>;
+
+        const ios_defs::fmtflags flags = io.flags();
 
         // Long enough to hold hex, dec, and octal representations.
-        const auto __ilen = 5 * sizeof(TValue);
-        std::vector<char_type> cs_vec(__ilen);
-        char_type* __cs = cs_vec.data();
+        const auto ilen = 5 * sizeof(TValue);
+        std::vector<char_type> cs_vec(ilen);
+        char_type* cs = cs_vec.data();
 
         // [22.2.2.2.2] Stage 1, numeric conversion to character.
         // Result is returned right-justified in the buffer.
-        const ios_defs::fmtflags __basefield = __flags & ios_defs::basefield;
-        const bool __dec = (__basefield != ios_defs::oct && __basefield != ios_defs::hex);
-        const __unsigned_type __u = ((__v > 0 || !__dec) ? __unsigned_type(__v)
-                                                         : -__unsigned_type(__v));
-        auto __len = int_to_char(__cs + __ilen, __u, __flags, __dec);
-        __cs += __ilen - __len;
-        
+        const ios_defs::fmtflags basefield = flags & ios_defs::basefield;
+        const bool dec = (basefield != ios_defs::oct && basefield != ios_defs::hex);
+        const unsigned_type u = ((v > 0 || !dec) ? unsigned_type(v)
+                                                 : -unsigned_type(v));
+        auto len = int_to_char(cs + ilen, u, flags, dec);
+        cs += ilen - len;
+
         // Add grouping, if necessary.
         if (!m_grouping.empty())
         {
             // Grouping can add (almost) as many separators as the number
             // of digits + space is reserved for numeric base or sign.
-            std::vector<char_type> cs_vec2((__ilen + 1) * 2);
-            char_type* __cs2 = cs_vec2.data() + 2;
-            __len = FacetHelper::add_grouping(__cs2, m_thousands_sep, m_grouping, __cs, __cs + __len) - __cs2;
+            std::vector<char_type> cs_vec2((ilen + 1) * 2);
+            char_type* cs2 = cs_vec2.data() + 2;
+            len = FacetHelper::add_grouping(cs2, m_thousands_sep, m_grouping, cs, cs + len) - cs2;
             std::swap(cs_vec, cs_vec2);
-            __cs = cs_vec.data() + 2;
+            cs = cs_vec.data() + 2;
         }
-        
+
         // Complete Stage 1, prepend numeric base or sign.
-        if (__dec)
+        if (dec)
         { // Decimal.
-            if (__v >= 0)
+            if (v >= 0)
             {
-                if (bool(__flags & ios_defs::showpos) && std::is_signed_v<TValue>)
-                    *--__cs = m_out_atoms[s_oplus], ++__len;
+                if (bool(flags & ios_defs::showpos) && std::is_signed_v<TValue>)
+                    *--cs = m_out_atoms[s_oplus], ++len;
             }
             else
-                *--__cs = m_out_atoms[s_ominus], ++__len;
+                *--cs = m_out_atoms[s_ominus], ++len;
         }
-        else if (bool(__flags & ios_defs::showbase) && __v)
+        else if (bool(flags & ios_defs::showbase) && v)
         {
-            if (__basefield == ios_defs::oct)
-                *--__cs = m_out_atoms[s_odigits], ++__len;
+            if (basefield == ios_defs::oct)
+                *--cs = m_out_atoms[s_odigits], ++len;
             else
             {
                 // 'x' or 'X'
-                const bool __uppercase = __flags & ios_defs::uppercase;
-                *--__cs = m_out_atoms[s_ox + __uppercase];
+                const bool uppercase = flags & ios_defs::uppercase;
+                *--cs = m_out_atoms[s_ox + uppercase];
                 // '0'
-                *--__cs = m_out_atoms[s_odigits];
-                    __len += 2;
+                *--cs = m_out_atoms[s_odigits];
+                    len += 2;
             }
         }
-        
+
         // Pad.
-        const std::streamsize __w = __io.width();
-        if (__w > static_cast<std::streamsize>(__len))
+        const std::streamsize w = io.width();
+        if (w > static_cast<std::streamsize>(len))
         {
-            std::vector<char_type> cs_vec3(__w);
-            char_type* __cs3 = cs_vec3.data();
-            bool startSign = (__cs[0] == m_out_atoms[s_ominus]) || (__cs[0] == m_out_atoms[s_oplus]);
-            bool start0x = (__cs[0] == m_out_atoms[s_odigits]) && (__len > 1) && 
-                           ((__cs[1] == m_out_atoms[s_ox]) || (__cs[1] == m_out_atoms[s_oX]));
-            const ios_defs::fmtflags __adjust = __io.flags() & ios_defs::adjustfield;
-            pad(__io.fill(), __w, __adjust, __cs3, __cs, __len, startSign, start0x);
+            std::vector<char_type> cs_vec3(w);
+            char_type* cs3 = cs_vec3.data();
+            bool startSign = (cs[0] == m_out_atoms[s_ominus]) || (cs[0] == m_out_atoms[s_oplus]);
+            bool start0x = (cs[0] == m_out_atoms[s_odigits]) && (len > 1) &&
+                           ((cs[1] == m_out_atoms[s_ox]) || (cs[1] == m_out_atoms[s_oX]));
+            const ios_defs::fmtflags adjust = io.flags() & ios_defs::adjustfield;
+            pad(io.fill(), w, adjust, cs3, cs, len, startSign, start0x);
             std::swap(cs_vec, cs_vec3);
-            __cs = cs_vec.data();
+            cs = cs_vec.data();
         }
-        __io.width(0);
+        io.width(0);
 
         // [22.2.2.2.2] Stage 4.
         // Write resulting, fully-formatted string to output iterator.
-        return std::copy(__cs, __cs + __len, __s);
+        return std::copy(cs, cs + len, s);
     }
     
     template <typename TValue>
-    int int_to_char(CharT* __bufend, TValue __v, ios_defs::fmtflags __flags, bool __dec) const
+    int int_to_char(CharT* bufend, TValue v, ios_defs::fmtflags flags, bool dec) const
     {
-        auto __buf = __bufend;
-        if (__dec)
+        auto buf = bufend;
+        if (dec)
         {   // Decimal.
             do
             {
-                *--__buf = m_out_atoms[(__v % 10) + s_odigits];
-                __v /= 10;
-            } while (__v != 0);
+                *--buf = m_out_atoms[(v % 10) + s_odigits];
+                v /= 10;
+            } while (v != 0);
         }
-        else if ((__flags & ios_defs::basefield) == ios_defs::oct)
+        else if ((flags & ios_defs::basefield) == ios_defs::oct)
         { // Octal.
             do
             {
-                *--__buf = m_out_atoms[(__v & 0x7) + s_odigits];
-                __v >>= 3;
-            } while (__v != 0);
+                *--buf = m_out_atoms[(v & 0x7) + s_odigits];
+                v >>= 3;
+            } while (v != 0);
         }
         else
         {   // Hex.
-            const bool __uppercase = __flags & ios_defs::uppercase;
-            const int __case_offset = __uppercase ? s_oudigits : s_odigits;
+            const bool uppercase = flags & ios_defs::uppercase;
+            const int case_offset = uppercase ? s_oudigits : s_odigits;
             do
             {
-                *--__buf = m_out_atoms[(__v & 0xf) + __case_offset];
-                __v >>= 4;
-            } while (__v != 0);
+                *--buf = m_out_atoms[(v & 0xf) + case_offset];
+                v >>= 4;
+            } while (v != 0);
         }
-        return __bufend - __buf;
+        return bufend - buf;
     }
 
-    void pad(char_type __fill, std::streamsize __w, ios_defs::fmtflags __adjust,
-             char_type* __new, const char_type* __cs, int& __len,
+    void pad(char_type fill, std::streamsize w, ios_defs::fmtflags adjust,
+             char_type* new_buf, const char_type* cs, int& len,
              bool startSign, bool start0x) const
     {
       // [22.2.2.2.2] Stage 3.
       // If necessary, pad.
-      _S_pad(__adjust, __fill, __new, __cs, __w, __len, startSign, start0x);
-      __len = static_cast<int>(__w);
+      _S_pad(adjust, fill, new_buf, cs, w, len, startSign, start0x);
+      len = static_cast<int>(w);
     }
-    
-    void _S_pad(ios_defs::fmtflags __adjust, char_type __fill,
-                char_type* __news, const char_type* __olds,
-                std::streamsize __newlen, std::streamsize __oldlen,
+
+    void _S_pad(ios_defs::fmtflags adjust, char_type fill,
+                char_type* news, const char_type* olds,
+                std::streamsize newlen, std::streamsize oldlen,
                 bool startSign, bool start0x) const
     {
-        
-        const size_t __plen = static_cast<size_t>(__newlen - __oldlen);
+
+        const size_t plen = static_cast<size_t>(newlen - oldlen);
 
         // Padding last.
-        if (__adjust == ios_defs::left)
+        if (adjust == ios_defs::left)
         {
-            std::copy(__olds, __olds + __oldlen, __news);
-            std::fill_n(__news + __oldlen, __plen, __fill);
+            std::copy(olds, olds + oldlen, news);
+            std::fill_n(news + oldlen, plen, fill);
             return;
         }
 
-        size_t __mod = 0;
-        if (__adjust == ios_defs::internal)
+        size_t mod = 0;
+        if (adjust == ios_defs::internal)
         {
             // Pad after the sign, if there is one.
             // Pad after 0[xX], if there is one.
             // Who came up with these rules, anyway? Jeeze.
             if (startSign)
             {
-                __news[0] = __olds[0];
-                __mod = 1;
-                ++__news;
+                news[0] = olds[0];
+                mod = 1;
+                ++news;
             }
             else if (start0x)
             {
-                __news[0] = __olds[0];
-                __news[1] = __olds[1];
-                __mod = 2;
-                __news += 2;
+                news[0] = olds[0];
+                news[1] = olds[1];
+                mod = 2;
+                news += 2;
             }
             // else Padding first.
         }
-        std::fill_n(__news, __plen, __fill);
-        std::copy(__olds + __mod, __olds + __oldlen, __news + __plen);
+        std::fill_n(news, plen, fill);
+        std::copy(olds + mod, olds + oldlen, news + plen);
     }
     
-    void _S_format_float(ios_defs::fmtflags __flags, char* __fptr, char __mod) const noexcept
+    void _S_format_float(ios_defs::fmtflags flags, char* fptr, char mod) const noexcept
     {
-        *__fptr++ = '%';
+        *fptr++ = '%';
         // [22.2.2.2.2] Table 60
-        if (__flags & ios_defs::showpos)
-            *__fptr++ = '+';
-        if (__flags & ios_defs::showpoint)
-            *__fptr++ = '#';
-            
-        ios_defs::fmtflags __fltfield = __flags & ios_defs::floatfield;
-        if (__fltfield != (ios_defs::fixed | ios_defs::scientific))
+        if (flags & ios_defs::showpos)
+            *fptr++ = '+';
+        if (flags & ios_defs::showpoint)
+            *fptr++ = '#';
+
+        ios_defs::fmtflags fltfield = flags & ios_defs::floatfield;
+        if (fltfield != (ios_defs::fixed | ios_defs::scientific))
         {
-            // As per DR 231: not only when __flags & ios_base::fixed || __prec > 0
-            *__fptr++ = '.';
-            *__fptr++ = '*';
+            // As per DR 231: not only when flags & ios_base::fixed || prec > 0
+            *fptr++ = '.';
+            *fptr++ = '*';
         }
-        
-        if (__mod)
-            *__fptr++ = __mod;
+
+        if (mod)
+            *fptr++ = mod;
         // [22.2.2.2.2] Table 58
-        if (__fltfield == ios_defs::fixed)
-            *__fptr++ = 'f';
-        else if (__fltfield == ios_defs::scientific)
-            *__fptr++ = (__flags & ios_defs::uppercase) ? 'E' : 'e';
-        else if (__fltfield == (ios_defs::fixed | ios_defs::scientific))
-            *__fptr++ = (__flags & ios_defs::uppercase) ? 'A' : 'a';
+        if (fltfield == ios_defs::fixed)
+            *fptr++ = 'f';
+        else if (fltfield == ios_defs::scientific)
+            *fptr++ = (flags & ios_defs::uppercase) ? 'E' : 'e';
+        else if (fltfield == (ios_defs::fixed | ios_defs::scientific))
+            *fptr++ = (flags & ios_defs::uppercase) ? 'A' : 'a';
         else
-            *__fptr++ = (__flags & ios_defs::uppercase) ? 'G' : 'g';
-        *__fptr = '\0';
+            *fptr++ = (flags & ios_defs::uppercase) ? 'G' : 'g';
+        *fptr = '\0';
     }
     
-    void group_float(const std::vector<uint8_t>& __grouping, char_type __sep, const char_type* __p, char_type* __new, char_type* __cs, int& __len) const
+    void group_float(const std::vector<uint8_t>& grouping, char_type sep, const char_type* p, char_type* new_buf, char_type* cs, int& len) const
     {
         // _GLIBCXX_RESOLVE_LIB_DEFECTS
         // 282. What types does numpunct grouping refer to?
         // Add grouping, if necessary.
-        const int __declen = __p ? __p - __cs : __len;
-        char_type* __p2 = FacetHelper::add_grouping(__new, __sep, __grouping, __cs, __cs + __declen);
+        const int declen = p ? p - cs : len;
+        char_type* p2 = FacetHelper::add_grouping(new_buf, sep, grouping, cs, cs + declen);
 
         // Tack on decimal part.
-        int __newlen = __p2 - __new;
-        if (__p)
+        int newlen = p2 - new_buf;
+        if (p)
         {
-            std::copy(__p, __p + __len - __declen, __p2);
-            __newlen += __len - __declen;
+            std::copy(p, p + len - declen, p2);
+            newlen += len - declen;
         }
-        __len = __newlen;
+        len = newlen;
     }
     
     template <typename TIter, std::sentinel_for<TIter> TSent, typename TValue>
-    std::pair<bool, TIter> extract_int(TIter __beg, TSent __end, ios_base<char_type>& __io, TValue& __v) const
+    std::pair<bool, TIter> extract_int(TIter beg, TSent end, ios_base<char_type>& io, TValue& v) const
     {
-        using __unsigned_type = std::make_unsigned_t<TValue>;
-        
-        CharT __c{};
+        using unsigned_type = std::make_unsigned_t<TValue>;
 
-        // NB: Iff __basefield == 0, __base can change based on contents.
-        const ios_defs::fmtflags __basefield = __io.flags() & ios_defs::basefield;
-        const bool __oct = __basefield == ios_defs::oct;
-        int __base = __oct ? 8 : (__basefield == ios_defs::hex ? 16 : 10);
+        CharT c{};
 
-        // True if __beg becomes equal to __end.
-        bool __testeof = __beg == __end;
+        // NB: Iff basefield == 0, base can change based on contents.
+        const ios_defs::fmtflags basefield = io.flags() & ios_defs::basefield;
+        const bool oct = basefield == ios_defs::oct;
+        int base = oct ? 8 : (basefield == ios_defs::hex ? 16 : 10);
+
+        // True if beg becomes equal to end.
+        bool testeof = beg == end;
 
         // First check for sign.
-        bool __negative = false;
-        if (!__testeof)
+        bool negative = false;
+        if (!testeof)
         {
-            __c = *__beg;
-            __negative = __c == m_in_atoms[s_ominus];
-            if ((__negative || __c == m_in_atoms[s_oplus])
-                && (m_grouping.empty() || __c != m_thousands_sep)
-                && (__c != m_decimal_point))
+            c = *beg;
+            negative = c == m_in_atoms[s_ominus];
+            if ((negative || c == m_in_atoms[s_oplus])
+                && (m_grouping.empty() || c != m_thousands_sep)
+                && (c != m_decimal_point))
             {
-                if (++__beg != __end)
-                    __c = *__beg;
+                if (++beg != end)
+                    c = *beg;
                 else
-                    __testeof = true;
+                    testeof = true;
             }
         }
 
         // Next, look for leading zeros and check required digits
         // for base formats.
-        bool __found_zero = false;
-        int __sep_pos = 0;
-        while (!__testeof)
+        bool found_zero = false;
+        int sep_pos = 0;
+        while (!testeof)
         {
-            if ((!m_grouping.empty() && __c == m_thousands_sep)
-                || __c == m_decimal_point)
+            if ((!m_grouping.empty() && c == m_thousands_sep)
+                || c == m_decimal_point)
                 break;
-            else if (__c == m_in_atoms[s_odigits] && (!__found_zero || __base == 10))
+            else if (c == m_in_atoms[s_odigits] && (!found_zero || base == 10))
             {
-                __found_zero = true;
-                ++__sep_pos;
-                if (__basefield == 0) __base = 8;
-                if (__base == 8) __sep_pos = 0;
+                found_zero = true;
+                ++sep_pos;
+                if (basefield == 0) base = 8;
+                if (base == 8) sep_pos = 0;
             }
-            else if (__found_zero && (__c == m_in_atoms[s_ox] || __c == m_in_atoms[s_oX]))
+            else if (found_zero && (c == m_in_atoms[s_ox] || c == m_in_atoms[s_oX]))
             {
-                if (__basefield == 0) __base = 16;
-                if (__base == 16)
+                if (basefield == 0) base = 16;
+                if (base == 16)
                 {
-                    __found_zero = false;
-                    __sep_pos = 0;
+                    found_zero = false;
+                    sep_pos = 0;
                 }
                 else
                     break;
@@ -599,235 +599,235 @@ private:
             else
                 break;
 
-            if (++__beg != __end)
+            if (++beg != end)
             {
-                __c = *__beg;
-                if (!__found_zero) break;
+                c = *beg;
+                if (!found_zero) break;
             }
             else
-                __testeof = true;
+                testeof = true;
         }
 
         // At this point, base is determined. If not hex, only allow
         // base digits as valid input.
-        const size_t __len = (__base == 16 ? s_iend - s_izero : __base);
+        const size_t len = (base == 16 ? s_iend - s_izero : base);
 
         // Extract.
-        std::string __found_grouping;
-        if (!m_grouping.empty()) __found_grouping.reserve(32);
-        bool __testfail = false;
-        bool __testoverflow = false;
-        const __unsigned_type __max = (__negative && std::is_signed_v<TValue>)
-                                        ? -static_cast<__unsigned_type>(std::numeric_limits<TValue>::min()) : std::numeric_limits<TValue>::max();
-        const __unsigned_type __smax = __max / __base;
-        __unsigned_type __result = 0;
-        int __digit = 0;
-        const char_type* __lit_zero = m_in_atoms + s_izero;
+        std::string found_grouping;
+        if (!m_grouping.empty()) found_grouping.reserve(32);
+        bool testfail = false;
+        bool testoverflow = false;
+        const unsigned_type max_val = (negative && std::is_signed_v<TValue>)
+                                        ? -static_cast<unsigned_type>(std::numeric_limits<TValue>::min()) : std::numeric_limits<TValue>::max();
+        const unsigned_type smax = max_val / base;
+        unsigned_type result = 0;
+        int digit = 0;
+        const char_type* lit_zero = m_in_atoms + s_izero;
 
-        while (!__testeof)
+        while (!testeof)
         {
             // According to 22.2.2.1.2, p8-9, first look for thousands_sep
             // and decimal_point.
-            if (!m_grouping.empty() && __c == m_thousands_sep)
+            if (!m_grouping.empty() && c == m_thousands_sep)
             {
                 // NB: Thousands separator at the beginning of a string
                 // is a no-no, as is two consecutive thousands separators.
-                if (__sep_pos)
+                if (sep_pos)
                 {
-                    __found_grouping += static_cast<char>(__sep_pos);
-                    __sep_pos = 0;
+                    found_grouping += static_cast<char>(sep_pos);
+                    sep_pos = 0;
                 }
                 else
                 {
-                    __testfail = true;
+                    testfail = true;
                     break;
                 }
             }
-            else if (__c == m_decimal_point) break;
+            else if (c == m_decimal_point) break;
             else
             {
-                const char_type* __q = std::find(__lit_zero, __lit_zero + __len, __c);
-                if (__q == __lit_zero + __len) break;
+                const char_type* q = std::find(lit_zero, lit_zero + len, c);
+                if (q == lit_zero + len) break;
 
-                __digit = __q - __lit_zero;
-                if (__digit > 15) __digit -= 6;
-                if (__result > __smax) __testoverflow = true;
+                digit = q - lit_zero;
+                if (digit > 15) digit -= 6;
+                if (result > smax) testoverflow = true;
                 else
                 {
-                    __result *= __base;
-                    __testoverflow |= __result > __max - __digit;
-                    __result += __digit;
-                    ++__sep_pos;
+                    result *= base;
+                    testoverflow |= result > max_val - digit;
+                    result += digit;
+                    ++sep_pos;
                 }
             }
-            
-            if (++__beg != __end) __c = *__beg;
-            else __testeof = true;
+
+            if (++beg != end) c = *beg;
+            else testeof = true;
         }
 
         bool success = true;
         // Digit grouping is checked. If grouping and found_grouping don't
         // match, then get very very upset, and set failbit.
-        if (!__found_grouping.empty())
+        if (!found_grouping.empty())
         {
             // Add the ending grouping.
-            __found_grouping += static_cast<char>(__sep_pos);
+            found_grouping += static_cast<char>(sep_pos);
 
-            success = FacetHelper::verify_grouping(m_grouping, __found_grouping);
+            success = FacetHelper::verify_grouping(m_grouping, found_grouping);
         }
 
         // _GLIBCXX_RESOLVE_LIB_DEFECTS
         // 23. Num_get overflow result.
-        if ((!__sep_pos && !__found_zero && !__found_grouping.size()) || __testfail)
+        if ((!sep_pos && !found_zero && !found_grouping.size()) || testfail)
         {
-            __v = 0;
+            v = 0;
             success = false;
         }
-        else if (__testoverflow)
+        else if (testoverflow)
         {
-            if (__negative && std::is_signed_v<TValue>)
-                __v = std::numeric_limits<TValue>::min();
+            if (negative && std::is_signed_v<TValue>)
+                v = std::numeric_limits<TValue>::min();
             else
-                __v = std::numeric_limits<TValue>::max();
+                v = std::numeric_limits<TValue>::max();
             success = false;
         }
         else
-            __v = __negative ? -__result : __result;
+            v = negative ? -result : result;
 
-        return std::pair(success, __beg);
+        return std::pair(success, beg);
     }
 
     template <typename TIter, std::sentinel_for<TIter> TSent>
-    std::pair<bool, TIter> extract_float(TIter __beg, TSent __end, ios_base<char_type>& __io, std::string& __xtrc) const
+    std::pair<bool, TIter> extract_float(TIter beg, TSent end, ios_base<char_type>& io, std::string& xtrc) const
     {
-        char_type __c = char_type();
+        char_type c = char_type();
 
-        // True if __beg becomes equal to __end.
-        bool __testeof = __beg == __end;
+        // True if beg becomes equal to end.
+        bool testeof = beg == end;
 
         // First check for sign.
-        if (!__testeof)
+        if (!testeof)
         {
-            __c = *__beg;
-            const bool __plus = __c == m_in_atoms[s_iplus];
-            if ((__plus || __c == m_in_atoms[s_iminus])
-                && (m_grouping.empty() || __c != m_thousands_sep)
-                && (__c != m_decimal_point))
+            c = *beg;
+            const bool plus = c == m_in_atoms[s_iplus];
+            if ((plus || c == m_in_atoms[s_iminus])
+                && (m_grouping.empty() || c != m_thousands_sep)
+                && (c != m_decimal_point))
             {
-                __xtrc += __plus ? '+' : '-';
-                if (++__beg != __end) __c = *__beg;
+                xtrc += plus ? '+' : '-';
+                if (++beg != end) c = *beg;
                 else
-                    __testeof = true;
+                    testeof = true;
             }
         }
 
         // Next, look for leading zeros.
-        bool __found_mantissa = false;
-        int __sep_pos = 0;
-        while (!__testeof)
+        bool found_mantissa = false;
+        int sep_pos = 0;
+        while (!testeof)
         {
-            if ((!m_grouping.empty() && __c == m_thousands_sep) || __c == m_decimal_point)
+            if ((!m_grouping.empty() && c == m_thousands_sep) || c == m_decimal_point)
                 break;
-            else if (__c == m_in_atoms[s_izero])
+            else if (c == m_in_atoms[s_izero])
             {
-                if (!__found_mantissa)
+                if (!found_mantissa)
                 {
-                    __xtrc += '0';
-                    __found_mantissa = true;
+                    xtrc += '0';
+                    found_mantissa = true;
                 }
-                ++__sep_pos;
+                ++sep_pos;
 
-                if (++__beg != __end)
-                    __c = *__beg;
+                if (++beg != end)
+                    c = *beg;
                 else
-                    __testeof = true;
+                    testeof = true;
             }
             else
                 break;
         }
 
         // Only need acceptable digits for floating point numbers.
-        bool __found_dec = false;
-        bool __found_sci = false;
-        std::string __found_grouping;
+        bool found_dec = false;
+        bool found_sci = false;
+        std::string found_grouping;
         if (!m_grouping.empty())
-            __found_grouping.reserve(32);
-        const char_type* __lit_zero = m_in_atoms + s_izero;
+            found_grouping.reserve(32);
+        const char_type* lit_zero = m_in_atoms + s_izero;
 
-        while (!__testeof)
+        while (!testeof)
         {
             // According to 22.2.2.1.2, p8-9, first look for thousands_sep
             // and decimal_point.
-            if (!m_grouping.empty() && __c == m_thousands_sep)
+            if (!m_grouping.empty() && c == m_thousands_sep)
             {
-                if (!__found_dec && !__found_sci)
+                if (!found_dec && !found_sci)
                 {
                     // NB: Thousands separator at the beginning of a string
                     // is a no-no, as is two consecutive thousands separators.
-                    if (__sep_pos)
+                    if (sep_pos)
                     {
-                        __found_grouping += static_cast<char>(__sep_pos);
-                        __sep_pos = 0;
+                        found_grouping += static_cast<char>(sep_pos);
+                        sep_pos = 0;
                     }
                     else
                     {
-                        // NB: convert_to_v will not assign __v and will
+                        // NB: convert_to_v will not assign v and will
                         // set the failbit.
-                        __xtrc.clear();
+                        xtrc.clear();
                         break;
                     }
                 }
                 else
                     break;
             }
-            else if (__c == m_decimal_point)
+            else if (c == m_decimal_point)
             {
-                if (!__found_dec && !__found_sci)
+                if (!found_dec && !found_sci)
                 {
                     // If no grouping chars are seen, no grouping check
-                    // is applied. Therefore __found_grouping is adjusted
+                    // is applied. Therefore found_grouping is adjusted
                     // only if decimal_point comes after some thousands_sep.
-                    if (__found_grouping.size())
-                        __found_grouping += static_cast<char>(__sep_pos);
-                    __xtrc += '.';
-                    __found_dec = true;
+                    if (found_grouping.size())
+                        found_grouping += static_cast<char>(sep_pos);
+                    xtrc += '.';
+                    found_dec = true;
                 }
                 else
                     break;
             }
             else
             {
-                const char_type* __q = std::find(__lit_zero, __lit_zero + 10, __c);
-                if (__q != __lit_zero + 10)
+                const char_type* q = std::find(lit_zero, lit_zero + 10, c);
+                if (q != lit_zero + 10)
                 {
-                    __xtrc += '0' + (__q - __lit_zero);
-                    __found_mantissa = true;
-                    ++__sep_pos;
+                    xtrc += '0' + (q - lit_zero);
+                    found_mantissa = true;
+                    ++sep_pos;
                 }
-                else if ((__c == m_in_atoms[s_ie] || __c == m_in_atoms[s_iE])
-                        && !__found_sci && __found_mantissa)
+                else if ((c == m_in_atoms[s_ie] || c == m_in_atoms[s_iE])
+                        && !found_sci && found_mantissa)
                 {
                     // Scientific notation.
-                    if (__found_grouping.size() && !__found_dec)
-                        __found_grouping += static_cast<char>(__sep_pos);
-                    __xtrc += 'e';
-                    __found_sci = true;
+                    if (found_grouping.size() && !found_dec)
+                        found_grouping += static_cast<char>(sep_pos);
+                    xtrc += 'e';
+                    found_sci = true;
 
                     // Remove optional plus or minus sign, if they exist.
-                    if (++__beg != __end)
+                    if (++beg != end)
                     {
-                        __c = *__beg;
-                        const bool __plus = __c == m_in_atoms[s_iplus];
-                        if ((__plus || __c == m_in_atoms[s_iminus])
-                            && (m_grouping.empty() || __c != m_thousands_sep)
-                            && (__c != m_decimal_point))
-                            __xtrc += __plus ? '+' : '-';
+                        c = *beg;
+                        const bool plus = c == m_in_atoms[s_iplus];
+                        if ((plus || c == m_in_atoms[s_iminus])
+                            && (m_grouping.empty() || c != m_thousands_sep)
+                            && (c != m_decimal_point))
+                            xtrc += plus ? '+' : '-';
                         else
                             continue;
                     }
                     else
                     {
-                        __testeof = true;
+                        testeof = true;
                         break;
                     }
                 }
@@ -835,58 +835,58 @@ private:
                     break;
             }
 
-            if (++__beg != __end)
-                __c = *__beg;
+            if (++beg != end)
+                c = *beg;
             else
-                __testeof = true;
+                testeof = true;
         }
 
         bool success = true;
         // Digit grouping is checked. If grouping and found_grouping don't
         // match, then get very very upset, and set failbit.
-        if (__found_grouping.size())
+        if (found_grouping.size())
         {
             // Add the ending grouping if a decimal or 'e'/'E' wasn't found.
-            if (!__found_dec && !__found_sci)
-                __found_grouping += static_cast<char>(__sep_pos);
+            if (!found_dec && !found_sci)
+                found_grouping += static_cast<char>(sep_pos);
 
-            success = FacetHelper::verify_grouping(m_grouping, __found_grouping);
+            success = FacetHelper::verify_grouping(m_grouping, found_grouping);
         }
 
-        return std::pair(success, __beg);
+        return std::pair(success, beg);
     }
 
     template <typename TValue>
-    bool convert_to_v(const char* __s, TValue& __v) const noexcept
+    bool convert_to_v(const char* s, TValue& v) const noexcept
     {
         bool res = true;
-        char* __sanity;
-        
+        char* sanity;
+
         clocale_wrapper inter_locale("C");
         clocale_user guard(inter_locale.c_locale);
-        
+
         if constexpr (std::is_same_v<TValue, float>)
-            __v = strtof(__s, &__sanity);
+            v = strtof(s, &sanity);
         else if constexpr (std::is_same_v<TValue, double>)
-            __v = strtod(__s, &__sanity);
+            v = strtod(s, &sanity);
         else
-            __v = strtold(__s, &__sanity);
+            v = strtold(s, &sanity);
 
         // _GLIBCXX_RESOLVE_LIB_DEFECTS
         // 23. Num_get overflow result.
-        if (__sanity == __s || *__sanity != '\0')
+        if (sanity == s || *sanity != '\0')
         {
-            __v = 0.0l;
+            v = 0.0l;
             res = false;
         }
-        else if (__v == std::numeric_limits<TValue>::infinity())
+        else if (v == std::numeric_limits<TValue>::infinity())
         {
-            __v = std::numeric_limits<TValue>::max();
+            v = std::numeric_limits<TValue>::max();
             res = false;
         }
-        else if (__v == -std::numeric_limits<TValue>::infinity())
+        else if (v == -std::numeric_limits<TValue>::infinity())
         {
-            __v = -std::numeric_limits<TValue>::max();
+            v = -std::numeric_limits<TValue>::max();
             res = false;
         }
         return res;

--- a/include/facet/numeric_details.h
+++ b/include/facet/numeric_details.h
@@ -108,13 +108,13 @@ public:
         clocale_wrapper inter_locale(name.c_str());
         clocale_user guard(inter_locale.c_locale);
         
-        union { char* s; CharT w; } __u;
-        
-        __u.s = nl_langinfo(_NL_NUMERIC_DECIMAL_POINT_WC);
-        m_decimal_point = __u.w;
-        
-        __u.s = nl_langinfo(_NL_NUMERIC_THOUSANDS_SEP_WC);
-        m_thousands_sep = __u.w;
+        union { char* s; CharT w; } u;
+
+        u.s = nl_langinfo(_NL_NUMERIC_DECIMAL_POINT_WC);
+        m_decimal_point = u.w;
+
+        u.s = nl_langinfo(_NL_NUMERIC_THOUSANDS_SEP_WC);
+        m_thousands_sep = u.w;
                 
         if (m_thousands_sep != '\0')
         {

--- a/include/facet/timeio.h
+++ b/include/facet/timeio.h
@@ -546,7 +546,7 @@ public:
 
     template <typename TIter, std::sentinel_for<TIter> TSent, bool HaveDate, bool HaveTime, bool HaveTimeZone>
         requires (std::bidirectional_iterator<TIter> || is_istreambuf_iterator_v<TIter>)
-    TIter get(TIter __beg, TSent __end, time_parse_context<char_type, HaveDate, HaveTime, HaveTimeZone>& ctx,
+    TIter get(TIter beg, TSent end, time_parse_context<char_type, HaveDate, HaveTime, HaveTimeZone>& ctx,
               char format, char modifier = 0) const
     {
         CharT fmt[4]; fmt[0] = static_cast<CharT>('%');
@@ -555,13 +555,13 @@ public:
             fmt[1] = modifier;
             fmt[2] = format;
             fmt[3] = static_cast<CharT>('\0');
-            return get(__beg, __end, ctx, fmt);
+            return get(beg, end, ctx, fmt);
         }
         else
         {
             fmt[1] = format;
             fmt[2] = static_cast<CharT>('\0');
-            return get(__beg, __end, ctx, fmt);
+            return get(beg, end, ctx, fmt);
         }
     }
 
@@ -704,10 +704,10 @@ private:
                 else if (modifier == static_cast<CharT>('O')) goto bad_parse_format;
                 else if ((modifier == static_cast<CharT>('\0')) || (m_era_items.empty()))
                 {
-                    int __mem = 0;
-                    rp = extract_num(rp, rp_end, __mem, 0, 99, 2, succ);
+                    int mem = 0;
+                    rp = extract_num(rp, rp_end, mem, 0, 99, 2, succ);
                     if (!succ) return rp;
-                    ctx.m_century = __mem;
+                    ctx.m_century = mem;
                     ctx.m_have_century = true;
                 }
                 else
@@ -738,13 +738,13 @@ private:
                 else if (modifier == static_cast<CharT>('E')) goto bad_parse_format;
                 else
                 {
-                    int __mem = -1;
+                    int mem = -1;
                     if (modifier == static_cast<CharT>('O'))
-                        rp = extract_num_with_alt_digits(rp, rp_end, __mem, 1, 31, 2, succ);
+                        rp = extract_num_with_alt_digits(rp, rp_end, mem, 1, 31, 2, succ);
                     else
-                        rp = extract_num(rp, rp_end, __mem, 1, 31, 2, succ);
+                        rp = extract_num(rp, rp_end, mem, 1, 31, 2, succ);
                     if (!succ) return rp;
-                    ctx.m_mday = __mem;
+                    ctx.m_mday = mem;
                     ctx.m_have_mday = true;
                 }
                 break;
@@ -804,13 +804,13 @@ private:
                 else if (modifier == static_cast<CharT>('E')) goto bad_parse_format;
                 else
                 {
-                    int __mem = -1;
+                    int mem = -1;
                     if (modifier == static_cast<CharT>('O'))
-                        rp = extract_num_with_alt_digits(rp, rp_end, __mem, 0, 23, 2, succ);
+                        rp = extract_num_with_alt_digits(rp, rp_end, mem, 0, 23, 2, succ);
                     else
-                        rp= extract_num(rp, rp_end, __mem, 0, 23, 2, succ);
+                        rp= extract_num(rp, rp_end, mem, 0, 23, 2, succ);
                     if (!succ) return rp;
-                    ctx.m_hour = __mem;
+                    ctx.m_hour = mem;
                     ctx.m_have_I = false;
                 }
                 break;
@@ -820,13 +820,13 @@ private:
                 else if (modifier == static_cast<CharT>('E')) goto bad_parse_format;
                 else
                 {
-                    int __mem = -1;
+                    int mem = -1;
                     if (modifier == static_cast<CharT>('O'))
-                        rp = extract_num_with_alt_digits(rp, rp_end, __mem, 1, 12, 2, succ);
+                        rp = extract_num_with_alt_digits(rp, rp_end, mem, 1, 12, 2, succ);
                     else
-                        rp = extract_num(rp, rp_end, __mem, 1, 12, 2, succ);
+                        rp = extract_num(rp, rp_end, mem, 1, 12, 2, succ);
                     if (!succ) return rp;
-                    ctx.m_hour = __mem % 12;
+                    ctx.m_hour = mem % 12;
                     ctx.m_have_I = true;
                 }
                 break;
@@ -837,10 +837,10 @@ private:
                 else if (modifier) goto bad_parse_format;
                 else
                 {
-                    int __mem = 0;
-                    rp = extract_num(rp, rp_end, __mem, 1, 366, 3, succ);
+                    int mem = 0;
+                    rp = extract_num(rp, rp_end, mem, 1, 366, 3, succ);
                     if (!succ) return rp;
-                    ctx.m_yday = __mem - 1;
+                    ctx.m_yday = mem - 1;
                     ctx.m_have_yday = true;
                 }
                 break;
@@ -851,13 +851,13 @@ private:
                 else if (modifier == static_cast<CharT>('E')) goto bad_parse_format;
                 else
                 {
-                    int __mem = -1;
+                    int mem = -1;
                     if (modifier == static_cast<CharT>('O'))
-                        rp = extract_num_with_alt_digits(rp, rp_end, __mem, 1, 12, 2, succ);
+                        rp = extract_num_with_alt_digits(rp, rp_end, mem, 1, 12, 2, succ);
                     else
-                        rp = extract_num(rp, rp_end, __mem, 1, 12, 2, succ);
+                        rp = extract_num(rp, rp_end, mem, 1, 12, 2, succ);
                     if (!succ) return rp;
-                    ctx.m_month = __mem;
+                    ctx.m_month = mem;
                     ctx.m_have_mon = true;
                 }
                 break;
@@ -867,13 +867,13 @@ private:
                 else if (modifier == static_cast<CharT>('E')) goto bad_parse_format;
                 else
                 {
-                    int __mem = -1;
+                    int mem = -1;
                     if (modifier == static_cast<CharT>('O'))
-                        rp = extract_num_with_alt_digits(rp, rp_end, __mem, 0, 59, 2, succ);
+                        rp = extract_num_with_alt_digits(rp, rp_end, mem, 0, 59, 2, succ);
                     else
-                        rp = extract_num(rp, rp_end, __mem, 0, 59, 2, succ);
+                        rp = extract_num(rp, rp_end, mem, 0, 59, 2, succ);
                     if (!succ) return rp;
-                    ctx.m_minute = __mem;
+                    ctx.m_minute = mem;
                 }
                 break;
 
@@ -929,13 +929,13 @@ private:
                 else if (modifier == static_cast<CharT>('E')) goto bad_parse_format;
                 else
                 {
-                    int __mem = -1;
+                    int mem = -1;
                     if (modifier == static_cast<CharT>('O'))
-                        rp = extract_num_with_alt_digits(rp, rp_end, __mem, 0, 59, 2, succ);
+                        rp = extract_num_with_alt_digits(rp, rp_end, mem, 0, 59, 2, succ);
                     else
-                        rp = extract_num(rp, rp_end, __mem, 0, 59, 2, succ);
+                        rp = extract_num(rp, rp_end, mem, 0, 59, 2, succ);
                     if (!succ) return rp;
-                    ctx.m_second = __mem;
+                    ctx.m_second = mem;
                 }
                 break;
 
@@ -957,13 +957,13 @@ private:
                 else if (modifier == static_cast<CharT>('E')) goto bad_parse_format;
                 else
                 {
-                    int __mem = -1;
+                    int mem = -1;
                     if (modifier == static_cast<CharT>('O'))
-                        rp = extract_num_with_alt_digits(rp, rp_end, __mem, 1, 7, 1, succ);
+                        rp = extract_num_with_alt_digits(rp, rp_end, mem, 1, 7, 1, succ);
                     else
-                        rp = extract_num(rp, rp_end, __mem, 1, 7, 1, succ);
+                        rp = extract_num(rp, rp_end, mem, 1, 7, 1, succ);
                     if (!succ) return rp;
-                    ctx.m_wday = __mem % 7;
+                    ctx.m_wday = mem % 7;
                     ctx.m_have_wday = true;
                 }
                 break;
@@ -973,13 +973,13 @@ private:
                 else if (modifier == static_cast<CharT>('E')) goto bad_parse_format;
                 else
                 {
-                    int __mem = -1;
+                    int mem = -1;
                     if (modifier == static_cast<CharT>('O'))
-                        rp = extract_num_with_alt_digits(rp, rp_end, __mem, 0, 53, 2, succ);
+                        rp = extract_num_with_alt_digits(rp, rp_end, mem, 0, 53, 2, succ);
                     else
-                        rp = extract_num(rp, rp_end, __mem, 0, 53, 2, succ);
+                        rp = extract_num(rp, rp_end, mem, 0, 53, 2, succ);
                     if (!succ) return rp;
-                    ctx.m_week_no = __mem;
+                    ctx.m_week_no = mem;
                     ctx.m_have_uweek = true;
                     ctx.m_have_wweek = false;
                 }
@@ -990,13 +990,13 @@ private:
                 else if (modifier == static_cast<CharT>('E')) goto bad_parse_format;
                 else
                 {
-                    int __mem = -1;
+                    int mem = -1;
                     if (modifier == static_cast<CharT>('O'))
-                        rp = extract_num_with_alt_digits(rp, rp_end, __mem, 1, 53, 2, succ);
+                        rp = extract_num_with_alt_digits(rp, rp_end, mem, 1, 53, 2, succ);
                     else
-                        rp = extract_num(rp, rp_end, __mem, 1, 53, 2, succ);
+                        rp = extract_num(rp, rp_end, mem, 1, 53, 2, succ);
                     if (!succ) return rp;
-                    ctx.m_iso_8601_week = __mem;
+                    ctx.m_iso_8601_week = mem;
                     ctx.m_have_iso_8601_week = true;
                 }
                 break;
@@ -1007,13 +1007,13 @@ private:
                 else if (modifier == static_cast<CharT>('E')) goto bad_parse_format;
                 else
                 {
-                    int __mem = -1;
+                    int mem = -1;
                     if (modifier == static_cast<CharT>('O'))
-                        rp = extract_num_with_alt_digits(rp, rp_end, __mem, 0, 6, 1, succ);
+                        rp = extract_num_with_alt_digits(rp, rp_end, mem, 0, 6, 1, succ);
                     else
-                        rp = extract_num(rp, rp_end, __mem, 0, 6, 1, succ);
+                        rp = extract_num(rp, rp_end, mem, 0, 6, 1, succ);
                     if (!succ) return rp;
-                    ctx.m_wday = __mem;
+                    ctx.m_wday = mem;
                     ctx.m_have_wday = 1;
                 }
                 break;
@@ -1023,13 +1023,13 @@ private:
                 else if (modifier == static_cast<CharT>('E')) goto bad_parse_format;
                 else
                 {
-                    int __mem = -1;
+                    int mem = -1;
                     if (modifier == static_cast<CharT>('O'))
-                        rp = extract_num_with_alt_digits(rp, rp_end, __mem, 0, 53, 2, succ);
+                        rp = extract_num_with_alt_digits(rp, rp_end, mem, 0, 53, 2, succ);
                     else
-                        rp = extract_num(rp, rp_end, __mem, 0, 53, 2, succ);
+                        rp = extract_num(rp, rp_end, mem, 0, 53, 2, succ);
                     if (!succ) return rp;
-                    ctx.m_week_no = __mem;
+                    ctx.m_week_no = mem;
                     ctx.m_have_wweek = true;
                     ctx.m_have_uweek = false;
                 }
@@ -1094,15 +1094,15 @@ private:
                 }
                 else
                 {/* Match year within century.  */
-                    int __mem = -1;
+                    int mem = -1;
                     if (modifier == static_cast<CharT>('O'))
-                        rp = extract_num_with_alt_digits(rp, rp_end, __mem, 0, 99, 2, succ);
+                        rp = extract_num_with_alt_digits(rp, rp_end, mem, 0, 99, 2, succ);
                     else
-                        rp = extract_num(rp, rp_end, __mem, 0, 99, 2, succ);
+                        rp = extract_num(rp, rp_end, mem, 0, 99, 2, succ);
                     if (!succ) return rp;
                     /* The "Year 2000: The Millennium Rollover" paper suggests that
                     values in the range 69-99 refer to the twentieth century.  */
-                    ctx.m_year = __mem >= 69 ? __mem + 1900 : __mem + 2000;
+                    ctx.m_year = mem >= 69 ? mem + 1900 : mem + 2000;
                     ctx.m_have_year_in_century = 1;
                 }
                 break;
@@ -1817,36 +1817,36 @@ private:
     }
 
     template <typename TIter, std::sentinel_for<TIter> TSent>
-    static TIter extract_num(TIter __beg, TSent __end, int& __member, int __min, int __max, size_t __len, bool& succ)
+    static TIter extract_num(TIter beg, TSent end, int& member, int min_val, int max_val, size_t len, bool& succ)
     {
-        size_t __i = 0;
-        int __value = 0;
-        for (; __beg != __end && __i < __len; ++__beg, (void)++__i)
+        size_t i = 0;
+        int value = 0;
+        for (; beg != end && i < len; ++beg, (void)++i)
         {
-            const CharT __c = *__beg;
-            if (__c >= static_cast<CharT>('0') && __c <= static_cast<CharT>('9'))
+            const CharT c = *beg;
+            if (c >= static_cast<CharT>('0') && c <= static_cast<CharT>('9'))
             {
-                __value = __value * 10 + (__c - static_cast<CharT>('0'));
-                if (__value > __max) break;
+                value = value * 10 + (c - static_cast<CharT>('0'));
+                if (value > max_val) break;
             }
             else
                 break;
         }
-        if (__i && __value >= __min && __value <= __max) __member = __value;
+        if (i && value >= min_val && value <= max_val) member = value;
         else succ = false;
-        return __beg;
+        return beg;
     }
     
     template <typename TIter, std::sentinel_for<TIter> TSent>
-    TIter extract_num_with_alt_digits(TIter __beg, TSent __end, int& __member, int __min, int __max, size_t __len, bool& succ) const
+    TIter extract_num_with_alt_digits(TIter beg, TSent end, int& member, int min_val, int max_val, size_t len, bool& succ) const
     {
-        __member = -1;
-        __beg = m_alt_digits_tree.max_match(__beg, __end, __member);
-        if (__member == -1)
-            __beg = extract_num(__beg, __end, __member, __min, __max, __len, succ);
-        else if ((__member < __min) || (__member > __max))
+        member = -1;
+        beg = m_alt_digits_tree.max_match(beg, end, member);
+        if (member == -1)
+            beg = extract_num(beg, end, member, min_val, max_val, len, succ);
+        else if ((member < min_val) || (member > max_val))
             succ = false;
-        return __beg;
+        return beg;
     }
 
 private:

--- a/include/facet/timeio_details.h
+++ b/include/facet/timeio_details.h
@@ -469,10 +469,10 @@ public:
             m_abbr_month[11] = nl_langinfo_w<CharT>(_NL_WABMON_12);
 
             {// alternative digits
-                union { char* __s; CharT* __w; } __u;
-                __u.__s = nl_langinfo(_NL_WALT_DIGITS);
-                
-                CharT* ptr = __u.__w;
+                union { char* s; CharT* w; } u;
+                u.s = nl_langinfo(_NL_WALT_DIGITS);
+
+                CharT* ptr = u.w;
                 size_t i = 0;
                 for (; i < 100; ++i)
                 {

--- a/include/io/fp_defs/char_and_str.h
+++ b/include/io/fp_defs/char_and_str.h
@@ -12,7 +12,7 @@ namespace IOv2
 {
 template <typename TIter, typename TChar>
     requires (std::is_same_v<TChar, typename TIter::value_type>)
-TIter __ostream_insert(TIter iter, ios_base<TChar>& io, const TChar* s, std::streamsize n)
+TIter ostream_insert(TIter iter, ios_base<TChar>& io, const TChar* s, std::streamsize n)
 {
     const std::streamsize w = io.width();
     if (w > n)
@@ -33,7 +33,7 @@ TIter __ostream_insert(TIter iter, ios_base<TChar>& io, const TChar* s, std::str
 
 template <typename TIter, std::sentinel_for<TIter> TSent, typename TChar>
     requires (std::is_same_v<TChar, typename TIter::value_type>)
-TIter __istream_extract(TIter iter, TSent iter_end, ios_base<TChar>& io, const locale<TChar>& loc, TChar* s, std::streamsize num)
+TIter istream_extract(TIter iter, TSent iter_end, ios_base<TChar>& io, const locale<TChar>& loc, TChar* s, std::streamsize num)
 {
     std::streamsize width = io.width();
     if (0 < width && width < num)
@@ -78,7 +78,7 @@ struct writer<TChar, TChar>
     static TIter swrite(TIter iter, ios_base<TChar>& io, const locale<TChar>&, TChar c)
     {
         if (io.width() != 0)
-            return __ostream_insert(iter, io, &c, 1);
+            return ostream_insert(iter, io, &c, 1);
         *iter++ = c;
         return iter;
     }
@@ -112,7 +112,7 @@ struct writer<TChar, char>
 
         TChar wc = mp->widen(c);
         if (io.width() != 0)
-            return __ostream_insert(iter, io, &wc, 1);
+            return ostream_insert(iter, io, &wc, 1);
         *iter++ = wc;
         return iter;
     }
@@ -131,7 +131,7 @@ struct writer<char, char>
 
         char wc = mp->widen(c);
         if (io.width() != 0)
-            return __ostream_insert(iter, io, &wc, 1);
+            return ostream_insert(iter, io, &wc, 1);
         *iter++ = wc;
         return iter;
     }
@@ -149,7 +149,7 @@ struct writer<TChar, TChar*>
         size_t n = 0;
         for (const TChar* ptr = c; *ptr != 0; ++ptr, ++n);
 
-        return __ostream_insert(iter, io, c, n);
+        return ostream_insert(iter, io, c, n);
     }
 };
 
@@ -174,7 +174,7 @@ struct reader<TChar, TChar*>
         if (c == nullptr) throw IOv2::stream_error("Cannot read NULL character sequence");
         
         std::streamsize n = std::numeric_limits<std::streamsize>::max();
-        return __istream_extract(iter, iter_end, io, loc, c, n);
+        return istream_extract(iter, iter_end, io, loc, c, n);
     }
 };
 
@@ -189,7 +189,7 @@ struct reader<TChar, TChar[N]>
             throw IOv2::stream_error("Character buffer not enough");
         
         std::streamsize n = N;
-        return __istream_extract(iter, iter_end, io, loc, c, n);
+        return istream_extract(iter, iter_end, io, loc, c, n);
     }
 };
 
@@ -214,7 +214,7 @@ struct reader<char, unsigned char[N]>
         if constexpr (N <= 1)
             throw IOv2::stream_error("Character buffer not enough");
         std::streamsize n = N;
-        return __istream_extract(iter, iter_end, io, loc, reinterpret_cast<char*>(c), n);
+        return istream_extract(iter, iter_end, io, loc, reinterpret_cast<char*>(c), n);
     }
 };
 
@@ -239,7 +239,7 @@ struct reader<char, signed char[N]>
         if constexpr (N <= 1)
             throw IOv2::stream_error("Character buffer not enough");
         std::streamsize n = N;
-        return __istream_extract(iter, iter_end, io, loc, reinterpret_cast<char*>(c), n);
+        return istream_extract(iter, iter_end, io, loc, reinterpret_cast<char*>(c), n);
     }
 };
 
@@ -278,7 +278,7 @@ struct writer<TChar, std::basic_string<TChar, TTraits, TAlloc>>
         requires (std::is_same_v<TChar, typename TIter::value_type>)
     static TIter swrite(TIter iter, ios_base<TChar>& io, const locale<TChar>&, const std::basic_string<TChar, TTraits, TAlloc>& str)
     {
-        return __ostream_insert(iter, io, str.data(), str.size());
+        return ostream_insert(iter, io, str.data(), str.size());
     }
 };
 

--- a/include/io/io_manip.h
+++ b/include/io/io_manip.h
@@ -6,49 +6,49 @@
 
 namespace IOv2
 {
-struct _Resetiosflags { ios_defs::fmtflags _M_mask; };
-inline _Resetiosflags resetiosflags(ios_defs::fmtflags __mask) { return { __mask }; }
+struct _Resetiosflags { ios_defs::fmtflags m_mask; };
+inline _Resetiosflags resetiosflags(ios_defs::fmtflags mask) { return { mask }; }
 
 template <ostream_type T>
 inline T& operator << (T& os, _Resetiosflags f)
 {
-    os.setf(ios_defs::fmtflags(0), f._M_mask);
+    os.setf(ios_defs::fmtflags(0), f.m_mask);
     return os;
 }
 
 template <istream_type T>
 inline T& operator >> (T& is, _Resetiosflags f)
 {
-    is.setf(ios_defs::fmtflags(0), f._M_mask);
+    is.setf(ios_defs::fmtflags(0), f.m_mask);
     return is;
 }
 
-struct _Setiosflags { ios_defs::fmtflags _M_mask; };
-inline _Setiosflags setiosflags(ios_defs::fmtflags __mask) { return { __mask }; }
+struct _Setiosflags { ios_defs::fmtflags m_mask; };
+inline _Setiosflags setiosflags(ios_defs::fmtflags mask) { return { mask }; }
 
 template <ostream_type T>
 inline T& operator << (T& os, _Setiosflags f)
 {
-    os.setf(f._M_mask);
+    os.setf(f.m_mask);
     return os;
 }
 
 template <istream_type T>
 inline T& operator >> (T& is, _Setiosflags f)
 {
-    is.setf(f._M_mask);
+    is.setf(f.m_mask);
     return is;
 }
 
-struct _Setbase { int _M_base; };
-inline _Setbase setbase(int __base) { return { __base }; }
+struct _Setbase { int m_base; };
+inline _Setbase setbase(int base) { return { base }; }
 
 template <ostream_type T>
 inline T& operator << (T& os, _Setbase f)
 {
-    os.setf(f._M_base ==  8 ? ios_defs::oct :
-        f._M_base == 10 ? ios_defs::dec :
-        f._M_base == 16 ? ios_defs::hex :
+    os.setf(f.m_base ==  8 ? ios_defs::oct :
+        f.m_base == 10 ? ios_defs::dec :
+        f.m_base == 16 ? ios_defs::hex :
         ios_defs::fmtflags(0), ios_defs::basefield);
     return os;
 }
@@ -56,68 +56,68 @@ inline T& operator << (T& os, _Setbase f)
 template <istream_type T>
 inline T& operator >> (T& is, _Setbase f)
 {
-    is.setf(f._M_base ==  8 ? ios_defs::oct :
-        f._M_base == 10 ? ios_defs::dec :
-        f._M_base == 16 ? ios_defs::hex :
+    is.setf(f.m_base ==  8 ? ios_defs::oct :
+        f.m_base == 10 ? ios_defs::dec :
+        f.m_base == 16 ? ios_defs::hex :
         ios_defs::fmtflags(0), ios_defs::basefield);
     return is;
 }
 
-template<typename _CharT> struct _Setfill { _CharT _M_c; };
+template<typename _CharT> struct _Setfill { _CharT m_c; };
 template<typename _CharT>
-inline _Setfill<_CharT> setfill(_CharT __c) { return { __c }; }
+inline _Setfill<_CharT> setfill(_CharT c) { return { c }; }
 
 template <ostream_type T>
 inline T& operator << (T& os, _Setfill<typename T::char_type> f)
 {
-    os.fill(f._M_c);
+    os.fill(f.m_c);
     return os;
 }
 
 template <istream_type T>
 inline T& operator >> (T& is, _Setfill<typename T::char_type> f)
 {
-    is.fill(f._M_c);
+    is.fill(f.m_c);
     return is;
 }
 
-struct _Setprecision { int _M_n; };
-inline _Setprecision setprecision(int __n) { return { __n }; }
+struct _Setprecision { int m_n; };
+inline _Setprecision setprecision(int n) { return { n }; }
 
 template <ostream_type T>
 inline T& operator << (T& os, _Setprecision f)
 {
-    os.precision(f._M_n);
+    os.precision(f.m_n);
     return os;
 }
 
 template <istream_type T>
 inline T& operator >> (T& is, _Setprecision f)
 {
-    is.precision(f._M_n);
+    is.precision(f.m_n);
     return is;
 }
 
-struct _Setw { int _M_n; };
-inline _Setw setw(int __n) { return { __n }; }
+struct _Setw { int m_n; };
+inline _Setw setw(int n) { return { n }; }
 
 template <ostream_type T>
 inline T& operator << (T& os, _Setw f)
 {
-    os.width(f._M_n);
+    os.width(f.m_n);
     return os;
 }
 
 template <istream_type T>
 inline T& operator >> (T& is, _Setw f)
 {
-    is.width(f._M_n);
+    is.width(f.m_n);
     return is;
 }
 
-template<typename _MoneyT> struct _Put_money { const _MoneyT& _M_mon; bool _M_intl; };
+template<typename _MoneyT> struct _Put_money { const _MoneyT& m_mon; bool m_intl; };
 template<typename _MoneyT>
-inline _Put_money<_MoneyT> put_money(const _MoneyT& __mon, bool __intl = false) { return { __mon, __intl }; }
+inline _Put_money<_MoneyT> put_money(const _MoneyT& mon, bool intl = false) { return { mon, intl }; }
 
 template <typename TChar, typename TMoney>
 struct writer<TChar, _Put_money<TMoney>>
@@ -130,13 +130,13 @@ struct writer<TChar, _Put_money<TMoney>>
         if (!mp)
             throw stream_error("cannot get monetary facet");
         
-        return mp->put(s, f._M_intl, io, f._M_mon);
+        return mp->put(s, f.m_intl, io, f.m_mon);
     }
 };
 
-template<typename _MoneyT> struct _Get_money { _MoneyT& _M_mon; bool _M_intl; };
+template<typename _MoneyT> struct _Get_money { _MoneyT& m_mon; bool m_intl; };
 template<typename _MoneyT>
-inline _Get_money<_MoneyT> get_money(_MoneyT& __mon, bool __intl = false) { return { __mon, __intl }; }
+inline _Get_money<_MoneyT> get_money(_MoneyT& mon, bool intl = false) { return { mon, intl }; }
 
 template <typename TChar, typename TMoney>
 struct reader<TChar, _Get_money<TMoney>>
@@ -149,13 +149,13 @@ struct reader<TChar, _Get_money<TMoney>>
         if (!mp)
             throw stream_error("cannot get monetary facet");
 
-        return mp->get(s, s_end, f._M_intl, io, f._M_mon);
+        return mp->get(s, s_end, f.m_intl, io, f.m_mon);
     }
 };
 
 template<typename _CharT> struct _Put_time { const std::tm* tmb; const _CharT* fmt; };
 template<typename _CharT>
-inline _Put_time<_CharT> put_time(const std::tm* __tmb, const _CharT* __fmt) { return { __tmb, __fmt }; }
+inline _Put_time<_CharT> put_time(const std::tm* tmb, const _CharT* fmt) { return { tmb, fmt }; }
 
 template <typename TChar>
 struct writer<TChar, _Put_time<TChar>>
@@ -174,7 +174,7 @@ struct writer<TChar, _Put_time<TChar>>
 
 template<typename _CharT> struct _Get_time { std::tm* tmb; const _CharT* fmt; };
 template<typename _CharT>
-inline _Get_time<_CharT> get_time(std::tm* __tmb, const _CharT* __fmt) { return { __tmb, __fmt }; }
+inline _Get_time<_CharT> get_time(std::tm* tmb, const _CharT* fmt) { return { tmb, fmt }; }
 
 template <typename TChar>
 struct reader<TChar, _Get_time<TChar>>

--- a/include/io/streambuf_iterator.h
+++ b/include/io/streambuf_iterator.h
@@ -43,10 +43,10 @@ public:
 
     istreambuf_iterator operator++(int)
     {
-        istreambuf_iterator __old = *this;
-        __old.m_c = m_streambuf->sbumpc();
+        istreambuf_iterator old = *this;
+        old.m_c = m_streambuf->sbumpc();
         m_c = std::optional<value_type>{};
-        return __old;
+        return old;
     }
 
     void sputbackc(value_type ch)


### PR DESCRIPTION
- Remove '__' prefix from function parameters and local variables.
- Replace '_M_' prefix with 'm_' for member variables.
- Rename internal helper functions to remove reserved prefixes.
- Align with C++ standard recommendations to avoid identifiers reserved for implementations.