### PR TITLE
refactor: use relaxed memory ordering for ios_base::xalloc() atomic increment

### DIFF
--- a/include/io/io_base.h
+++ b/include/io/io_base.h
@@ -255,7 +255,7 @@ public:
 public:
     static size_t xalloc() noexcept
     {
-        return (ios_base<void>::s_top)++;
+        return ios_base<void>::s_top.fetch_add(1, std::memory_order_relaxed);
     }
 
     std::shared_ptr<void> set_pword(size_t id, std::shared_ptr<void> pword)


### PR DESCRIPTION


Replaced (ios_base<void>::s_top)++ with fetch_add(1, std::memory_order_relaxed) to improve performance and adhere to modern C++ best practices as described in issue #24.