### PR TITLE
docs: document moved-from state and fix self-assignment issues in root_cvt

### DIFF
--- a/include/cvt/root_cvt.h
+++ b/include/cvt/root_cvt.h
@@ -12,6 +12,15 @@
 
 namespace IOv2
 {
+/// @brief Root converter class for I/O operations, managing device buffers.
+///
+/// @note Moved-from objects: After a move operation (move construction or move
+///       assignment), the source object is left in a valid but unspecified state.
+///       The only safe operations on a moved-from object are:
+///       - Destruction
+///       - Assignment (copy or move)
+///       Calling any other method on a moved-from object results in undefined behavior.
+///       This follows standard C++ conventions for moved-from objects.
 template <io_device DeviceType, bool HasInBuffer>
 class root_cvt
 {
@@ -69,6 +78,8 @@ public:
     root_cvt& operator= (const root_cvt& val)
         requires (std::is_copy_assignable_v<device_type>)
     {
+        if (this == &val) return *this;
+
         if constexpr (dev_cpt::support_put<device_type>)
             flush();
 
@@ -88,6 +99,8 @@ public:
     
     root_cvt& operator= (root_cvt&& val)
     {
+        if (this == &val) return *this;
+
         if constexpr (dev_cpt::support_put<device_type>)
             flush();
 

--- a/test/cvt/root_cvt/root_cvt_mem.cpp
+++ b/test/cvt/root_cvt/root_cvt_mem.cpp
@@ -314,13 +314,13 @@ void test_root_cvt_mem_put_1()
         e_lit[i+6] = (i / 7) % 127 + 1;
     }
 
-    auto helper = [&e_lit](auto& obj)
+    auto helper = [] (const std::string& e_lit, auto& obj)
     {
         size_t buffer_size[] = {2, 41, 3, 90, 7, 11, 13, 17, 19};
 
         if (obj.bos() != io_status::output) throw std::runtime_error("root_cvt<mem_device>::bos response incorrect");
         obj.main_cont_beg();
-        char* cur_pos = e_lit.data();
+        const char* cur_pos = e_lit.data();
         int buffer_id = 0;
         while (cur_pos < e_lit.data() + 4102)
         {
@@ -338,10 +338,10 @@ void test_root_cvt_mem_put_1()
     };
 
     auto obj1 = make_root_cvt<true>(mem_device(""));
-    helper(obj1);
+    helper(e_lit, obj1);
     
     runtime_cvt obj2(make_root_cvt<true>(mem_device("")));
-    helper(obj2);
+    helper(e_lit, obj2);
 
     dump_info("Done\n");
 }
@@ -595,5 +595,52 @@ void test_root_cvt_mem_attach_2()
         runtime_cvt obj(make_root_cvt<true>(mem_device("")));
         helper(obj);
     }
+    dump_info("Done\n");
+}
+
+void test_root_cvt_mem_self_assignment()
+{
+    using namespace IOv2;
+    dump_info("Test root_cvt<mem_device> self-assignment...");
+    
+    {
+        mem_device dev{"hello"}; dev.drseek(0);
+        auto obj = make_root_cvt<true>(std::move(dev));
+        VERIFY(obj.bos() == io_status::output); 
+        obj.main_cont_beg();
+        obj.put(" world", 6);
+        
+        // Self copy assignment
+        const auto& const_obj = obj;
+        obj = const_obj;
+        
+        obj.flush();
+        VERIFY(obj.device().str() == "hello world");
+        
+        // Self move assignment
+        auto* pObj = &obj;
+        obj = std::move(*pObj);
+        VERIFY(obj.device().str() == "hello world");
+    }
+    
+    {
+        mem_device dev{"hello"}; dev.drseek(0);
+        runtime_cvt obj(make_root_cvt<true>(std::move(dev)));
+        VERIFY(obj.bos() == io_status::output); 
+        obj.main_cont_beg();
+        obj.put(" world", 6);
+        
+        // Self copy assignment
+        const auto& const_obj = obj;
+        obj = const_obj;
+        obj.flush();
+        VERIFY(obj.device().str() == "hello world");
+        
+        // Self move assignment
+        auto* pObj = &obj;
+        obj = std::move(*pObj);
+        VERIFY(obj.device().str() == "hello world");
+    }
+
     dump_info("Done\n");
 }

--- a/test/cvt/root_cvt/test_root_cvt.cpp
+++ b/test/cvt/root_cvt/test_root_cvt.cpp
@@ -12,6 +12,7 @@ void test_root_cvt_mem_detach_1();
 void test_root_cvt_mem_detach_2();
 void test_root_cvt_mem_attach_1();
 void test_root_cvt_mem_attach_2();
+void test_root_cvt_mem_self_assignment();
 
 void test_root_cvt_std_gen_1();
 void test_root_cvt_std_gen_2();
@@ -51,6 +52,7 @@ void test_root_cvt()
     test_root_cvt_mem_detach_2();
     test_root_cvt_mem_attach_1();
     test_root_cvt_mem_attach_2();
+    test_root_cvt_mem_self_assignment();
     
     test_root_cvt_std_gen_1();
     test_root_cvt_std_gen_2();


### PR DESCRIPTION


- Applied documentation patch to clarify root_cvt state after move operations (Issue #31).
- Added self-assignment checks to copy and move assignment operators in root_cvt (Issue #43).
- Added unit tests to verify self-assignment safety for both root_cvt and runtime_cvt.
- Improved robustness of existing mem_device put tests.