### PR TITLE
fix: improve lru_cache update behavior and perfect forwarding

### DIFF
--- a/include/common/lru_cache.h
+++ b/include/common/lru_cache.h
@@ -3,6 +3,7 @@
 #include <list>
 #include <optional>
 #include <unordered_map>
+#include <utility>
 
 namespace IOv2
 {
@@ -29,7 +30,8 @@ public:
         return m_it->second->second;
     }
     
-    void put(TK key, TV value)
+    template <typename K, typename V>
+    bool try_put(K&& key, V&& value)
     {
         auto m_it = m_cache_map.find(key);
 
@@ -38,7 +40,7 @@ public:
             auto l_it = m_it->second;
             m_cache_list.splice(m_cache_list.begin(), m_cache_list, l_it);
             m_it->second = m_cache_list.begin();
-            return;
+            return false;
         }
         
         if (m_cache_list.size() >= Capacity)
@@ -46,8 +48,32 @@ public:
             m_cache_map.erase(m_cache_list.back().first);
             m_cache_list.pop_back();
         }
-        m_cache_list.push_front({key, value});
-        m_cache_map.insert({key, m_cache_list.begin()});
+        m_cache_list.emplace_front(std::forward<K>(key), std::forward<V>(value));
+        m_cache_map.insert({m_cache_list.front().first, m_cache_list.begin()});
+        return true;
+    }
+
+    template <typename K, typename V>
+    void put(K&& key, V&& value)
+    {
+        auto m_it = m_cache_map.find(key);
+
+        if (m_it != m_cache_map.end())
+        {
+            auto l_it = m_it->second;
+            l_it->second = std::forward<V>(value);
+            m_cache_list.splice(m_cache_list.begin(), m_cache_list, l_it);
+            m_it->second = m_cache_list.begin();
+            return;
+        }
+
+        if (m_cache_list.size() >= Capacity)
+        {
+            m_cache_map.erase(m_cache_list.back().first);
+            m_cache_list.pop_back();
+        }
+        m_cache_list.emplace_front(std::forward<K>(key), std::forward<V>(value));
+        m_cache_map.insert({m_cache_list.front().first, m_cache_list.begin()});
     }
 private:
     std::list<std::pair<TK, TV>> m_cache_list;

--- a/include/facet/ctype.h
+++ b/include/facet/ctype.h
@@ -278,7 +278,7 @@ private:
         if (!res.has_value())
         {
             auto v = m_obj->is(c);
-            m_table_cache.put(c, v);
+            m_table_cache.try_put(c, v);
             return v;
         }
         return res.value();
@@ -294,7 +294,7 @@ private:
         if (!res.has_value())
         {
             auto v = m_obj->toupper(c);
-            m_upper_cache.put(c, v);
+            m_upper_cache.try_put(c, v);
             return v;
         }
         return res.value();
@@ -310,7 +310,7 @@ private:
         if (!res.has_value())
         {
             auto v = m_obj->tolower(c);
-            m_lower_cache.put(c, v);
+            m_lower_cache.try_put(c, v);
             return v;
         }
         return res.value();
@@ -326,7 +326,7 @@ private:
         if (!res.has_value())
         {
             auto v = m_obj->narrow(c);
-            m_narrow_cache.put(c, v);
+            m_narrow_cache.try_put(c, v);
             return v;
         }
         return res.value();

--- a/test/util/test_lru_cache.cpp
+++ b/test/util/test_lru_cache.cpp
@@ -1,0 +1,79 @@
+#include <common/lru_cache.h>
+#include <common/verify.h>
+#include <common/dump_info.h>
+#include <string>
+
+using namespace IOv2;
+
+void test_lru_cache_basic()
+{
+    dump_info("Test lru_cache basic...");
+    lru_cache<int, std::string, 3> cache;
+    cache.put(1, "one");
+    cache.put(2, "two");
+    cache.put(3, "three");
+
+    auto r1 = cache.get(1);
+    VERIFY(r1.has_value() && *r1 == "one");
+    auto r2 = cache.get(2);
+    VERIFY(r2.has_value() && *r2 == "two");
+    auto r3 = cache.get(3);
+    VERIFY(r3.has_value() && *r3 == "three");
+    dump_info("Done\n");
+}
+
+void test_lru_cache_update()
+{
+    dump_info("Test lru_cache update...");
+    lru_cache<int, std::string, 3> cache;
+    cache.put(1, "hello");
+    cache.put(1, "world"); // Should update existing key
+
+    auto result = cache.get(1);
+    VERIFY(result.has_value() && *result == "world");
+    dump_info("Done\n");
+}
+
+void test_lru_cache_try_put()
+{
+    dump_info("Test lru_cache try_put...");
+    lru_cache<int, std::string, 3> cache;
+    VERIFY(cache.try_put(1, "hello") == true);
+    VERIFY(cache.try_put(1, "world") == false); // Should NOT update
+
+    auto result = cache.get(1);
+    VERIFY(result.has_value() && *result == "hello");
+    dump_info("Done\n");
+}
+
+void test_lru_cache_eviction()
+{
+    dump_info("Test lru_cache eviction...");
+    lru_cache<int, std::string, 2> cache;
+    cache.put(1, "one");
+    cache.put(2, "two");
+    
+    // 1 is MRU, 2 is LRU
+    cache.get(1); 
+    
+    // 2 should be evicted
+    cache.put(3, "three"); 
+
+    auto r1 = cache.get(1);
+    VERIFY(r1.has_value() && *r1 == "one");
+    
+    auto r2 = cache.get(2);
+    VERIFY(!r2.has_value());
+    
+    auto r3 = cache.get(3);
+    VERIFY(r3.has_value() && *r3 == "three");
+    dump_info("Done\n");
+}
+
+void test_lru_cache()
+{
+    test_lru_cache_basic();
+    test_lru_cache_update();
+    test_lru_cache_try_put();
+    test_lru_cache_eviction();
+}

--- a/test/util/test_util.cpp
+++ b/test/util/test_util.cpp
@@ -3,12 +3,14 @@
 #include <common/dump_info.h>
 
 void test_prefix_tree();
+void test_lru_cache();
 
 int main()
 {
     try
     {
         test_prefix_tree();
+        test_lru_cache();
         return 0;
     }
     catch (const std::exception& e)


### PR DESCRIPTION
- Renamed original insert-only put to try_put for semantic clarity.
- Implemented standard put with insert-or-update semantics.
- Optimized both methods using perfect forwarding and emplace_front.
- Updated ctype.h to use try_put for its fixed key-value pairs.
- Added comprehensive unit tests for lru_cache in test/util.