### PR TITLE
fix: improve safety, correctness and coding style across headers

### DIFF
--- a/include/common/prefix_tree.h
+++ b/include/common/prefix_tree.h
@@ -30,7 +30,7 @@ class prefix_tree
         TValue val;
         size_t depth;
 
-        node(TValue v, int d)
+        node(TValue v, size_t d)
             : val(v)
             , depth(d) {}
     };
@@ -41,7 +41,7 @@ public:
         , m_root(dflt, 0)
     { }
 
-    prefix_tree(const std::vector<const CharT*>& strs, TValue dflt = (TValue)-1)
+    prefix_tree(const std::vector<const CharT*>& strs, TValue dflt = static_cast<TValue>(-1))
         : prefix_tree(dflt)
     {
         for (size_t i = 0; i < strs.size(); ++i)

--- a/include/common/sing_temp.h
+++ b/include/common/sing_temp.h
@@ -7,7 +7,7 @@ class sing_temp
 {
 public:
     // Note: This implementation assumes init objects are only created during
-    // static initialization before main(). Static initialization is single-threaded,
+    // static initialization **before** main(). Static initialization is single-threaded,
     // so atomic operations are not needed.
     // If init objects need to be created dynamically after main(), thread
     // synchronization mechanisms must be added.

--- a/include/cvt/crypt/hash_cvt.h
+++ b/include/cvt/crypt/hash_cvt.h
@@ -82,28 +82,34 @@ public:
 
     hash_cvt& operator=(const hash_cvt& val)
     {
-        if (m_has_main_cont)
-            dump_stream();
-        m_hash = val.m_hash->copy_state();
-        m_bos_done = val.m_bos_done;
-        m_has_main_cont = val.m_has_main_cont;
-        m_out_fmt = val.m_out_fmt;
+        if (this != &val)
+        {
+            if (m_has_main_cont)
+                dump_stream();
+            m_hash = val.m_hash->copy_state();
+            m_bos_done = val.m_bos_done;
+            m_has_main_cont = val.m_has_main_cont;
+            m_out_fmt = val.m_out_fmt;
 
-        BT::operator=(val);
+            BT::operator=(val);
+        }
         return *this;
     }
     
     hash_cvt& operator=(hash_cvt&& val)
     {
-        if (m_has_main_cont)
-            dump_stream();
-        m_hash = std::move(val.m_hash);
-        m_bos_done = val.m_bos_done;
-        m_has_main_cont = val.m_has_main_cont;
-        m_out_fmt = val.m_out_fmt;
-        val.m_has_main_cont = false;
+        if (this != &val)
+        {
+            if (m_has_main_cont)
+                dump_stream();
+            m_hash = std::move(val.m_hash);
+            m_bos_done = val.m_bos_done;
+            m_has_main_cont = val.m_has_main_cont;
+            m_out_fmt = val.m_out_fmt;
+            val.m_has_main_cont = false;
 
-        BT::operator=(std::move(val));
+            BT::operator=(std::move(val));
+        }
         return *this;
     }
     

--- a/include/device/mem_device.h
+++ b/include/device/mem_device.h
@@ -64,7 +64,7 @@ public:
     
     void dput(const char_type* ch, size_t n)
     {
-        if (m_next_pos + n >= m_str.size())
+        if (m_next_pos + n > m_str.size())
         {
             m_str.erase(m_str.begin() + m_next_pos, m_str.end());
             m_str.reserve(m_next_pos + n);

--- a/include/facet/ctype.h
+++ b/include/facet/ctype.h
@@ -234,7 +234,7 @@ public:
 
     CharT widen(char c) const
     {
-        return m_widen[static_cast<unsigned>(c)];
+        return m_widen[static_cast<unsigned char>(c)];
     }
 
     template <typename InIt, typename OutIt>

--- a/include/io/io_base.h
+++ b/include/io/io_base.h
@@ -48,7 +48,7 @@ namespace ios_defs
     class failure : public std::runtime_error
     {
     public:
-        explicit failure(const std::string& msg, const std::error_code& ec= std::io_errc::stream)
+        explicit failure(const std::string& msg, const std::error_code& ec = std::io_errc::stream)
             : std::runtime_error(msg)
             , m_ec(ec) {}
 


### PR DESCRIPTION
- Fix potential OOB in ctype::widen by using unsigned char cast to prevent sign extension.
- Optimize mem_device::dput boundary check to avoid redundant reallocations when buffer is full.
- Add self-assignment protection to hash_cvt copy and move assignment operators.
- Modernize casts and use size_t for depth in prefix_tree.
- Minor documentation and formatting refinements in sing_temp and io_base.