### PR TITLE
feat: enhance clocale_wrapper with move semantics and better encapsulation

### DIFF
--- a/include/common/clocale_wrapper.h
+++ b/include/common/clocale_wrapper.h
@@ -8,6 +8,9 @@ namespace IOv2
 {
 struct clocale_wrapper
 {
+    friend struct clocale_user;
+    template <typename CharT> friend class ctype_conf;
+
     clocale_wrapper(const char* name)
         : c_locale(newlocale(LC_ALL_MASK, name, 0))
     {
@@ -17,9 +20,10 @@ struct clocale_wrapper
         }
     }
 
-    ~clocale_wrapper()
+    ~clocale_wrapper() noexcept
     {
-        freelocale(c_locale);
+        if (c_locale)
+            freelocale(c_locale);
     }
     
     clocale_wrapper(const clocale_wrapper& val)
@@ -31,6 +35,24 @@ struct clocale_wrapper
         }
     }
 
+    clocale_wrapper(clocale_wrapper&& val) noexcept
+        : c_locale(val.c_locale)
+    {
+        val.c_locale = nullptr;
+    }
+
+    clocale_wrapper& operator = (clocale_wrapper&& val) noexcept
+    {
+        if (this != &val)
+        {
+            if (c_locale)
+                freelocale(c_locale);
+            c_locale = val.c_locale;
+            val.c_locale = nullptr;
+        }
+        return *this;
+    }
+
     clocale_wrapper& operator= (const clocale_wrapper& val)
     {
         if (this != &val)
@@ -40,19 +62,21 @@ struct clocale_wrapper
             {
                 throw cvt_error("clocale_wrapper: duplocale failed during assignment");
             }
-            freelocale(c_locale);
+            if (c_locale)
+                freelocale(c_locale);
             c_locale = tmp;
         }
         return *this;
     }
 
+private:
     locale_t c_locale;
 };
 
 struct clocale_user
 {
-    clocale_user(locale_t c_locale)
-        : old(uselocale(c_locale))
+    clocale_user(const clocale_wrapper& wrapper)
+        : old(uselocale(wrapper.c_locale))
     { }
     
     clocale_user(const clocale_user&) = delete;

--- a/include/cvt/code_cvt.h
+++ b/include/cvt/code_cvt.h
@@ -30,7 +30,7 @@ struct codecvt_kernel<char, TInt>
     codecvt_kernel(const std::string& name)
         : m_inter_locale(name.c_str())
     {
-        clocale_user guard(m_inter_locale.c_locale);
+        clocale_user guard(m_inter_locale);
 
         // there are no known constant length encodings
         // m_epc == 1 means fix len
@@ -51,7 +51,7 @@ struct codecvt_kernel<char, TInt>
     
     bool out_helper(TInt ch, char*& to, char* to_end)
     {
-        clocale_user guard(m_inter_locale.c_locale);
+        clocale_user guard(m_inter_locale);
         if (to_end - to < m_epc)
             return false;
 
@@ -68,7 +68,7 @@ struct codecvt_kernel<char, TInt>
     std::pair<bool, size_t> in_helper(const char*& from, const char* from_end,
                                       TInt*& to, TInt* to_end)
     {
-        clocale_user guard(m_inter_locale.c_locale);
+        clocale_user guard(m_inter_locale);
         wchar_t wch = 0;
         size_t i_count = 0;
 

--- a/include/facet/collate_details.h
+++ b/include/facet/collate_details.h
@@ -31,7 +31,7 @@ public:
         std::vector<CharT> buf1; bool extra_eos1 = false;
         std::vector<CharT> buf2; bool extra_eos2 = false;
         
-        clocale_user guard(m_inter_locale.c_locale);
+        clocale_user guard(m_inter_locale);
         
         while ((low1 != high1) && (low2 != high2))
         {
@@ -104,7 +104,7 @@ public:
         size_t res = 0;
         std::vector<CharT> buf;
         
-        clocale_user guard(m_inter_locale.c_locale);
+        clocale_user guard(m_inter_locale);
         while (low != high)
         {
             const CharT* cur = low;
@@ -152,7 +152,7 @@ public:
         std::vector<CharT> buf;
         bool extra_eos = false;
         
-        clocale_user guard(m_inter_locale.c_locale);
+        clocale_user guard(m_inter_locale);
         while ((low != high) && ((mx_len == 0) || (trans_count < mx_len)))
         {
             const CharT* cur = low;

--- a/include/facet/ctype_details.h
+++ b/include/facet/ctype_details.h
@@ -104,7 +104,7 @@ public:
         : ft_basic<ctype<CharT>>()
         , m_inter_locale(name.c_str())
     {
-        clocale_user guard(m_inter_locale.c_locale);
+        clocale_user guard(m_inter_locale);
         for (size_t j = 0; j < sizeof(m_widen) / sizeof(wint_t); ++j)
           m_widen[j] = btowc(j);
           
@@ -152,7 +152,7 @@ public:
 
     virtual std::optional<char> narrow(CharT wc) const
     {
-        clocale_user guard(m_inter_locale.c_locale);
+        clocale_user guard(m_inter_locale);
         const int c = wctob(wc);
         if (c == EOF) return std::nullopt;
         else return static_cast<char>(c);

--- a/include/facet/monetary_details.h
+++ b/include/facet/monetary_details.h
@@ -214,7 +214,7 @@ public:
         else
         {
             clocale_wrapper inter_locale(name.c_str());
-            clocale_user guard(inter_locale.c_locale);
+            clocale_user guard(inter_locale);
             
             m_decimal_point = FacetHelper::string_to_char_convert(nl_langinfo(__MON_DECIMAL_POINT), name);
             m_thousands_sep = FacetHelper::string_to_char_convert(nl_langinfo(__MON_THOUSANDS_SEP), name);
@@ -351,7 +351,7 @@ public:
         {
             union { char *s; wchar_t w; } u;
             clocale_wrapper inter_locale(name.c_str());
-            clocale_user guard(inter_locale.c_locale);
+            clocale_user guard(inter_locale);
 
             u.s = nl_langinfo(_NL_MONETARY_DECIMAL_POINT_WC);
             m_decimal_point = u.w;

--- a/include/facet/numeric.h
+++ b/include/facet/numeric.h
@@ -259,7 +259,7 @@ private:
 
         {
             clocale_wrapper inter_locale("C");
-            clocale_user guard(inter_locale.c_locale);
+            clocale_user guard(inter_locale);
             len = sprintf(cs, fbuf, prec, v);
         }
 
@@ -863,7 +863,7 @@ private:
         char* sanity;
 
         clocale_wrapper inter_locale("C");
-        clocale_user guard(inter_locale.c_locale);
+        clocale_user guard(inter_locale);
 
         if constexpr (std::is_same_v<TValue, float>)
             v = strtof(s, &sanity);

--- a/include/facet/numeric_details.h
+++ b/include/facet/numeric_details.h
@@ -31,7 +31,7 @@ public:
         else
         {
             clocale_wrapper inter_locale(name.c_str());
-            clocale_user guard(inter_locale.c_locale);
+            clocale_user guard(inter_locale);
             
             m_decimal_point = FacetHelper::string_to_char_convert(nl_langinfo(DECIMAL_POINT), name);
             m_thousands_sep = FacetHelper::string_to_char_convert(nl_langinfo(THOUSANDS_SEP), name);
@@ -106,7 +106,7 @@ public:
         }
 
         clocale_wrapper inter_locale(name.c_str());
-        clocale_user guard(inter_locale.c_locale);
+        clocale_user guard(inter_locale);
         
         union { char* s; CharT w; } u;
 

--- a/include/facet/timeio_details.h
+++ b/include/facet/timeio_details.h
@@ -159,7 +159,7 @@ public:
         else
         {
             clocale_wrapper inter_locale(name.c_str());
-            clocale_user guard(inter_locale.c_locale);
+            clocale_user guard(inter_locale);
 
             m_date_format = nl_langinfo(D_FMT);
             m_era_date_format = nl_langinfo(ERA_D_FMT);  if (m_era_date_format.empty()) m_era_date_format = m_date_format;
@@ -409,7 +409,7 @@ public:
         else
         {
             clocale_wrapper inter_locale(name.c_str());
-            clocale_user guard(inter_locale.c_locale);
+            clocale_user guard(inter_locale);
             using namespace IOv2::FacetHelper;
             m_date_format = nl_langinfo_w<CharT>(_NL_WD_FMT);
             m_era_date_format = nl_langinfo_w<CharT>(_NL_WERA_D_FMT);  if (m_era_date_format.empty()) m_era_date_format = m_date_format;

--- a/test/util/test_clocale_wrapper.cpp
+++ b/test/util/test_clocale_wrapper.cpp
@@ -1,0 +1,83 @@
+#include <common/clocale_wrapper.h>
+#include <common/verify.h>
+#include <common/dump_info.h>
+#include <type_traits>
+#include <utility>
+
+using namespace IOv2;
+
+void test_clocale_wrapper_traits()
+{
+    dump_info("Test clocale_wrapper traits...");
+    static_assert(std::is_nothrow_destructible_v<clocale_wrapper>);
+    static_assert(std::is_nothrow_move_constructible_v<clocale_wrapper>);
+    static_assert(std::is_nothrow_move_assignable_v<clocale_wrapper>);
+    dump_info("Done\n");
+}
+
+void test_clocale_wrapper_move()
+{
+    dump_info("Test clocale_wrapper move semantics...");
+    clocale_wrapper loc1("C");
+    
+    // Move construction
+    clocale_wrapper loc2(std::move(loc1));
+    // loc1 should now be empty (c_locale == nullptr)
+    // We can't access c_locale directly as it's private, but we can test safety of destruction
+    
+    // Move assignment
+    clocale_wrapper loc3("C");
+    loc3 = std::move(loc2);
+    
+    dump_info("Done\n");
+}
+
+void test_clocale_wrapper_copy()
+{
+    dump_info("Test clocale_wrapper copy semantics...");
+    clocale_wrapper loc1("C");
+    
+    // Copy construction
+    clocale_wrapper loc2(loc1);
+    
+    // Copy assignment
+    clocale_wrapper loc3("C");
+    loc3 = loc2;
+    
+    dump_info("Done\n");
+}
+
+void test_clocale_wrapper_self_assignment()
+{
+    dump_info("Test clocale_wrapper self assignment...");
+    clocale_wrapper loc1("C");
+    
+    // Self copy assignment
+    loc1 = loc1;
+    
+    // Self move assignment
+    loc1 = std::move(loc1);
+    
+    dump_info("Done\n");
+}
+
+void test_clocale_wrapper_safety()
+{
+    dump_info("Test clocale_wrapper safety (moved-from state)...");
+    {
+        clocale_wrapper loc1("C");
+        clocale_wrapper loc2(std::move(loc1));
+        // loc1 is now in a moved-from state. 
+        // Its destructor should be safe (it is marked noexcept and we added a null check).
+    }
+    dump_info("Done\n");
+}
+
+void test_clocale_wrapper()
+{
+    test_clocale_wrapper_traits();
+    test_clocale_wrapper_move();
+    test_clocale_wrapper_copy();
+    test_clocale_wrapper_self_assignment();
+    test_clocale_wrapper_safety();
+}

--- a/test/util/test_util.cpp
+++ b/test/util/test_util.cpp
@@ -4,6 +4,7 @@
 
 void test_prefix_tree();
 void test_lru_cache();
+void test_clocale_wrapper();
 
 int main()
 {
@@ -11,6 +12,7 @@ int main()
     {
         test_prefix_tree();
         test_lru_cache();
+        test_clocale_wrapper();
         return 0;
     }
     catch (const std::exception& e)


### PR DESCRIPTION


- Add move constructor and move assignment operator to clocale_wrapper
- Add noexcept specifications to destructor and move operations
- Add null pointer checks in destructor and assignment operators
- Make c_locale private and use friend declarations for clocale_user and ctype_conf
- Update all clocale_user usages to pass clocale_wrapper objects directly
- Add comprehensive unit tests for clocale_wrapper move/copy/safety