### PR TITLE
feat: improve prefix_tree design and add unit tests

### DIFF
--- a/include/common/prefix_tree.h
+++ b/include/common/prefix_tree.h
@@ -4,6 +4,7 @@
 #include <memory>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <vector>
 
@@ -11,6 +12,15 @@
 
 namespace IOv2
 {
+/**
+ * @brief A prefix tree (Trie) used for internal IOv2 components.
+ * 
+ * Note:
+ * 1. This class is intended for internal use and does not provide a comprehensive
+ *    set of public interfaces (e.g., remove, clear, size).
+ * 2. It is designed to use a sentinel (default) value to represent "no value" at a node.
+ *    As a result, the default value itself cannot be stored as a legitimate value in the tree.
+ */
 template <typename CharT, typename TValue>
 class prefix_tree
 {
@@ -44,33 +54,10 @@ public:
     {
         if (str == nullptr)
             throw std::runtime_error("Null input for prefix_tree:add");
-        if (v == m_def)
-            throw std::runtime_error("cannot add with default value");
-            
-        node* node_ptr = &m_root;
-        while (*str != '\0')
-        {
-            CharT ch = *str;
-            
-            auto child = node_ptr->children.find(ch);
-            if (child == node_ptr->children.end())
-            {
-                bool insert_suc = false;
-                auto c = std::make_unique<node>(m_def, node_ptr->depth + 1);
-                std::tie(child, insert_suc) = node_ptr->children.insert(std::pair(ch, std::move(c)));
-                if (!insert_suc)
-                    throw std::runtime_error("prefix_tree insert fails");
-            }
-            node_ptr = child->second.get();
-            ++str;
-        }
-        
-        if (node_ptr->val != m_def)
-            throw std::runtime_error("duplicate items in prefix_tree");
-        node_ptr->val = v;
+        return add(std::basic_string_view<CharT>(str), v);
     }
     
-    void add(const std::basic_string<CharT> str, TValue v)
+    void add(std::basic_string_view<CharT> str, TValue v)
     {
         return add(str.begin(), str.end(), v);
     }

--- a/include/common/prefix_tree.h
+++ b/include/common/prefix_tree.h
@@ -50,13 +50,6 @@ public:
         }
     }
     
-    void add(const CharT* str, TValue v)
-    {
-        if (str == nullptr)
-            throw std::runtime_error("Null input for prefix_tree:add");
-        return add(std::basic_string_view<CharT>(str), v);
-    }
-    
     void add(std::basic_string_view<CharT> str, TValue v)
     {
         return add(str.begin(), str.end(), v);

--- a/test/Makefile
+++ b/test/Makefile
@@ -18,7 +18,7 @@ endif
 LINK_FLAGS := -lz -lbotan-2
 
 # Module definitions
-MODULES := device cvt facet locale io
+MODULES := device cvt facet locale io util
 
 # Per-module source collection
 device_SOURCES := $(shell find ./device -name '*.cpp')
@@ -26,6 +26,7 @@ cvt_SOURCES := $(shell find ./cvt -name '*.cpp')
 facet_SOURCES := $(shell find ./facet -name '*.cpp')
 locale_SOURCES := $(shell find ./locale -name '*.cpp')
 io_SOURCES := $(shell find ./io -name '*.cpp')
+util_SOURCES := $(shell find ./util -name '*.cpp')
 
 # Per-module object files
 device_OBJECTS := $(patsubst ./%.cpp,$(OBJ_DIR)/%.o,$(device_SOURCES))
@@ -33,6 +34,7 @@ cvt_OBJECTS := $(patsubst ./%.cpp,$(OBJ_DIR)/%.o,$(cvt_SOURCES))
 facet_OBJECTS := $(patsubst ./%.cpp,$(OBJ_DIR)/%.o,$(facet_SOURCES))
 locale_OBJECTS := $(patsubst ./%.cpp,$(OBJ_DIR)/%.o,$(locale_SOURCES))
 io_OBJECTS := $(patsubst ./%.cpp,$(OBJ_DIR)/%.o,$(io_SOURCES))
+util_OBJECTS := $(patsubst ./%.cpp,$(OBJ_DIR)/%.o,$(util_SOURCES))
 
 # Target binaries
 TARGETS := $(addprefix $(BIN_DIR)/test_,$(MODULES))
@@ -61,12 +63,17 @@ $(BIN_DIR)/test_io: $(io_OBJECTS)
 	@mkdir -p $(BIN_DIR)
 	$(CXX) -o $@ $^ $(LINK_FLAGS)
 
+$(BIN_DIR)/test_util: $(util_OBJECTS)
+	@mkdir -p $(BIN_DIR)
+	$(CXX) -o $@ $^ $(LINK_FLAGS)
+
 # Convenience targets for building individual modules
 device: $(BIN_DIR)/test_device
 cvt: $(BIN_DIR)/test_cvt
 facet: $(BIN_DIR)/test_facet
 locale: $(BIN_DIR)/test_locale
 io: $(BIN_DIR)/test_io
+util: $(BIN_DIR)/test_util
 
 # Convenience targets for building and running individual modules
 test-device: device
@@ -84,6 +91,9 @@ test-locale: locale
 test-io: io
 	@echo "Running $(BIN_DIR)/test_io..."; $(BIN_DIR)/test_io
 
+test-util: util
+	@echo "Running $(BIN_DIR)/test_util..."; $(BIN_DIR)/test_util
+
 # Convenience targets for building and running individual modules with valgrind
 valgrind-device: device
 	@echo "Running $(BIN_DIR)/test_device with valgrind..."; valgrind --error-exitcode=1 --leak-check=full --max-stackframe=6000000 $(BIN_DIR)/test_device
@@ -99,6 +109,9 @@ valgrind-locale: locale
 
 valgrind-io: io
 	@echo "Running $(BIN_DIR)/test_io with valgrind..."; valgrind --error-exitcode=1 --leak-check=full --max-stackframe=6000000 $(BIN_DIR)/test_io
+
+valgrind-util: util
+	@echo "Running $(BIN_DIR)/test_util with valgrind..."; valgrind --error-exitcode=1 --leak-check=full --max-stackframe=6000000 $(BIN_DIR)/test_util
 
 # Generic compilation rule
 $(OBJ_DIR)/%.o: ./%.cpp

--- a/test/README.md
+++ b/test/README.md
@@ -41,6 +41,7 @@ make test
 | `facet` | 仅构建 facet 测试 |
 | `locale` | 仅构建 locale 测试 |
 | `io` | 仅构建 io 测试 |
+| `util` | 仅构建 util 测试 |
 
 ### 单模块构建并运行
 
@@ -51,6 +52,7 @@ make test
 | `test-facet` | 构建并运行 facet 测试 |
 | `test-locale` | 构建并运行 locale 测试 |
 | `test-io` | 构建并运行 io 测试 |
+| `test-util` | 构建并运行 util 测试 |
 
 ### 单模块内存检测 (Valgrind)
 
@@ -61,6 +63,7 @@ make test
 | `valgrind-facet` | 使用 valgrind 构建并运行 facet 测试 |
 | `valgrind-locale` | 使用 valgrind 构建并运行 locale 测试 |
 | `valgrind-io` | 使用 valgrind 构建并运行 io 测试 |
+| `valgrind-util` | 使用 valgrind 构建并运行 util 测试 |
 
 ### 构建模式
 
@@ -144,6 +147,7 @@ make test
 | `facet` | Build facet tests only |
 | `locale` | Build locale tests only |
 | `io` | Build io tests only |
+| `util` | Build util tests only |
 
 ### Single Module Build and Run
 
@@ -154,6 +158,7 @@ make test
 | `test-facet` | Build and run facet tests |
 | `test-locale` | Build and run locale tests |
 | `test-io` | Build and run io tests |
+| `test-util` | Build and run util tests |
 
 ### Single Module Run with Valgrind
 
@@ -164,6 +169,7 @@ make test
 | `valgrind-facet` | Build and run facet tests with valgrind |
 | `valgrind-locale` | Build and run locale tests with valgrind |
 | `valgrind-io` | Build and run io tests with valgrind |
+| `valgrind-util` | Build and run util tests with valgrind |
 
 ### Build Modes
 

--- a/test/util/test_prefix_tree.cpp
+++ b/test/util/test_prefix_tree.cpp
@@ -1,0 +1,130 @@
+#include <common/prefix_tree.h>
+#include <common/verify.h>
+#include <string>
+#include <vector>
+#include <iostream>
+
+using namespace IOv2;
+
+void test_prefix_tree_basic()
+{
+    prefix_tree<char, int> tree;
+    tree.add("hello", 1);
+    tree.add("world", 2);
+    tree.add("he", 3);
+
+    int out = -1;
+    std::string s1 = "hello";
+    auto it1 = tree.max_match(s1.begin(), s1.end(), out);
+    VERIFY(out == 1);
+    VERIFY(it1 == s1.end());
+
+    std::string s2 = "he";
+    auto it2 = tree.max_match(s2.begin(), s2.end(), out);
+    VERIFY(out == 3);
+    VERIFY(it2 == s2.end());
+
+    std::string s3 = "hell";
+    auto it3 = tree.max_match(s3.begin(), s3.end(), out);
+    VERIFY(out == 3); // "he" is the max match
+    VERIFY(it3 == s3.begin() + 2);
+
+    std::string s4 = "world";
+    auto it4 = tree.max_match(s4.begin(), s4.end(), out);
+    VERIFY(out == 2);
+    VERIFY(it4 == s4.end());
+
+    std::string s5 = "not_found";
+    auto it5 = tree.max_match(s5.begin(), s5.end(), out);
+    VERIFY(out == -1); // root default value
+    VERIFY(it5 == s5.begin());
+}
+
+void test_prefix_tree_duplicate_handling()
+{
+    prefix_tree<char, int> tree;
+    tree.add("test", 10);
+    
+    // Adding same key with same value should NOT throw
+    try {
+        tree.add("test", 10);
+    } catch (...) {
+        VERIFY(false); // Should not throw
+    }
+
+    // Adding same key with different value SHOULD throw
+    try {
+        tree.add("test", 20);
+        VERIFY(false); // Should have thrown
+    } catch (const std::runtime_error& e) {
+        // Expected
+    }
+
+    // Test with iterator version
+    std::string s = "iter";
+    tree.add(s.begin(), s.end(), 100);
+    try {
+        tree.add(s.begin(), s.end(), 100);
+    } catch (...) {
+        VERIFY(false); // Should not throw
+    }
+
+    try {
+        tree.add(s.begin(), s.end(), 200);
+        VERIFY(false); // Should have thrown
+    } catch (const std::runtime_error& e) {
+        // Expected
+    }
+}
+
+void test_prefix_tree_sentinel_value()
+{
+    prefix_tree<char, int> tree(999); // Use 999 as sentinel
+
+    // Should NOT be able to add the sentinel value
+    try {
+        tree.add("bad", 999);
+        VERIFY(false); // Should have thrown
+    } catch (const std::runtime_error& e) {
+        // Expected
+    }
+
+    // Should be able to add other values
+    tree.add("good", 1);
+    int out = -1;
+    std::string s = "good";
+    tree.max_match(s.begin(), s.end(), out);
+    VERIFY(out == 1);
+}
+
+void test_prefix_tree_string_view()
+{
+    prefix_tree<char, int> tree;
+    std::string_view sv = "view";
+    tree.add(sv, 5);
+
+    int out = -1;
+    auto it = tree.max_match(sv.begin(), sv.end(), out);
+    VERIFY(out == 5);
+    VERIFY(it == sv.end());
+}
+
+void test_prefix_tree_vector_constructor()
+{
+    std::vector<const char*> strs = {"apple", "banana", "cherry"};
+    prefix_tree<char, int> tree(strs);
+
+    int out = -1;
+    std::string s = "banana";
+    tree.max_match(s.begin(), s.end(), out);
+    VERIFY(out == 1); // Index 1 in the vector
+}
+
+void test_prefix_tree()
+{
+    test_prefix_tree_basic();
+    test_prefix_tree_duplicate_handling();
+    test_prefix_tree_sentinel_value();
+    test_prefix_tree_string_view();
+    test_prefix_tree_vector_constructor();
+}

--- a/test/util/test_prefix_tree.cpp
+++ b/test/util/test_prefix_tree.cpp
@@ -1,13 +1,14 @@
 #include <common/prefix_tree.h>
 #include <common/verify.h>
+#include <common/dump_info.h>
 #include <string>
 #include <vector>
-#include <iostream>
 
 using namespace IOv2;
 
 void test_prefix_tree_basic()
 {
+    dump_info("Test prefix_tree basic...");
     prefix_tree<char, int> tree;
     tree.add("hello", 1);
     tree.add("world", 2);
@@ -38,10 +39,12 @@ void test_prefix_tree_basic()
     auto it5 = tree.max_match(s5.begin(), s5.end(), out);
     VERIFY(out == -1); // root default value
     VERIFY(it5 == s5.begin());
+    dump_info("Done\n");
 }
 
 void test_prefix_tree_duplicate_handling()
 {
+    dump_info("Test prefix_tree duplicate handling...");
     prefix_tree<char, int> tree;
     tree.add("test", 10);
     
@@ -75,10 +78,12 @@ void test_prefix_tree_duplicate_handling()
     } catch (const std::runtime_error& e) {
         // Expected
     }
+    dump_info("Done\n");
 }
 
 void test_prefix_tree_sentinel_value()
 {
+    dump_info("Test prefix_tree sentinel value...");
     prefix_tree<char, int> tree(999); // Use 999 as sentinel
 
     // Should NOT be able to add the sentinel value
@@ -95,10 +100,12 @@ void test_prefix_tree_sentinel_value()
     std::string s = "good";
     tree.max_match(s.begin(), s.end(), out);
     VERIFY(out == 1);
+    dump_info("Done\n");
 }
 
 void test_prefix_tree_string_view()
 {
+    dump_info("Test prefix_tree string_view...");
     prefix_tree<char, int> tree;
     std::string_view sv = "view";
     tree.add(sv, 5);
@@ -107,10 +114,12 @@ void test_prefix_tree_string_view()
     auto it = tree.max_match(sv.begin(), sv.end(), out);
     VERIFY(out == 5);
     VERIFY(it == sv.end());
+    dump_info("Done\n");
 }
 
 void test_prefix_tree_vector_constructor()
 {
+    dump_info("Test prefix_tree vector constructor...");
     std::vector<const char*> strs = {"apple", "banana", "cherry"};
     prefix_tree<char, int> tree(strs);
 
@@ -118,6 +127,7 @@ void test_prefix_tree_vector_constructor()
     std::string s = "banana";
     tree.max_match(s.begin(), s.end(), out);
     VERIFY(out == 1); // Index 1 in the vector
+    dump_info("Done\n");
 }
 
 void test_prefix_tree()

--- a/test/util/test_util.cpp
+++ b/test/util/test_util.cpp
@@ -1,0 +1,24 @@
+#include <exception>
+#include <string>
+#include <common/dump_info.h>
+
+void test_prefix_tree();
+
+int main()
+{
+    try
+    {
+        test_prefix_tree();
+        return 0;
+    }
+    catch (const std::exception& e)
+    {
+        dump_info((std::string("\n[!] Util test failed with exception: ") + e.what() + "\n").c_str());
+        return 1;
+    }
+    catch (...)
+    {
+        dump_info("\n[!] Util test failed with an unknown exception.\n");
+        return 1;
+    }
+}


### PR DESCRIPTION
- Unified duplicate key handling in prefix_tree::add.
- Optimized string parameters using std::basic_string_view.
- Added descriptive comments for internal design constraints.
- Introduced test/util directory and unit tests for prefix_tree.
- Updated Makefile and README.md with the new 'util' test module.