### PR TITLE
perf: replace std::list with std::deque in streambuf and istreambuf putback buffer

### DIFF
--- a/include/io/streambuf.h
+++ b/include/io/streambuf.h
@@ -1,5 +1,5 @@
 #pragma once
-#include <list>
+#include <deque>
 #include <optional>
 #include <utility>
 #include <cvt/runtime_cvt.h>
@@ -199,7 +199,7 @@ private:
 
 private:
     runtime_cvt<TDevice, TChar> m_cvt;
-    std::list<char_type> m_read_buf;
+    std::deque<char_type> m_read_buf;
 };
 
 template <io_device TDevice, typename TChar>
@@ -348,7 +348,7 @@ private:
 
 private:
     runtime_cvt<TDevice, TChar> m_cvt;
-    std::list<char_type> m_read_buf;
+    std::deque<char_type> m_read_buf;
 };
 
 template <io_device TDevice, typename TChar>


### PR DESCRIPTION


The putback buffer is typically small and its operations focus on the front. std::deque provides O(1) amortized time for front operations while reducing frequent small memory allocations and providing better cache locality compared to std::list.