### PR TITLE
fix: chacha20_cvt constructor used uninitialized m_key instead of key

### DIFF
--- a/include/cvt/crypt/chacha20_cvt.h
+++ b/include/cvt/crypt/chacha20_cvt.h
@@ -37,7 +37,7 @@ public:
         if (!hash)
             throw cvt_error("chacha20_cvt::bos fail: cannot create SHA-256 hash");
         
-        hash->update((const uint8_t*)m_key.data(), m_key.size());
+        hash->update((const uint8_t*)key.data(), key.size());
         m_key = hash->final();
     }
     

--- a/test/cvt/crypt/chacha20_cvt.cpp
+++ b/test/cvt/crypt/chacha20_cvt.cpp
@@ -250,3 +250,44 @@ void test_chacha20_cvt_io_1()
     
     dump_info("Done\n");
 }
+
+void test_chacha20_cvt_key_1()
+{
+    using namespace IOv2;
+    dump_info("Test chacha20_cvt key difference...");
+
+    std::string msg = "Hello, world! This is a test message for ChaCha20.";
+    std::string enc_msg;
+
+    using CheckType = Crypt::chacha20_cvt<root_cvt<mem_device<char>, true>>;
+
+    {
+        CheckType obj(make_root_cvt<true>(mem_device("")), "key1");
+        obj.bos();
+        obj.main_cont_beg();
+        obj.put(msg.data(), msg.size());
+        enc_msg = obj.detach().str();
+    }
+
+    {
+        CheckType obj(make_root_cvt<true>(mem_device(enc_msg)), "key1");
+        obj.bos();
+        obj.main_cont_beg();
+        std::string dec_msg;
+        dec_msg.resize(msg.size());
+        obj.get(dec_msg.data(), dec_msg.size());
+        if (dec_msg != msg) throw std::runtime_error("chacha20 decryption with correct key failed");
+    }
+
+    {
+        CheckType obj(make_root_cvt<true>(mem_device(enc_msg)), "key2");
+        obj.bos();
+        obj.main_cont_beg();
+        std::string dec_msg;
+        dec_msg.resize(msg.size());
+        obj.get(dec_msg.data(), dec_msg.size());
+        if (dec_msg == msg) throw std::runtime_error("chacha20 decryption with WRONG key succeeded (unexpectedly)");
+    }
+
+    dump_info("Done\n");
+}

--- a/test/cvt/crypt/test_crypt_cvt.cpp
+++ b/test/cvt/crypt/test_crypt_cvt.cpp
@@ -31,6 +31,7 @@ void test_chacha20_cvt_gen_1();
 void test_chacha20_cvt_gen_2();
 void test_chacha20_cvt_put_1();
 void test_chacha20_cvt_io_1();
+void test_chacha20_cvt_key_1();
 
 void test_chacha20_cvt_wchar_t_gen_1();
 void test_chacha20_cvt_wchar_t_gen_2();
@@ -72,6 +73,7 @@ void test_crypt_cvt()
     test_chacha20_cvt_gen_2();
     test_chacha20_cvt_put_1();
     test_chacha20_cvt_io_1();
+    test_chacha20_cvt_key_1();
 
     test_chacha20_cvt_wchar_t_gen_1();
     test_chacha20_cvt_wchar_t_gen_2();


### PR DESCRIPTION
- Fixed the bug in chacha20_cvt constructor where the SHA-256 hash was updated using the uninitialized member variable m_key.
- Replaced m_key with the constructor parameter key.
- Added test_chacha20_cvt_key_1 to verify that encryption and decryption are key-dependent.
- Registered the new test in test_crypt_cvt.