### PR TITLE
refactor: replace root_cvt with rb_root_cvt and no_rb_root_cvt for be…

### DIFF
--- a/include/cvt/cvt_facilities.h
+++ b/include/cvt/cvt_facilities.h
@@ -8,8 +8,8 @@ namespace IOv2
 {
     inline std::wstring to_wstring(const std::string& val, const std::string& locale_name)
     {
-        using cvt_type = code_cvt<root_cvt<mem_device<char>, true>, wchar_t>;
-        cvt_type tmp_cvt(make_root_cvt<true>(mem_device(val)), locale_name);
+        using cvt_type = code_cvt<rb_root_cvt<mem_device<char>>, wchar_t>;
+        cvt_type tmp_cvt(rb_root_cvt{mem_device(val)}, locale_name);
         tmp_cvt.bos();
         tmp_cvt.main_cont_beg();
         
@@ -27,8 +27,8 @@ namespace IOv2
 
     inline std::u32string to_u32string(const char* val, const std::string& locale_name)
     {
-        using cvt_type = code_cvt<root_cvt<mem_device<char>, true>, char32_t>;
-        cvt_type tmp_cvt(make_root_cvt<true>(mem_device(val)), locale_name);
+        using cvt_type = code_cvt<rb_root_cvt<mem_device<char>>, char32_t>;
+        cvt_type tmp_cvt(rb_root_cvt{mem_device(val)}, locale_name);
         tmp_cvt.bos();
         tmp_cvt.main_cont_beg();
         
@@ -46,8 +46,8 @@ namespace IOv2
 
     inline std::u32string to_u32string(const char8_t* val)
     {
-        using cvt_type = code_cvt<root_cvt<mem_device<char8_t>, true>, char32_t>;
-        cvt_type tmp_cvt(make_root_cvt<true>(mem_device(val)));
+        using cvt_type = code_cvt<rb_root_cvt<mem_device<char8_t>>, char32_t>;
+        cvt_type tmp_cvt(rb_root_cvt{mem_device(val)});
         tmp_cvt.bos();
         tmp_cvt.main_cont_beg();
         
@@ -65,8 +65,8 @@ namespace IOv2
 
     inline std::u8string to_u8string(const std::u32string& val)
     {
-        using cvt_type = code_cvt<root_cvt<mem_device<char8_t>, true>, char32_t>;
-        cvt_type tmp_cvt(make_root_cvt<true>(mem_device<char8_t>()));
+        using cvt_type = code_cvt<rb_root_cvt<mem_device<char8_t>>, char32_t>;
+        cvt_type tmp_cvt(rb_root_cvt{mem_device<char8_t>()});
         tmp_cvt.bos();
         tmp_cvt.main_cont_beg();
 
@@ -76,8 +76,8 @@ namespace IOv2
 
     inline std::u8string to_u8string(char32_t val)
     {
-        using cvt_type = code_cvt<root_cvt<mem_device<char8_t>, true>, char32_t>;
-        cvt_type tmp_cvt(make_root_cvt<true>(mem_device(u8"")));
+        using cvt_type = code_cvt<rb_root_cvt<mem_device<char8_t>>, char32_t>;
+        cvt_type tmp_cvt(rb_root_cvt{mem_device(u8"")});
         tmp_cvt.bos();
         tmp_cvt.main_cont_beg();
         

--- a/include/cvt/root_cvt.h
+++ b/include/cvt/root_cvt.h
@@ -33,6 +33,7 @@ class root_cvt
 public:
     constexpr static size_t s_buffer_length = 2048;
 
+    constexpr static bool s_has_buffer = HasInBuffer;
     using device_type = DeviceType;
     using internal_type = typename device_type::char_type;
     using external_type = typename device_type::char_type;
@@ -402,19 +403,26 @@ private:
     io_status                   m_io_status;
 };
 
-template <bool HasInBuffer, io_device DeviceType>
-auto make_root_cvt(DeviceType dev)
+template <io_device DeviceType>
+class rb_root_cvt : public root_cvt<DeviceType, true>
 {
-    return root_cvt<DeviceType, HasInBuffer>(std::move(dev));
-}
+    using root_cvt<DeviceType, true>::root_cvt;
+};
+
+template <io_device DeviceType>
+class no_rb_root_cvt : public root_cvt<DeviceType, false>
+{
+    using root_cvt<DeviceType, false>::root_cvt;
+};
 
 template <io_converter KernelType>
 class root_cvt_reader;
 
-template <io_device DeviceType>
-class root_cvt_reader<root_cvt<DeviceType, true>>
+template <io_converter KernelType>
+    requires (std::is_base_of_v<root_cvt<typename KernelType::device_type, true>, KernelType>)
+class root_cvt_reader<KernelType>
 {
-    using KernelType = root_cvt<DeviceType, true>;
+    using device_type = typename KernelType::device_type;
     using char_type = typename KernelType::internal_type;
 
 public:
@@ -431,7 +439,7 @@ public:
         if (to_max > m_buf_size)
             throw cvt_error("cvt_reader::get_buf fail, read size too large.");
 
-        if constexpr (dev_cpt::support_put<DeviceType>)
+        if constexpr (dev_cpt::support_put<device_type>)
         {
             if (m_kernel.m_io_status != io_status::input)
                 m_kernel.switch_to_get();
@@ -496,10 +504,11 @@ private:
 template <io_converter KernelType>
 class root_cvt_writer;
 
-template <io_device DeviceType, bool HasInBuffer>
-class root_cvt_writer<root_cvt<DeviceType, HasInBuffer>>
+template <io_converter KernelType>
+    requires (std::is_base_of_v<root_cvt<typename KernelType::device_type, KernelType::s_has_buffer>, KernelType>)
+class root_cvt_writer<KernelType>
 {
-    using KernelType = root_cvt<DeviceType, HasInBuffer>;
+    using device_type = typename KernelType::device_type;
     using char_type = typename KernelType::internal_type;
 
 public:
@@ -515,7 +524,7 @@ public:
         if (len > m_buf_size)
             throw cvt_error("root_cvt_writer::put_buf fail, write size too large.");
 
-        if constexpr (dev_cpt::support_get<DeviceType>)
+        if constexpr (dev_cpt::support_get<device_type>)
         {
             if (m_kernel.m_io_status != io_status::output)
                 m_kernel.switch_to_put();
@@ -553,16 +562,19 @@ private:
     const size_t m_buf_size;
 };
 
-template <io_device DeviceType, bool HasInBuffer>
-class cvt_io<root_cvt<DeviceType, HasInBuffer>>
+template <io_converter KernelType>
+class cvt_io;
+
+template <io_converter KernelType>
+    requires (std::is_base_of_v<root_cvt<typename KernelType::device_type, KernelType::s_has_buffer>, KernelType>)
+class cvt_io<KernelType>
 {
-    using KernelType = root_cvt<DeviceType, HasInBuffer>;
     using char_type = typename KernelType::internal_type;
 
 public:
     auto reader(KernelType& kernel, size_t buf_size)
     {
-        if constexpr (HasInBuffer)
+        if constexpr (KernelType::s_has_buffer)
         {
             if (buf_size > KernelType::s_buffer_length)
                 throw cvt_error("cvt_io::reader construction fail: buffer too large");

--- a/include/facet/messages_details.h
+++ b/include/facet/messages_details.h
@@ -350,7 +350,7 @@ private:
                 std::unordered_map<std::string, std::string> res;
                 auto tmp_dict = get_translate_dictionary(get_domain_file(domain, lang));
 
-                auto cvt = IOv2::code_cvt_creator<char, wchar_t>(cvt_ft).create(make_root_cvt<true>(mem_device{""}));
+                auto cvt = IOv2::code_cvt_creator<char, wchar_t>(cvt_ft).create(rb_root_cvt{mem_device{""}});
 
                 for (const auto& [k, v] : tmp_dict)
                 {

--- a/include/io/io_concepts.h
+++ b/include/io/io_concepts.h
@@ -9,7 +9,7 @@ namespace IOv2
 template <io_device TDevice, cvt_creator TCreator>
 struct ext_to_int_helper
 {
-    using RootCvt = decltype(make_root_cvt<true>(std::declval<TDevice>()));
+    using RootCvt = decltype(rb_root_cvt{std::declval<TDevice>()});
     using Kernel = decltype(std::declval<TCreator>().create(std::declval<RootCvt>()));
     using type = typename Kernel::internal_type;
 };

--- a/include/io/streambuf.h
+++ b/include/io/streambuf.h
@@ -21,29 +21,29 @@ public:
 
 public:
     explicit base_streambuf(TDevice dev) requires (IsOut)
-        : m_cvt(make_root_cvt<false>(std::move(dev)))
+        : m_cvt(no_rb_root_cvt{std::move(dev)})
     {
         init_cvt();
     }
 
     template <cvt_creator TCreator>
     base_streambuf(TDevice dev, const TCreator& creator) requires (IsOut)
-        : m_cvt(creator.create(make_root_cvt<false>(std::move(dev))))
+        : m_cvt(creator.create(no_rb_root_cvt{std::move(dev)}))
     {
         init_cvt();
     }
 
     explicit base_streambuf(TDevice dev, bool has_in_buf = true) requires (IsIn && !IsOut)
-        : m_cvt(has_in_buf ? runtime_cvt<TDevice, TChar>(make_root_cvt<true>(std::move(dev)))
-                           : runtime_cvt<TDevice, TChar>(make_root_cvt<false>(std::move(dev))))
+        : m_cvt(has_in_buf ? runtime_cvt<TDevice, TChar>(rb_root_cvt{std::move(dev)})
+                           : runtime_cvt<TDevice, TChar>(no_rb_root_cvt{std::move(dev)}))
     {
         init_cvt();
     }
 
     template <cvt_creator TCreator>
     base_streambuf(TDevice dev, const TCreator& creator, bool has_in_buf = true) requires (IsIn && !IsOut)
-        : m_cvt(has_in_buf ? runtime_cvt<TDevice, TChar>(creator.create(make_root_cvt<true>(std::move(dev))))
-                           : runtime_cvt<TDevice, TChar>(creator.create(make_root_cvt<false>(std::move(dev)))))
+        : m_cvt(has_in_buf ? runtime_cvt<TDevice, TChar>(creator.create(rb_root_cvt{std::move(dev)}))
+                           : runtime_cvt<TDevice, TChar>(creator.create(no_rb_root_cvt{std::move(dev)})))
     {
         init_cvt();
     }

--- a/test/cvt/code_cvt/code_cvt_mem_char8_t.cpp
+++ b/test/cvt/code_cvt/code_cvt_mem_char8_t.cpp
@@ -12,7 +12,7 @@ void test_code_cvt_mem_char8_t_gen_1()
     dump_info("Test code_cvt<memory<char8_t>> general case 1...");
     
     {
-        using CheckType = code_cvt<root_cvt<mem_device<char8_t>, true>, char32_t>;
+        using CheckType = code_cvt<rb_root_cvt<mem_device<char8_t>>, char32_t>;
         static_assert(io_converter<CheckType>);
         static_assert(std::is_same_v<CheckType::device_type, mem_device<char8_t>>);
         static_assert(std::is_same_v<CheckType::internal_type, char32_t>);
@@ -25,7 +25,7 @@ void test_code_cvt_mem_char8_t_gen_1()
     }
 
     {
-        using CheckType = code_cvt<root_cvt<mem_device<char8_t>, false>, char32_t>;
+        using CheckType = code_cvt<no_rb_root_cvt<mem_device<char8_t>>, char32_t>;
         static_assert(io_converter<CheckType>);
         static_assert(std::is_same_v<CheckType::device_type, mem_device<char8_t>>);
         static_assert(std::is_same_v<CheckType::internal_type, char32_t>);
@@ -87,12 +87,12 @@ void test_code_cvt_mem_char8_t_gen_2()
         }
     };
 
-    using CheckType = code_cvt<root_cvt<mem_device<char8_t>, true>, char32_t>;
+    using CheckType = code_cvt<rb_root_cvt<mem_device<char8_t>>, char32_t>;
 
-    CheckType obj1{make_root_cvt<true>(mem_device(e_lit))};
+    CheckType obj1{rb_root_cvt{mem_device(e_lit)}};
     helper(obj1);
 
-    runtime_cvt obj2{CheckType{make_root_cvt<true>(mem_device(e_lit))}};
+    runtime_cvt obj2{CheckType{rb_root_cvt{mem_device(e_lit)}}};
     helper(obj2);
 
     dump_info("Done\n");
@@ -150,11 +150,11 @@ void test_code_cvt_mem_char8_t_gen_3()
         }
     };
 
-    using CheckType = code_cvt<root_cvt<mem_device<char8_t>, true>, char32_t>;
-    CheckType obj1{make_root_cvt<true>(mem_device(e_lit))};
+    using CheckType = code_cvt<rb_root_cvt<mem_device<char8_t>>, char32_t>;
+    CheckType obj1{rb_root_cvt{mem_device(e_lit)}};
     helper(obj1);
 
-    runtime_cvt obj2{CheckType{make_root_cvt<true>(mem_device(e_lit))}};
+    runtime_cvt obj2{CheckType{rb_root_cvt{mem_device(e_lit)}}};
     helper(obj2);
 
     dump_info("Done\n");
@@ -209,11 +209,11 @@ void test_code_cvt_mem_char8_t_gen_4()
         if (obj.device().str() != e_lit) throw std::runtime_error("code_cvt<memory<char8_t>>::put response incorrect");
     };
 
-    using CheckType = code_cvt<root_cvt<mem_device<char8_t>, true>, char32_t>;
-    CheckType obj(make_root_cvt<true>(mem_device(u8"")));
+    using CheckType = code_cvt<rb_root_cvt<mem_device<char8_t>>, char32_t>;
+    CheckType obj(rb_root_cvt{mem_device(u8"")});
     helper(obj);
 
-    runtime_cvt obj2{CheckType{make_root_cvt<true>(mem_device(u8""))}};
+    runtime_cvt obj2{CheckType{rb_root_cvt{mem_device(u8"")}}};
     helper(obj2);
 
     dump_info("Done\n");
@@ -268,11 +268,11 @@ void test_code_cvt_mem_char8_t_gen_5()
         if (obj.device().str() != e_lit) throw std::runtime_error("code_cvt<memory<char8_t>>::put response incorrect");
     };
 
-    using CheckType = code_cvt<root_cvt<mem_device<char8_t>, true>, char32_t>;
-    CheckType obj(make_root_cvt<true>(mem_device(u8"")));
+    using CheckType = code_cvt<rb_root_cvt<mem_device<char8_t>>, char32_t>;
+    CheckType obj(rb_root_cvt{mem_device(u8"")});
     helper(obj);
 
-    runtime_cvt obj2{CheckType{make_root_cvt<true>(mem_device(u8""))}};
+    runtime_cvt obj2{CheckType{rb_root_cvt{mem_device(u8"")}}};
     helper(obj2);
 
     dump_info("Done\n");
@@ -292,11 +292,11 @@ void test_code_cvt_mem_char8_t_bos_1()
         if (obj.device().dtell() != 0) throw std::runtime_error("code_cvt<memory<char8_t>>::bos fail");
     };
     
-    using CheckType = code_cvt<root_cvt<mem_device<char8_t>, true>, char32_t>;
-    CheckType obj(make_root_cvt<true>(mem_device(u8"")));
+    using CheckType = code_cvt<rb_root_cvt<mem_device<char8_t>>, char32_t>;
+    CheckType obj(rb_root_cvt{mem_device(u8"")});
     helper(obj);
 
-    runtime_cvt obj2{CheckType{make_root_cvt<true>(mem_device(u8""))}};
+    runtime_cvt obj2{CheckType{rb_root_cvt{mem_device(u8"")}}};
     helper(obj2);
 
     dump_info("Done\n");
@@ -322,17 +322,17 @@ void test_code_cvt_mem_char8_t_bos_2()
         if (obj.detach().dtell() != 12) throw std::runtime_error("code_cvt<...char...>::bos fail");
     };
     
-    using CheckType = code_cvt<root_cvt<mem_device<char8_t>, true>, char32_t>;
+    using CheckType = code_cvt<rb_root_cvt<mem_device<char8_t>>, char32_t>;
     std::u8string info;
     info += u8'1'; info += u8'\x00'; info += u8'\x00'; info += u8'\x00';
     info += u8'2'; info += u8'\x00'; info += u8'\x00'; info += u8'\x00';
     info += u8'3'; info += u8'\x00'; info += u8'\x00'; info += u8'\x00';
     info += u8'4'; info += u8'\x00'; info += u8'\x00'; info += u8'\x00';
     info += u8'5'; info += u8'\x00'; info += u8'\x00'; info += u8'\x00';
-    CheckType obj(make_root_cvt<true>(mem_device(info)));
+    CheckType obj(rb_root_cvt{mem_device(info)});
     helper(obj);
 
-    runtime_cvt obj2{CheckType{make_root_cvt<true>(mem_device(info))}};
+    runtime_cvt obj2{CheckType{rb_root_cvt{mem_device(info)}}};
     helper(obj2);
 
     dump_info("Done\n");
@@ -356,7 +356,7 @@ void test_code_cvt_mem_char8_t_bos_3()
         if (obj.detach().dtell() != 12) throw std::runtime_error("code_cvt<memory<char8_t>>::bos fail");
     };
     
-    using CheckType = code_cvt<root_cvt<mem_device<char8_t>, true>, char32_t>;
+    using CheckType = code_cvt<rb_root_cvt<mem_device<char8_t>>, char32_t>;
     std::u8string info;
     info += u8'\x4e'; info += u8'\x67'; info += u8'\x00'; info += u8'\x00';
     info += u8'd';    info += u8'\x00'; info += u8'\x00'; info += u8'\x00';
@@ -364,10 +364,10 @@ void test_code_cvt_mem_char8_t_bos_3()
     info += u8'c';    info += u8'\x00'; info += u8'\x00'; info += u8'\x00';
     info += u8'p';    info += u8'\x00'; info += u8'\x00'; info += u8'\x00';
     info += u8'p';    info += u8'\x00'; info += u8'\x00'; info += u8'\x00';
-    CheckType obj(make_root_cvt<true>(mem_device(info)));
+    CheckType obj(rb_root_cvt{mem_device(info)});
     helper(obj);
 
-    runtime_cvt obj2{CheckType{make_root_cvt<true>(mem_device(info))}};
+    runtime_cvt obj2{CheckType{rb_root_cvt{mem_device(info)}}};
     helper(obj2);
 
     dump_info("Done\n");
@@ -396,11 +396,11 @@ void test_code_cvt_mem_char8_t_bos_4()
         if (dev.str() != info) throw std::runtime_error("code_cvt<memory<char8_t>>::bos fail");
     };
     
-    using CheckType = code_cvt<root_cvt<mem_device<char8_t>, true>, char32_t>;
-    CheckType obj(make_root_cvt<true>(mem_device(u8"")));
+    using CheckType = code_cvt<rb_root_cvt<mem_device<char8_t>>, char32_t>;
+    CheckType obj(rb_root_cvt{mem_device(u8"")});
     helper(obj);
 
-    runtime_cvt obj2{CheckType{make_root_cvt<true>(mem_device(u8""))}};
+    runtime_cvt obj2{CheckType{rb_root_cvt{mem_device(u8"")}}};
     helper(obj2);
 
     dump_info("Done\n");
@@ -430,11 +430,11 @@ void test_code_cvt_mem_char8_t_bos_5()
         if (dev.str() != info) throw std::runtime_error("code_cvt<memory<char8_t>>::bos fail");
     };
     
-    using CheckType = code_cvt<root_cvt<mem_device<char8_t>, true>, char32_t>;
-    CheckType obj(make_root_cvt<true>(mem_device(u8"")));
+    using CheckType = code_cvt<rb_root_cvt<mem_device<char8_t>>, char32_t>;
+    CheckType obj(rb_root_cvt{mem_device(u8"")});
     helper(obj);
 
-    runtime_cvt obj2{CheckType{make_root_cvt<true>(mem_device(u8""))}};
+    runtime_cvt obj2{CheckType{rb_root_cvt{mem_device(u8"")}}};
     helper(obj2);
 
     dump_info("Done\n");
@@ -490,11 +490,11 @@ void test_code_cvt_mem_char8_t_get_1()
         }
     };
 
-    using CheckType = code_cvt<root_cvt<mem_device<char8_t>, true>, char32_t>;
-    CheckType obj{make_root_cvt<true>(mem_device(e_lit))};
+    using CheckType = code_cvt<rb_root_cvt<mem_device<char8_t>>, char32_t>;
+    CheckType obj{rb_root_cvt{mem_device(e_lit)}};
     helper(obj);
 
-    runtime_cvt obj2{CheckType{make_root_cvt<true>(mem_device(e_lit))}};
+    runtime_cvt obj2{CheckType{rb_root_cvt{mem_device(e_lit)}}};
     helper(obj2);
 
     dump_info("Done\n");
@@ -550,11 +550,11 @@ void test_code_cvt_mem_char8_t_get_nra_1()
         }
     };
 
-    using CheckType = code_cvt<root_cvt<mem_device<char8_t>, false>, char32_t>;
-    CheckType obj{make_root_cvt<false>(mem_device(e_lit))};
+    using CheckType = code_cvt<no_rb_root_cvt<mem_device<char8_t>>, char32_t>;
+    CheckType obj{no_rb_root_cvt{mem_device(e_lit)}};
     helper(obj);
 
-    runtime_cvt obj2{CheckType{make_root_cvt<false>(mem_device(e_lit))}};
+    runtime_cvt obj2{CheckType{no_rb_root_cvt{mem_device(e_lit)}}};
     helper(obj2);
 
     dump_info("Done\n");
@@ -607,11 +607,11 @@ void test_code_cvt_mem_char8_t_put_1()
         if (obj.device().str() != e_lit) throw std::runtime_error("code_cvt<memory<char8_t>>::put response incorrect");
     };
 
-    using CheckType = code_cvt<root_cvt<mem_device<char8_t>, true>, char32_t>;
-    CheckType obj(make_root_cvt<true>(mem_device(u8"")));
+    using CheckType = code_cvt<rb_root_cvt<mem_device<char8_t>>, char32_t>;
+    CheckType obj(rb_root_cvt{mem_device(u8"")});
     helper(obj);
 
-    runtime_cvt obj2{CheckType{make_root_cvt<true>(mem_device(u8""))}};
+    runtime_cvt obj2{CheckType{rb_root_cvt{mem_device(u8"")}}};
     helper(obj2);
 
     dump_info("Done\n");
@@ -651,11 +651,11 @@ void test_code_cvt_mem_char8_t_put_2()
         if (obj.device().str() != e_lit) throw std::runtime_error("code_cvt<memory<char8_t>>::put response incorrect");
     };
 
-    using CheckType = code_cvt<root_cvt<mem_device<char8_t>, true>, char32_t>;
-    CheckType obj(make_root_cvt<true>(mem_device(u8"")));
+    using CheckType = code_cvt<rb_root_cvt<mem_device<char8_t>>, char32_t>;
+    CheckType obj(rb_root_cvt{mem_device(u8"")});
     helper(obj);
 
-    runtime_cvt obj2{CheckType{make_root_cvt<true>(mem_device(u8""))}};
+    runtime_cvt obj2{CheckType{rb_root_cvt{mem_device(u8"")}}};
     helper(obj2);
 
     dump_info("Done\n");
@@ -701,11 +701,11 @@ void test_code_cvt_mem_char8_t_flush_1()
         if (dev.str() != e_lit) throw std::runtime_error("code_cvt<memory<char8_t>>::put response incorrect");
     };
     
-    using CheckType = code_cvt<root_cvt<mem_device<char8_t>, true>, char32_t>;
-    CheckType obj(make_root_cvt<true>(mem_device(u8"")));
+    using CheckType = code_cvt<rb_root_cvt<mem_device<char8_t>>, char32_t>;
+    CheckType obj(rb_root_cvt{mem_device(u8"")});
     helper(obj);
 
-    runtime_cvt obj2{CheckType{make_root_cvt<true>(mem_device(u8""))}};
+    runtime_cvt obj2{CheckType{rb_root_cvt{mem_device(u8"")}}};
     helper(obj2);
 
     dump_info("Done\n");
@@ -763,11 +763,11 @@ void test_code_cvt_mem_char8_t_flush_2()
         if (obj.device().str() != e_lit) throw std::runtime_error("code_cvt<memory<char8_t>>::put response incorrect");
     };
 
-    using CheckType = code_cvt<root_cvt<mem_device<char8_t>, true>, char32_t>;
-    CheckType obj(make_root_cvt<true>(mem_device(u8"")));
+    using CheckType = code_cvt<rb_root_cvt<mem_device<char8_t>>, char32_t>;
+    CheckType obj(rb_root_cvt{mem_device(u8"")});
     helper(obj);
 
-    runtime_cvt obj2{CheckType{make_root_cvt<true>(mem_device(u8""))}};
+    runtime_cvt obj2{CheckType{rb_root_cvt{mem_device(u8"")}}};
     helper(obj2);
 
     dump_info("Done\n");
@@ -796,11 +796,11 @@ void test_code_cvt_mem_char8_t_seek_1()
         if (str != U"123456") throw std::runtime_error("code_cvt<memory<char8_t>>::get response incorrect");
     };
 
-    using CheckType = code_cvt<root_cvt<mem_device<char8_t>, true>, char32_t>;
-    CheckType obj(make_root_cvt<true>(mem_device(u8"123456")));
+    using CheckType = code_cvt<rb_root_cvt<mem_device<char8_t>>, char32_t>;
+    CheckType obj(rb_root_cvt{mem_device(u8"123456")});
     helper(obj);
 
-    runtime_cvt obj2{CheckType{make_root_cvt<true>(mem_device(u8"123456"))}};
+    runtime_cvt obj2{CheckType{rb_root_cvt{mem_device(u8"123456")}}};
     helper(obj2);
     dump_info("Done\n");
 }
@@ -840,11 +840,11 @@ void test_code_cvt_mem_char8_t_seek_2()
         if (obj.device().str() != u8"李x伟xy") std::runtime_error("code_cvt<memory<char8_t>> response incorrect");
     };
 
-    using CheckType = code_cvt<root_cvt<mem_device<char8_t>, true>, char32_t>;
-    CheckType obj(make_root_cvt<true>(mem_device(u8"")));
+    using CheckType = code_cvt<rb_root_cvt<mem_device<char8_t>>, char32_t>;
+    CheckType obj(rb_root_cvt{mem_device(u8"")});
     helper(obj);
 
-    runtime_cvt obj2{CheckType{make_root_cvt<true>(mem_device(u8""))}};
+    runtime_cvt obj2{CheckType{rb_root_cvt{mem_device(u8"")}}};
     helper(obj2);
 
     dump_info("Done\n");
@@ -873,11 +873,11 @@ void test_code_cvt_mem_char8_t_rseek_1()
         if (obj.device().str() != u8"123456") std::runtime_error("code_cvt<memory<char8_t>> response incorrect");
     };
     
-    using CheckType = code_cvt<root_cvt<mem_device<char8_t>, true>, char32_t>;
-    CheckType obj(make_root_cvt<true>(mem_device(u8"123456")));
+    using CheckType = code_cvt<rb_root_cvt<mem_device<char8_t>>, char32_t>;
+    CheckType obj(rb_root_cvt{mem_device(u8"123456")});
     helper(obj);
 
-    runtime_cvt obj2{CheckType{make_root_cvt<true>(mem_device(u8"123456"))}};
+    runtime_cvt obj2{CheckType{rb_root_cvt{mem_device(u8"123456")}}};
     helper(obj2);
 
     dump_info("Done\n");
@@ -918,11 +918,11 @@ void test_code_cvt_mem_char8_t_rseek_2()
         if (obj.device().str() != u8"李x伟xy") std::runtime_error("code_cvt<memory<char8_t>> response incorrect");
     };
 
-    using CheckType = code_cvt<root_cvt<mem_device<char8_t>, true>, char32_t>;
-    CheckType obj(make_root_cvt<true>(mem_device(u8"")));
+    using CheckType = code_cvt<rb_root_cvt<mem_device<char8_t>>, char32_t>;
+    CheckType obj(rb_root_cvt{mem_device(u8"")});
     helper(obj);
 
-    runtime_cvt obj2{CheckType{make_root_cvt<true>(mem_device(u8""))}};
+    runtime_cvt obj2{CheckType{rb_root_cvt{mem_device(u8"")}}};
     helper(obj2);
 
     dump_info("Done\n");
@@ -981,11 +981,11 @@ void test_code_cvt_mem_char8_t_io_1()
         if (obj.device().str() != info) throw std::runtime_error("code_cvt<memory<char8_t>> response incorrect");
     };
     
-    using CheckType = code_cvt<root_cvt<mem_device<char8_t>, true>, char32_t>;
-    CheckType obj(make_root_cvt<true>(mem_device(u8"")));
+    using CheckType = code_cvt<rb_root_cvt<mem_device<char8_t>>, char32_t>;
+    CheckType obj(rb_root_cvt{mem_device(u8"")});
     helper(obj);
 
-    runtime_cvt obj2{CheckType{make_root_cvt<true>(mem_device(u8""))}};
+    runtime_cvt obj2{CheckType{rb_root_cvt{mem_device(u8"")}}};
     helper(obj2);
 
     dump_info("Done\n");
@@ -1043,10 +1043,10 @@ void test_code_cvt_mem_char8_t_io_2()
     };
 
     code_cvt_creator<char8_t, char32_t> creator;
-    auto obj = creator.create(make_root_cvt<false>(mem_device(info)));
+    auto obj = creator.create(no_rb_root_cvt{mem_device(info)});
     helper(obj);
 
-    runtime_cvt obj2(creator.create(make_root_cvt<false>(mem_device(info))));
+    runtime_cvt obj2(creator.create(no_rb_root_cvt{mem_device(info)}));
     helper(obj2);
 
     dump_info("Done\n");

--- a/test/cvt/code_cvt/code_cvt_mem_char8_t_wchar_t.cpp
+++ b/test/cvt/code_cvt/code_cvt_mem_char8_t_wchar_t.cpp
@@ -12,7 +12,7 @@ void test_code_cvt_mem_char8_t_wchar_t_gen_1()
     dump_info("Test code_cvt<memory<char8_t>, wchar_t> general case 1...");
     
     {
-        using CheckType = code_cvt<root_cvt<mem_device<char8_t>, true>, wchar_t>;
+        using CheckType = code_cvt<rb_root_cvt<mem_device<char8_t>>, wchar_t>;
         static_assert(io_converter<CheckType>);
         static_assert(std::is_same_v<CheckType::device_type, mem_device<char8_t>>);
         static_assert(std::is_same_v<CheckType::internal_type, wchar_t>);
@@ -25,7 +25,7 @@ void test_code_cvt_mem_char8_t_wchar_t_gen_1()
     }
 
     {
-        using CheckType = code_cvt<root_cvt<mem_device<char8_t>, false>, wchar_t>;
+        using CheckType = code_cvt<no_rb_root_cvt<mem_device<char8_t>>, wchar_t>;
         static_assert(io_converter<CheckType>);
         static_assert(std::is_same_v<CheckType::device_type, mem_device<char8_t>>);
         static_assert(std::is_same_v<CheckType::internal_type, wchar_t>);
@@ -87,12 +87,12 @@ void test_code_cvt_mem_char8_t_wchar_t_gen_2()
         }
     };
 
-    using CheckType = code_cvt<root_cvt<mem_device<char8_t>, true>, wchar_t>;
+    using CheckType = code_cvt<rb_root_cvt<mem_device<char8_t>>, wchar_t>;
 
-    CheckType obj1{make_root_cvt<true>(mem_device(e_lit))};
+    CheckType obj1{rb_root_cvt{mem_device(e_lit)}};
     helper(obj1);
 
-    runtime_cvt obj2{CheckType{make_root_cvt<true>(mem_device(e_lit))}};
+    runtime_cvt obj2{CheckType{rb_root_cvt{mem_device(e_lit)}}};
     helper(obj2);
 
     dump_info("Done\n");
@@ -150,11 +150,11 @@ void test_code_cvt_mem_char8_t_wchar_t_gen_3()
         }
     };
 
-    using CheckType = code_cvt<root_cvt<mem_device<char8_t>, true>, wchar_t>;
-    CheckType obj1{make_root_cvt<true>(mem_device(e_lit))};
+    using CheckType = code_cvt<rb_root_cvt<mem_device<char8_t>>, wchar_t>;
+    CheckType obj1{rb_root_cvt{mem_device(e_lit)}};
     helper(obj1);
 
-    runtime_cvt obj2{CheckType{make_root_cvt<true>(mem_device(e_lit))}};
+    runtime_cvt obj2{CheckType{rb_root_cvt{mem_device(e_lit)}}};
     helper(obj2);
 
     dump_info("Done\n");
@@ -209,11 +209,11 @@ void test_code_cvt_mem_char8_t_wchar_t_gen_4()
         if (obj.device().str() != e_lit) throw std::runtime_error("code_cvt<memory<char8_t>>::put response incorrect");
     };
 
-    using CheckType = code_cvt<root_cvt<mem_device<char8_t>, true>, wchar_t>;
-    CheckType obj(make_root_cvt<true>(mem_device(u8"")));
+    using CheckType = code_cvt<rb_root_cvt<mem_device<char8_t>>, wchar_t>;
+    CheckType obj(rb_root_cvt{mem_device(u8"")});
     helper(obj);
 
-    runtime_cvt obj2{CheckType{make_root_cvt<true>(mem_device(u8""))}};
+    runtime_cvt obj2{CheckType{rb_root_cvt{mem_device(u8"")}}};
     helper(obj2);
 
     dump_info("Done\n");
@@ -268,11 +268,11 @@ void test_code_cvt_mem_char8_t_wchar_t_gen_5()
         if (obj.device().str() != e_lit) throw std::runtime_error("code_cvt<memory<char8_t>>::put response incorrect");
     };
 
-    using CheckType = code_cvt<root_cvt<mem_device<char8_t>, true>, wchar_t>;
-    CheckType obj(make_root_cvt<true>(mem_device(u8"")));
+    using CheckType = code_cvt<rb_root_cvt<mem_device<char8_t>>, wchar_t>;
+    CheckType obj(rb_root_cvt{mem_device(u8"")});
     helper(obj);
 
-    runtime_cvt obj2{CheckType{make_root_cvt<true>(mem_device(u8""))}};
+    runtime_cvt obj2{CheckType{rb_root_cvt{mem_device(u8"")}}};
     helper(obj2);
 
     dump_info("Done\n");
@@ -292,11 +292,11 @@ void test_code_cvt_mem_char8_t_wchar_t_bos_1()
         if (obj.device().dtell() != 0) throw std::runtime_error("code_cvt<memory<char8_t>>::bos fail");
     };
     
-    using CheckType = code_cvt<root_cvt<mem_device<char8_t>, true>, wchar_t>;
-    CheckType obj(make_root_cvt<true>(mem_device(u8"")));
+    using CheckType = code_cvt<rb_root_cvt<mem_device<char8_t>>, wchar_t>;
+    CheckType obj(rb_root_cvt{mem_device(u8"")});
     helper(obj);
 
-    runtime_cvt obj2{CheckType{make_root_cvt<true>(mem_device(u8""))}};
+    runtime_cvt obj2{CheckType{rb_root_cvt{mem_device(u8"")}}};
     helper(obj2);
 
     dump_info("Done\n");
@@ -322,17 +322,17 @@ void test_code_cvt_mem_char8_t_wchar_t_bos_2()
         if (obj.detach().dtell() != 12) throw std::runtime_error("code_cvt<...char...>::bos fail");
     };
     
-    using CheckType = code_cvt<root_cvt<mem_device<char8_t>, true>, wchar_t>;
+    using CheckType = code_cvt<rb_root_cvt<mem_device<char8_t>>, wchar_t>;
     std::u8string info;
     info += u8'1'; info += u8'\x00'; info += u8'\x00'; info += u8'\x00';
     info += u8'2'; info += u8'\x00'; info += u8'\x00'; info += u8'\x00';
     info += u8'3'; info += u8'\x00'; info += u8'\x00'; info += u8'\x00';
     info += u8'4'; info += u8'\x00'; info += u8'\x00'; info += u8'\x00';
     info += u8'5'; info += u8'\x00'; info += u8'\x00'; info += u8'\x00';
-    CheckType obj(make_root_cvt<true>(mem_device(info)));
+    CheckType obj(rb_root_cvt{mem_device(info)});
     helper(obj);
 
-    runtime_cvt obj2{CheckType{make_root_cvt<true>(mem_device(info))}};
+    runtime_cvt obj2{CheckType{rb_root_cvt{mem_device(info)}}};
     helper(obj2);
 
     dump_info("Done\n");
@@ -356,7 +356,7 @@ void test_code_cvt_mem_char8_t_wchar_t_bos_3()
         if (obj.detach().dtell() != 12) throw std::runtime_error("code_cvt<memory<char8_t>>::bos fail");
     };
     
-    using CheckType = code_cvt<root_cvt<mem_device<char8_t>, true>, wchar_t>;
+    using CheckType = code_cvt<rb_root_cvt<mem_device<char8_t>>, wchar_t>;
     std::u8string info;
     info += u8'\x4e'; info += u8'\x67'; info += u8'\x00'; info += u8'\x00';
     info += u8'd';    info += u8'\x00'; info += u8'\x00'; info += u8'\x00';
@@ -364,10 +364,10 @@ void test_code_cvt_mem_char8_t_wchar_t_bos_3()
     info += u8'c';    info += u8'\x00'; info += u8'\x00'; info += u8'\x00';
     info += u8'p';    info += u8'\x00'; info += u8'\x00'; info += u8'\x00';
     info += u8'p';    info += u8'\x00'; info += u8'\x00'; info += u8'\x00';
-    CheckType obj(make_root_cvt<true>(mem_device(info)));
+    CheckType obj(rb_root_cvt{mem_device(info)});
     helper(obj);
 
-    runtime_cvt obj2{CheckType{make_root_cvt<true>(mem_device(info))}};
+    runtime_cvt obj2{CheckType{rb_root_cvt{mem_device(info)}}};
     helper(obj2);
 
     dump_info("Done\n");
@@ -396,11 +396,11 @@ void test_code_cvt_mem_char8_t_wchar_t_bos_4()
         if (dev.str() != info) throw std::runtime_error("code_cvt<memory<char8_t>>::bos fail");
     };
     
-    using CheckType = code_cvt<root_cvt<mem_device<char8_t>, true>, wchar_t>;
-    CheckType obj(make_root_cvt<true>(mem_device(u8"")));
+    using CheckType = code_cvt<rb_root_cvt<mem_device<char8_t>>, wchar_t>;
+    CheckType obj(rb_root_cvt{mem_device(u8"")});
     helper(obj);
 
-    runtime_cvt obj2{CheckType{make_root_cvt<true>(mem_device(u8""))}};
+    runtime_cvt obj2{CheckType{rb_root_cvt{mem_device(u8"")}}};
     helper(obj2);
 
     dump_info("Done\n");
@@ -430,11 +430,11 @@ void test_code_cvt_mem_char8_t_wchar_t_bos_5()
         if (dev.str() != info) throw std::runtime_error("code_cvt<memory<char8_t>>::bos fail");
     };
     
-    using CheckType = code_cvt<root_cvt<mem_device<char8_t>, true>, wchar_t>;
-    CheckType obj(make_root_cvt<true>(mem_device(u8"")));
+    using CheckType = code_cvt<rb_root_cvt<mem_device<char8_t>>, wchar_t>;
+    CheckType obj(rb_root_cvt{mem_device(u8"")});
     helper(obj);
 
-    runtime_cvt obj2{CheckType{make_root_cvt<true>(mem_device(u8""))}};
+    runtime_cvt obj2{CheckType{rb_root_cvt{mem_device(u8"")}}};
     helper(obj2);
 
     dump_info("Done\n");
@@ -490,11 +490,11 @@ void test_code_cvt_mem_char8_t_wchar_t_get_1()
         }
     };
 
-    using CheckType = code_cvt<root_cvt<mem_device<char8_t>, true>, wchar_t>;
-    CheckType obj{make_root_cvt<true>(mem_device(e_lit))};
+    using CheckType = code_cvt<rb_root_cvt<mem_device<char8_t>>, wchar_t>;
+    CheckType obj{rb_root_cvt{mem_device(e_lit)}};
     helper(obj);
 
-    runtime_cvt obj2{CheckType{make_root_cvt<true>(mem_device(e_lit))}};
+    runtime_cvt obj2{CheckType{rb_root_cvt{mem_device(e_lit)}}};
     helper(obj2);
 
     dump_info("Done\n");
@@ -550,11 +550,11 @@ void test_code_cvt_mem_char8_t_wchar_t_get_nra_1()
         }
     };
 
-    using CheckType = code_cvt<root_cvt<mem_device<char8_t>, false>, wchar_t>;
-    CheckType obj{make_root_cvt<false>(mem_device(e_lit))};
+    using CheckType = code_cvt<no_rb_root_cvt<mem_device<char8_t>>, wchar_t>;
+    CheckType obj{no_rb_root_cvt{mem_device(e_lit)}};
     helper(obj);
 
-    runtime_cvt obj2{CheckType{make_root_cvt<false>(mem_device(e_lit))}};
+    runtime_cvt obj2{CheckType{no_rb_root_cvt{mem_device(e_lit)}}};
     helper(obj2);
 
     dump_info("Done\n");
@@ -607,11 +607,11 @@ void test_code_cvt_mem_char8_t_wchar_t_put_1()
         if (obj.device().str() != e_lit) throw std::runtime_error("code_cvt<memory<char8_t>>::put response incorrect");
     };
 
-    using CheckType = code_cvt<root_cvt<mem_device<char8_t>, true>, wchar_t>;
-    CheckType obj(make_root_cvt<true>(mem_device(u8"")));
+    using CheckType = code_cvt<rb_root_cvt<mem_device<char8_t>>, wchar_t>;
+    CheckType obj(rb_root_cvt{mem_device(u8"")});
     helper(obj);
 
-    runtime_cvt obj2{CheckType{make_root_cvt<true>(mem_device(u8""))}};
+    runtime_cvt obj2{CheckType{rb_root_cvt{mem_device(u8"")}}};
     helper(obj2);
 
     dump_info("Done\n");
@@ -651,11 +651,11 @@ void test_code_cvt_mem_char8_t_wchar_t_put_2()
         if (obj.device().str() != e_lit) throw std::runtime_error("code_cvt<memory<char8_t>>::put response incorrect");
     };
 
-    using CheckType = code_cvt<root_cvt<mem_device<char8_t>, true>, wchar_t>;
-    CheckType obj(make_root_cvt<true>(mem_device(u8"")));
+    using CheckType = code_cvt<rb_root_cvt<mem_device<char8_t>>, wchar_t>;
+    CheckType obj(rb_root_cvt{mem_device(u8"")});
     helper(obj);
 
-    runtime_cvt obj2{CheckType{make_root_cvt<true>(mem_device(u8""))}};
+    runtime_cvt obj2{CheckType{rb_root_cvt{mem_device(u8"")}}};
     helper(obj2);
 
     dump_info("Done\n");
@@ -701,11 +701,11 @@ void test_code_cvt_mem_char8_t_wchar_t_flush_1()
         if (dev.str() != e_lit) throw std::runtime_error("code_cvt<memory<char8_t>>::put response incorrect");
     };
     
-    using CheckType = code_cvt<root_cvt<mem_device<char8_t>, true>, wchar_t>;
-    CheckType obj(make_root_cvt<true>(mem_device(u8"")));
+    using CheckType = code_cvt<rb_root_cvt<mem_device<char8_t>>, wchar_t>;
+    CheckType obj(rb_root_cvt{mem_device(u8"")});
     helper(obj);
 
-    runtime_cvt obj2{CheckType{make_root_cvt<true>(mem_device(u8""))}};
+    runtime_cvt obj2{CheckType{rb_root_cvt{mem_device(u8"")}}};
     helper(obj2);
 
     dump_info("Done\n");
@@ -763,11 +763,11 @@ void test_code_cvt_mem_char8_t_wchar_t_flush_2()
         if (obj.device().str() != e_lit) throw std::runtime_error("code_cvt<memory<char8_t>>::put response incorrect");
     };
 
-    using CheckType = code_cvt<root_cvt<mem_device<char8_t>, true>, wchar_t>;
-    CheckType obj(make_root_cvt<true>(mem_device(u8"")));
+    using CheckType = code_cvt<rb_root_cvt<mem_device<char8_t>>, wchar_t>;
+    CheckType obj(rb_root_cvt{mem_device(u8"")});
     helper(obj);
 
-    runtime_cvt obj2{CheckType{make_root_cvt<true>(mem_device(u8""))}};
+    runtime_cvt obj2{CheckType{rb_root_cvt{mem_device(u8"")}}};
     helper(obj2);
 
     dump_info("Done\n");
@@ -796,11 +796,11 @@ void test_code_cvt_mem_char8_t_wchar_t_seek_1()
         if (str != L"123456") throw std::runtime_error("code_cvt<memory<char8_t>>::get response incorrect");
     };
 
-    using CheckType = code_cvt<root_cvt<mem_device<char8_t>, true>, wchar_t>;
-    CheckType obj(make_root_cvt<true>(mem_device(u8"123456")));
+    using CheckType = code_cvt<rb_root_cvt<mem_device<char8_t>>, wchar_t>;
+    CheckType obj(rb_root_cvt{mem_device(u8"123456")});
     helper(obj);
 
-    runtime_cvt obj2{CheckType{make_root_cvt<true>(mem_device(u8"123456"))}};
+    runtime_cvt obj2{CheckType{rb_root_cvt{mem_device(u8"123456")}}};
     helper(obj2);
     dump_info("Done\n");
 }
@@ -840,11 +840,11 @@ void test_code_cvt_mem_char8_t_wchar_t_seek_2()
         if (obj.device().str() != u8"李x伟xy") std::runtime_error("code_cvt<memory<char8_t>> response incorrect");
     };
 
-    using CheckType = code_cvt<root_cvt<mem_device<char8_t>, true>, wchar_t>;
-    CheckType obj(make_root_cvt<true>(mem_device(u8"")));
+    using CheckType = code_cvt<rb_root_cvt<mem_device<char8_t>>, wchar_t>;
+    CheckType obj(rb_root_cvt{mem_device(u8"")});
     helper(obj);
 
-    runtime_cvt obj2{CheckType{make_root_cvt<true>(mem_device(u8""))}};
+    runtime_cvt obj2{CheckType{rb_root_cvt{mem_device(u8"")}}};
     helper(obj2);
 
     dump_info("Done\n");
@@ -873,11 +873,11 @@ void test_code_cvt_mem_char8_t_wchar_t_rseek_1()
         if (obj.device().str() != u8"123456") std::runtime_error("code_cvt<memory<char8_t>> response incorrect");
     };
     
-    using CheckType = code_cvt<root_cvt<mem_device<char8_t>, true>, wchar_t>;
-    CheckType obj(make_root_cvt<true>(mem_device(u8"123456")));
+    using CheckType = code_cvt<rb_root_cvt<mem_device<char8_t>>, wchar_t>;
+    CheckType obj(rb_root_cvt{mem_device(u8"123456")});
     helper(obj);
 
-    runtime_cvt obj2{CheckType{make_root_cvt<true>(mem_device(u8"123456"))}};
+    runtime_cvt obj2{CheckType{rb_root_cvt{mem_device(u8"123456")}}};
     helper(obj2);
 
     dump_info("Done\n");
@@ -918,11 +918,11 @@ void test_code_cvt_mem_char8_t_wchar_t_rseek_2()
         if (obj.device().str() != u8"李x伟xy") std::runtime_error("code_cvt<memory<char8_t>> response incorrect");
     };
 
-    using CheckType = code_cvt<root_cvt<mem_device<char8_t>, true>, wchar_t>;
-    CheckType obj(make_root_cvt<true>(mem_device(u8"")));
+    using CheckType = code_cvt<rb_root_cvt<mem_device<char8_t>>, wchar_t>;
+    CheckType obj(rb_root_cvt{mem_device(u8"")});
     helper(obj);
 
-    runtime_cvt obj2{CheckType{make_root_cvt<true>(mem_device(u8""))}};
+    runtime_cvt obj2{CheckType{rb_root_cvt{mem_device(u8"")}}};
     helper(obj2);
 
     dump_info("Done\n");
@@ -981,11 +981,11 @@ void test_code_cvt_mem_char8_t_wchar_t_io_1()
         if (obj.device().str() != info) throw std::runtime_error("code_cvt<memory<char8_t>> response incorrect");
     };
     
-    using CheckType = code_cvt<root_cvt<mem_device<char8_t>, true>, wchar_t>;
-    CheckType obj(make_root_cvt<true>(mem_device(u8"")));
+    using CheckType = code_cvt<rb_root_cvt<mem_device<char8_t>>, wchar_t>;
+    CheckType obj(rb_root_cvt{mem_device(u8"")});
     helper(obj);
 
-    runtime_cvt obj2{CheckType{make_root_cvt<true>(mem_device(u8""))}};
+    runtime_cvt obj2{CheckType{rb_root_cvt{mem_device(u8"")}}};
     helper(obj2);
 
     dump_info("Done\n");
@@ -1043,10 +1043,10 @@ void test_code_cvt_mem_char8_t_wchar_t_io_2()
     };
 
     code_cvt_creator<char8_t, wchar_t> creator;
-    auto obj = creator.create(make_root_cvt<false>(mem_device(info)));
+    auto obj = creator.create(no_rb_root_cvt{mem_device(info)});
     helper(obj);
 
-    runtime_cvt obj2(creator.create(make_root_cvt<false>(mem_device(info))));
+    runtime_cvt obj2(creator.create(no_rb_root_cvt{mem_device(info)}));
     helper(obj2);
 
     dump_info("Done\n");

--- a/test/cvt/code_cvt/code_cvt_mem_char_char32_t.cpp
+++ b/test/cvt/code_cvt/code_cvt_mem_char_char32_t.cpp
@@ -12,7 +12,7 @@ void test_code_cvt_mem_char_gen_1()
     dump_info("Test code_cvt<memory<char>, char32_t> general case 1...");
     
     {
-        using CheckType = code_cvt<root_cvt<mem_device<char>, true>, char32_t>;
+        using CheckType = code_cvt<rb_root_cvt<mem_device<char>>, char32_t>;
         static_assert(io_converter<CheckType>);
         static_assert(std::is_same_v<CheckType::device_type, mem_device<char>>);
         static_assert(std::is_same_v<CheckType::internal_type, char32_t>);
@@ -25,7 +25,7 @@ void test_code_cvt_mem_char_gen_1()
     }
     
     {
-        using CheckType = code_cvt<root_cvt<mem_device<char>, false>, char32_t>;
+        using CheckType = code_cvt<rb_root_cvt<mem_device<char>>, char32_t>;
         static_assert(io_converter<CheckType>);
         static_assert(std::is_same_v<CheckType::device_type, mem_device<char>>);
         static_assert(std::is_same_v<CheckType::internal_type, char32_t>);
@@ -33,7 +33,7 @@ void test_code_cvt_mem_char_gen_1()
     }
     
     {
-        using CheckType = code_cvt<root_cvt<mem_device<char>, true>, wchar_t>;
+        using CheckType = code_cvt<rb_root_cvt<mem_device<char>>, wchar_t>;
         static_assert(io_converter<CheckType>);
         static_assert(std::is_same_v<CheckType::device_type, mem_device<char>>);
         static_assert(std::is_same_v<CheckType::internal_type, wchar_t>);
@@ -95,12 +95,12 @@ void test_code_cvt_mem_char_gen_2()
         }
     };
 
-    using CheckType = code_cvt<root_cvt<mem_device<char>, true>, char32_t>;
+    using CheckType = code_cvt<rb_root_cvt<mem_device<char>>, char32_t>;
 
-    CheckType obj1{make_root_cvt<true>(mem_device(e_lit)), "zh_CN.UTF-8"};
+    CheckType obj1{rb_root_cvt{mem_device(e_lit)}, "zh_CN.UTF-8"};
     helper(obj1);
 
-    runtime_cvt obj2{CheckType{make_root_cvt<true>(mem_device(e_lit)), "zh_CN.UTF-8"}};
+    runtime_cvt obj2{CheckType{rb_root_cvt{mem_device(e_lit)}, "zh_CN.UTF-8"}};
     helper(obj2);
 
     dump_info("Done\n");
@@ -158,11 +158,11 @@ void test_code_cvt_mem_char_gen_3()
         }
     };
 
-    using CheckType = code_cvt<root_cvt<mem_device<char>, true>, char32_t>;
-    CheckType obj1{make_root_cvt<true>(mem_device(e_lit)), "zh_CN.UTF-8"};
+    using CheckType = code_cvt<rb_root_cvt<mem_device<char>>, char32_t>;
+    CheckType obj1{rb_root_cvt{mem_device(e_lit)}, "zh_CN.UTF-8"};
     helper(obj1);
 
-    runtime_cvt obj2{CheckType{make_root_cvt<true>(mem_device(e_lit)), "zh_CN.UTF-8"}};
+    runtime_cvt obj2{CheckType{rb_root_cvt{mem_device(e_lit)}, "zh_CN.UTF-8"}};
     helper(obj2);
 
     dump_info("Done\n");
@@ -218,11 +218,11 @@ void test_code_cvt_mem_char_gen_4()
         if (dev.str() != e_lit) throw std::runtime_error("code_cvt<memory<char>, char32_t>::put response incorrect");
     };
 
-    using CheckType = code_cvt<root_cvt<mem_device<char>, true>, char32_t>;
-    CheckType obj1{make_root_cvt<true>(mem_device("")), "zh_CN.UTF-8"};
+    using CheckType = code_cvt<rb_root_cvt<mem_device<char>>, char32_t>;
+    CheckType obj1{rb_root_cvt{mem_device("")}, "zh_CN.UTF-8"};
     helper(obj1);
 
-    runtime_cvt obj2{CheckType{make_root_cvt<true>(mem_device("")), "zh_CN.UTF-8"}};
+    runtime_cvt obj2{CheckType{rb_root_cvt{mem_device("")}, "zh_CN.UTF-8"}};
     helper(obj2);
 
     dump_info("Done\n");
@@ -278,11 +278,11 @@ void test_code_cvt_mem_char_gen_5()
         if (dev.str() != e_lit) throw std::runtime_error("code_cvt<memory<char>, char32_t>::put response incorrect");
     };
 
-    using CheckType = code_cvt<root_cvt<mem_device<char>, true>, char32_t>;
-    CheckType obj1(make_root_cvt<true>(mem_device("")), "zh_CN.UTF-8");
+    using CheckType = code_cvt<rb_root_cvt<mem_device<char>>, char32_t>;
+    CheckType obj1(rb_root_cvt{mem_device("")}, "zh_CN.UTF-8");
     helper(obj1);
     
-    runtime_cvt obj2{CheckType{make_root_cvt<true>(mem_device("")), "zh_CN.UTF-8"}};
+    runtime_cvt obj2{CheckType{rb_root_cvt{mem_device("")}, "zh_CN.UTF-8"}};
     helper(obj2);
 
     dump_info("Done\n");
@@ -303,11 +303,11 @@ void test_code_cvt_mem_char_bos_1()
         if (dev.dtell() != 0) throw std::runtime_error("code_cvt<memory<char>, char32_t>::bos fail");
     };
     
-    using CheckType = code_cvt<root_cvt<mem_device<char>, true>, char32_t>;
-    CheckType obj1(make_root_cvt<true>(mem_device("")), "zh_CN.UTF-8");
+    using CheckType = code_cvt<rb_root_cvt<mem_device<char>>, char32_t>;
+    CheckType obj1(rb_root_cvt{mem_device("")}, "zh_CN.UTF-8");
     helper(obj1);
     
-    runtime_cvt obj2{CheckType{make_root_cvt<true>(mem_device("")), "zh_CN.UTF-8"}};
+    runtime_cvt obj2{CheckType{rb_root_cvt{mem_device("")}, "zh_CN.UTF-8"}};
     helper(obj2);
 
     dump_info("Done\n");
@@ -334,17 +334,17 @@ void test_code_cvt_mem_char_bos_2()
         if (dev.dtell() != 12) throw std::runtime_error("code_cvt<memory<char>, char32_t>::bos fail");
     };
     
-    using CheckType = code_cvt<root_cvt<mem_device<char>, false>, char32_t>;
+    using CheckType = code_cvt<no_rb_root_cvt<mem_device<char>>, char32_t>;
     std::string info;
     info += '1'; info += '\x00'; info += '\x00'; info += '\x00';
     info += '2'; info += '\x00'; info += '\x00'; info += '\x00';
     info += '3'; info += '\x00'; info += '\x00'; info += '\x00';
     info += '4'; info += '\x00'; info += '\x00'; info += '\x00';
     info += '5'; info += '\x00'; info += '\x00'; info += '\x00';
-    CheckType obj(make_root_cvt<false>(mem_device(info)), "zh_CN.UTF-8");
+    CheckType obj(no_rb_root_cvt{mem_device(info)}, "zh_CN.UTF-8");
     helper(obj);
     
-    runtime_cvt obj2{CheckType{make_root_cvt<false>(mem_device(info)), "zh_CN.UTF-8"}};
+    runtime_cvt obj2{CheckType{no_rb_root_cvt{mem_device(info)}, "zh_CN.UTF-8"}};
     helper(obj2);
 
     dump_info("Done\n");
@@ -371,7 +371,7 @@ void test_code_cvt_mem_char_bos_3()
         if (dev.dtell() != 12) throw std::runtime_error("code_cvt<memory<char>, char32_t>::bos fail");
     };
     
-    using CheckType = code_cvt<root_cvt<mem_device<char>, true>, char32_t>;
+    using CheckType = code_cvt<rb_root_cvt<mem_device<char>>, char32_t>;
     std::string info;
     info += '\x4e'; info += '\x67'; info += '\x00'; info += '\x00';
     info += 'd'; info += '\x00'; info += '\x00'; info += '\x00';
@@ -379,10 +379,10 @@ void test_code_cvt_mem_char_bos_3()
     info += 'c'; info += '\x00'; info += '\x00'; info += '\x00';
     info += 'p'; info += '\x00'; info += '\x00'; info += '\x00';
     info += 'p'; info += '\x00'; info += '\x00'; info += '\x00';
-    CheckType obj(make_root_cvt<true>(mem_device(info)), "zh_CN.UTF-8");
+    CheckType obj(rb_root_cvt{mem_device(info)}, "zh_CN.UTF-8");
     helper(obj);
 
-    runtime_cvt obj2{CheckType{make_root_cvt<true>(mem_device(info)), "zh_CN.UTF-8"}};
+    runtime_cvt obj2{CheckType{rb_root_cvt{mem_device(info)}, "zh_CN.UTF-8"}};
     helper(obj2);
 
     dump_info("Done\n");
@@ -412,11 +412,11 @@ void test_code_cvt_mem_char_bos_4()
         if (dev.str() != info) throw std::runtime_error("code_cvt<memory<char>, char32_t>::bos fail");
     };
     
-    using CheckType = code_cvt<root_cvt<mem_device<char>, true>, char32_t>;
-    CheckType obj(make_root_cvt<true>(mem_device("")), "zh_CN.UTF-8");
+    using CheckType = code_cvt<rb_root_cvt<mem_device<char>>, char32_t>;
+    CheckType obj(rb_root_cvt{mem_device("")}, "zh_CN.UTF-8");
     helper(obj);
 
-    runtime_cvt obj2{CheckType{make_root_cvt<true>(mem_device("")), "zh_CN.UTF-8"}};
+    runtime_cvt obj2{CheckType{rb_root_cvt{mem_device("")}, "zh_CN.UTF-8"}};
     helper(obj2);
     dump_info("Done\n");
 }
@@ -445,11 +445,11 @@ void test_code_cvt_mem_char_bos_5()
         if (dev.str() != info) throw std::runtime_error("code_cvt<memory<char>, char32_t>::bos fail");
     };
     
-    using CheckType = code_cvt<root_cvt<mem_device<char>, true>, char32_t>;
-    CheckType obj(make_root_cvt<true>(mem_device("")), "zh_CN.UTF-8");
+    using CheckType = code_cvt<rb_root_cvt<mem_device<char>>, char32_t>;
+    CheckType obj(rb_root_cvt{mem_device("")}, "zh_CN.UTF-8");
     helper(obj);
 
-    runtime_cvt obj2{CheckType{make_root_cvt<true>(mem_device("")), "zh_CN.UTF-8"}};
+    runtime_cvt obj2{CheckType{rb_root_cvt{mem_device("")}, "zh_CN.UTF-8"}};
     helper(obj2);
     dump_info("Done\n");
 }
@@ -504,11 +504,11 @@ void test_code_cvt_mem_char_get_1()
         }
     };
 
-    using CheckType = code_cvt<root_cvt<mem_device<char>, true>, char32_t>;
-    CheckType obj{make_root_cvt<true>(mem_device(e_lit)), "zh_CN.UTF-8"};
+    using CheckType = code_cvt<rb_root_cvt<mem_device<char>>, char32_t>;
+    CheckType obj{rb_root_cvt{mem_device(e_lit)}, "zh_CN.UTF-8"};
     helper(obj);
 
-    runtime_cvt obj2{CheckType{make_root_cvt<true>(mem_device(e_lit)), "zh_CN.UTF-8"}};
+    runtime_cvt obj2{CheckType{rb_root_cvt{mem_device(e_lit)}, "zh_CN.UTF-8"}};
     helper(obj2);
 
     dump_info("Done\n");
@@ -564,11 +564,11 @@ void test_code_cvt_mem_char_get_nra_1()
         }
     };
 
-    using CheckType = code_cvt<root_cvt<mem_device<char>, false>, char32_t>;
-    CheckType obj{make_root_cvt<false>(mem_device(e_lit)), "zh_CN.UTF-8"};
+    using CheckType = code_cvt<no_rb_root_cvt<mem_device<char>>, char32_t>;
+    CheckType obj{no_rb_root_cvt{mem_device(e_lit)}, "zh_CN.UTF-8"};
     helper(obj);
 
-    runtime_cvt obj2{CheckType{make_root_cvt<false>(mem_device(e_lit)), "zh_CN.UTF-8"}};
+    runtime_cvt obj2{CheckType{no_rb_root_cvt{mem_device(e_lit)}, "zh_CN.UTF-8"}};
     helper(obj2);
     
     dump_info("Done\n");
@@ -622,11 +622,11 @@ void test_code_cvt_mem_char_put_1()
         if (dev.str() != e_lit) throw std::runtime_error("code_cvt<memory<char>, char32_t>::put response incorrect");
     };
 
-    using CheckType = code_cvt<root_cvt<mem_device<char>, true>, char32_t>;
-    CheckType obj(make_root_cvt<true>(mem_device("")), "zh_CN.UTF-8");
+    using CheckType = code_cvt<rb_root_cvt<mem_device<char>>, char32_t>;
+    CheckType obj(rb_root_cvt{mem_device("")}, "zh_CN.UTF-8");
     helper(obj);
 
-    runtime_cvt obj2{CheckType{make_root_cvt<true>(mem_device("")), "zh_CN.UTF-8"}};
+    runtime_cvt obj2{CheckType{rb_root_cvt{mem_device("")}, "zh_CN.UTF-8"}};
     helper(obj2);
     dump_info("Done\n");
 }
@@ -665,11 +665,11 @@ void test_code_cvt_mem_char_put_2()
         if (dev.str() != e_lit) throw std::runtime_error("code_cvt<memory<char>, char32_t>::put response incorrect");        
     };
 
-    using CheckType = code_cvt<root_cvt<mem_device<char>, true>, char32_t>;
-    CheckType obj1(make_root_cvt<true>(mem_device("")), "zh_CN.UTF-8");
+    using CheckType = code_cvt<rb_root_cvt<mem_device<char>>, char32_t>;
+    CheckType obj1(rb_root_cvt{mem_device("")}, "zh_CN.UTF-8");
     helper(obj1);
 
-    runtime_cvt obj2{CheckType{make_root_cvt<true>(mem_device("")), "zh_CN.UTF-8"}};
+    runtime_cvt obj2{CheckType{rb_root_cvt{mem_device("")}, "zh_CN.UTF-8"}};
     helper(obj2);
     dump_info("Done\n");
 }
@@ -721,11 +721,11 @@ void test_code_cvt_mem_char_put_3()
         if (obj.detach().str() != e_lit) throw std::runtime_error("code_cvt<memory<char>, char32_t>::put response incorrect");
     };
 
-    using CheckType = code_cvt<root_cvt<mem_device<char>, false>, char32_t>;
-    CheckType obj(make_root_cvt<false>(mem_device("")), "zh_CN.UTF-8");
+    using CheckType = code_cvt<no_rb_root_cvt<mem_device<char>>, char32_t>;
+    CheckType obj(no_rb_root_cvt{mem_device("")}, "zh_CN.UTF-8");
     helper(obj);
 
-    runtime_cvt obj2{CheckType{make_root_cvt<false>(mem_device("")), "zh_CN.UTF-8"}};
+    runtime_cvt obj2{CheckType{no_rb_root_cvt{mem_device("")}, "zh_CN.UTF-8"}};
     helper(obj2);
     dump_info("Done\n");
 }
@@ -762,11 +762,11 @@ void test_code_cvt_mem_char_put_4()
         if (obj.detach().str() != e_lit) throw std::runtime_error("code_cvt<memory<char>, char32_t>::put response incorrect");
     };
 
-    using CheckType = code_cvt<root_cvt<mem_device<char>, true>, char32_t>;
-    CheckType obj1(make_root_cvt<true>(mem_device("")), "zh_CN.UTF-8");
+    using CheckType = code_cvt<rb_root_cvt<mem_device<char>>, char32_t>;
+    CheckType obj1(rb_root_cvt{mem_device("")}, "zh_CN.UTF-8");
     helper(obj1);
 
-    runtime_cvt obj2{CheckType{make_root_cvt<true>(mem_device("")), "zh_CN.UTF-8"}};
+    runtime_cvt obj2{CheckType{rb_root_cvt{mem_device("")}, "zh_CN.UTF-8"}};
     helper(obj2);
     dump_info("Done\n");
 }
@@ -810,11 +810,11 @@ void test_code_cvt_mem_char_flush_1()
         if (dev.str() != e_lit) throw std::runtime_error("code_cvt<memory<char>, char32_t>::put response incorrect");
     };
     
-    using CheckType = code_cvt<root_cvt<mem_device<char>, true>, char32_t>;
-    CheckType obj1(make_root_cvt<true>(mem_device("")), "zh_CN.UTF-8");
+    using CheckType = code_cvt<rb_root_cvt<mem_device<char>>, char32_t>;
+    CheckType obj1(rb_root_cvt{mem_device("")}, "zh_CN.UTF-8");
     helper(obj1);
     
-    runtime_cvt obj2(CheckType{make_root_cvt<true>(mem_device("")), "zh_CN.UTF-8"});
+    runtime_cvt obj2(CheckType{rb_root_cvt{mem_device("")}, "zh_CN.UTF-8"});
     helper(obj2);
 
     dump_info("Done\n");
@@ -872,11 +872,11 @@ void test_code_cvt_mem_char_flush_2()
         if (dev.str() != e_lit) throw std::runtime_error("code_cvt<memory<char>, char32_t>::put response incorrect");
     };
 
-    using CheckType = code_cvt<root_cvt<mem_device<char>, true>, char32_t>;
-    CheckType obj(make_root_cvt<true>(mem_device("")), "zh_CN.UTF-8");
+    using CheckType = code_cvt<rb_root_cvt<mem_device<char>>, char32_t>;
+    CheckType obj(rb_root_cvt{mem_device("")}, "zh_CN.UTF-8");
     helper(obj);
 
-    runtime_cvt obj2(CheckType{make_root_cvt<true>(mem_device("")), "zh_CN.UTF-8"});
+    runtime_cvt obj2(CheckType{rb_root_cvt{mem_device("")}, "zh_CN.UTF-8"});
     helper(obj2);
 
     dump_info("Done\n");
@@ -920,11 +920,11 @@ void test_code_cvt_mem_char_flush_3()
         if (dev.str() != e_lit) throw std::runtime_error("code_cvt<memory<char>, char32_t>::put response incorrect");
     };
 
-    using CheckType = code_cvt<root_cvt<mem_device<char>, true>, char32_t>;
-    CheckType obj1(make_root_cvt<true>(mem_device("")), "zh_CN.UTF-8");
+    using CheckType = code_cvt<rb_root_cvt<mem_device<char>>, char32_t>;
+    CheckType obj1(rb_root_cvt{mem_device("")}, "zh_CN.UTF-8");
     helper(obj1);
 
-    runtime_cvt obj2(CheckType{make_root_cvt<true>(mem_device("")), "zh_CN.UTF-8"});
+    runtime_cvt obj2(CheckType{rb_root_cvt{mem_device("")}, "zh_CN.UTF-8"});
     helper(obj2);
 
     dump_info("Done\n");
@@ -953,11 +953,11 @@ void test_code_cvt_mem_char_seek_1()
         if (str != U"123456") throw std::runtime_error("code_cvt<memory<char>, char32_t>::get response incorrect");
     };
 
-    using CheckType = code_cvt<root_cvt<mem_device<char>, true>, char32_t>;
-    CheckType obj1(make_root_cvt<true>(mem_device("123456")), "zh_CN.UTF-8");
+    using CheckType = code_cvt<rb_root_cvt<mem_device<char>>, char32_t>;
+    CheckType obj1(rb_root_cvt{mem_device("123456")}, "zh_CN.UTF-8");
     helper(obj1);
 
-    runtime_cvt obj2(CheckType{make_root_cvt<true>(mem_device("123456")), "zh_CN.UTF-8"});
+    runtime_cvt obj2(CheckType{rb_root_cvt{mem_device("123456")}, "zh_CN.UTF-8"});
     helper(obj2);
 
     dump_info("Done\n");
@@ -985,11 +985,11 @@ void test_code_cvt_mem_char_seek_2()
         if (str != U"23456") throw std::runtime_error("code_cvt<memory<char>, char32_t>::get response incorrect");
     };
 
-    using CheckType = code_cvt<root_cvt<mem_device<char>, true>, char32_t>;
-    CheckType obj1(make_root_cvt<true>(mem_device("123456")), "C");
+    using CheckType = code_cvt<rb_root_cvt<mem_device<char>>, char32_t>;
+    CheckType obj1(rb_root_cvt{mem_device("123456")}, "C");
     helper(obj1);
 
-    runtime_cvt obj2(CheckType{make_root_cvt<true>(mem_device("123456")), "C"});
+    runtime_cvt obj2(CheckType{rb_root_cvt{mem_device("123456")}, "C"});
     helper(obj2);
 
     dump_info("Done\n");
@@ -1030,11 +1030,11 @@ void test_code_cvt_mem_char_seek_3()
         if (dev.str() != "李x伟xy") throw std::runtime_error("code_cvt<memory<char>, char32_t> response incorrect");
     };
 
-    using CheckType = code_cvt<root_cvt<mem_device<char>, true>, char32_t>;
-    CheckType obj1(make_root_cvt<true>(mem_device("")), "zh_CN.UTF-8");
+    using CheckType = code_cvt<rb_root_cvt<mem_device<char>>, char32_t>;
+    CheckType obj1(rb_root_cvt{mem_device("")}, "zh_CN.UTF-8");
     helper(obj1);
 
-    runtime_cvt obj2(CheckType{make_root_cvt<true>(mem_device("")), "zh_CN.UTF-8"});
+    runtime_cvt obj2(CheckType{rb_root_cvt{mem_device("")}, "zh_CN.UTF-8"});
     helper(obj2);
 
     dump_info("Done\n");
@@ -1073,11 +1073,11 @@ void test_code_cvt_mem_char_seek_4()
         if (dev.str() != "axy") throw std::runtime_error("code_cvt<memory<char>, char32_t> response incorrect");
     };
 
-    using CheckType = code_cvt<root_cvt<mem_device<char>, true>, char32_t>;
-    CheckType obj1(make_root_cvt<true>(mem_device("")), "C");
+    using CheckType = code_cvt<rb_root_cvt<mem_device<char>>, char32_t>;
+    CheckType obj1(rb_root_cvt{mem_device("")}, "C");
     helper(obj1);
     
-    runtime_cvt obj2(CheckType{make_root_cvt<true>(mem_device("")), "C"});
+    runtime_cvt obj2(CheckType{rb_root_cvt{mem_device("")}, "C"});
     helper(obj2);
     dump_info("Done\n");
 }
@@ -1105,11 +1105,11 @@ void test_code_cvt_mem_char_rseek_1()
         if (obj.device().str() != "123456") throw std::runtime_error("code_cvt<memory<char>, char32_t> response incorrect");
     };
 
-    using CheckType = code_cvt<root_cvt<mem_device<char>, true>, char32_t>;
-    CheckType obj1(make_root_cvt<true>(mem_device("123456")), "zh_CN.UTF-8");
+    using CheckType = code_cvt<rb_root_cvt<mem_device<char>>, char32_t>;
+    CheckType obj1(rb_root_cvt{mem_device("123456")}, "zh_CN.UTF-8");
     helper(obj1);
 
-    runtime_cvt obj2(CheckType{make_root_cvt<true>(mem_device("123456")), "zh_CN.UTF-8"});
+    runtime_cvt obj2(CheckType{rb_root_cvt{mem_device("123456")}, "zh_CN.UTF-8"});
     helper(obj2);
     dump_info("Done\n");
 }
@@ -1136,11 +1136,11 @@ void test_code_cvt_mem_char_rseek_2()
         if (str != U"3456") throw std::runtime_error("code_cvt<memory<char>, char32_t>::get response incorrect");
     };
 
-    using CheckType = code_cvt<root_cvt<mem_device<char>, true>, char32_t>;
-    CheckType obj1(make_root_cvt<true>(mem_device("123456")), "C");
+    using CheckType = code_cvt<rb_root_cvt<mem_device<char>>, char32_t>;
+    CheckType obj1(rb_root_cvt{mem_device("123456")}, "C");
     helper(obj1);
 
-    runtime_cvt obj2(CheckType{make_root_cvt<true>(mem_device("123456")), "C"});
+    runtime_cvt obj2(CheckType{rb_root_cvt{mem_device("123456")}, "C"});
     helper(obj2);
     dump_info("Done\n");
 }
@@ -1180,11 +1180,11 @@ void test_code_cvt_mem_char_rseek_3()
         if (obj.device().str() != "李x伟xy") throw std::runtime_error("code_cvt<memory<char>, char32_t> response incorrect");
     };
     
-    using CheckType = code_cvt<root_cvt<mem_device<char>, true>, char32_t>;
-    CheckType obj1(make_root_cvt<true>(mem_device("")), "zh_CN.UTF-8");
+    using CheckType = code_cvt<rb_root_cvt<mem_device<char>>, char32_t>;
+    CheckType obj1(rb_root_cvt{mem_device("")}, "zh_CN.UTF-8");
     helper(obj1);
 
-    runtime_cvt obj2(CheckType{make_root_cvt<true>(mem_device("")), "zh_CN.UTF-8"});
+    runtime_cvt obj2(CheckType{rb_root_cvt{mem_device("")}, "zh_CN.UTF-8"});
     helper(obj2);
 
     dump_info("Done\n");
@@ -1223,11 +1223,11 @@ void test_code_cvt_mem_char_rseek_4()
         if (obj.device().str() != "abxy") throw std::runtime_error("code_cvt<memory<char>, char32_t> response incorrect");
     };
 
-    using CheckType = code_cvt<root_cvt<mem_device<char>, true>, char32_t>;
-    CheckType obj1(make_root_cvt<true>(mem_device("")), "C");
+    using CheckType = code_cvt<rb_root_cvt<mem_device<char>>, char32_t>;
+    CheckType obj1(rb_root_cvt{mem_device("")}, "C");
     helper(obj1);
 
-    runtime_cvt obj2(CheckType{make_root_cvt<true>(mem_device("")), "C"});
+    runtime_cvt obj2(CheckType{rb_root_cvt{mem_device("")}, "C"});
     helper(obj2);
 
     dump_info("Done\n");
@@ -1274,11 +1274,11 @@ void test_code_cvt_mem_char_io_1()
         if (obj.device().str() != info) throw std::runtime_error("code_cvt<memory<char>, char32_t> response incorrect");
     };
 
-    using CheckType = code_cvt<root_cvt<mem_device<char>, false>, char32_t>;
-    CheckType obj1(make_root_cvt<false>(mem_device("")), "C");
+    using CheckType = code_cvt<no_rb_root_cvt<mem_device<char>>, char32_t>;
+    CheckType obj1(no_rb_root_cvt{mem_device("")}, "C");
     helper(obj1);
 
-    runtime_cvt obj2(CheckType{make_root_cvt<false>(mem_device("")), "C"});
+    runtime_cvt obj2(CheckType{no_rb_root_cvt{mem_device("")}, "C"});
     helper(obj2);
 
     dump_info("Done\n");
@@ -1342,11 +1342,11 @@ void test_code_cvt_mem_char_io_2()
         if (obj.device().str() != aim_info) throw std::runtime_error("code_cvt<memory<char>, char32_t> response incorrect");
     };
 
-    using CheckType = code_cvt<root_cvt<mem_device<char>, false>, char32_t>;
-    CheckType obj1(make_root_cvt<false>(mem_device(info)), "C");
+    using CheckType = code_cvt<no_rb_root_cvt<mem_device<char>>, char32_t>;
+    CheckType obj1(no_rb_root_cvt{mem_device(info)}, "C");
     helper(obj1);
 
-    runtime_cvt obj2(CheckType{make_root_cvt<false>(mem_device(info)), "C"});
+    runtime_cvt obj2(CheckType{no_rb_root_cvt{mem_device(info)}, "C"});
     helper(obj2);
 
     dump_info("Done\n");
@@ -1407,16 +1407,16 @@ void test_code_cvt_mem_char_io_3()
     };
 
     code_cvt_creator<char, char32_t> creator("zh_CN.UTF-8");
-    auto obj1 = creator.create(make_root_cvt<false>(mem_device("")));
+    auto obj1 = creator.create(no_rb_root_cvt{mem_device("")});
     helper(obj1);
 
-    auto obj2 = creator.create(make_root_cvt<true>(mem_device("")));
+    auto obj2 = creator.create(rb_root_cvt{mem_device("")});
     helper(obj2);
 
-    runtime_cvt obj3(creator.create(make_root_cvt<false>(mem_device(""))));
+    runtime_cvt obj3(creator.create(no_rb_root_cvt{mem_device("")}));
     helper(obj3);
 
-    runtime_cvt obj4(creator.create(make_root_cvt<true>(mem_device(""))));
+    runtime_cvt obj4(creator.create(rb_root_cvt{mem_device("")}));
     helper(obj4);
 
     dump_info("Done\n");
@@ -1475,16 +1475,16 @@ void test_code_cvt_mem_char_io_4()
     };
 
     code_cvt_creator<char, char32_t> creator("zh_CN.UTF-8");
-    auto obj1 = creator.create(make_root_cvt<false>(mem_device(info)));
+    auto obj1 = creator.create(no_rb_root_cvt{mem_device(info)});
     helper(obj1);
 
-    auto obj2 = creator.create(make_root_cvt<true>(mem_device(info)));
+    auto obj2 = creator.create(rb_root_cvt{mem_device(info)});
     helper(obj2);
     
-    runtime_cvt obj3(creator.create(make_root_cvt<false>(mem_device(info))));
+    runtime_cvt obj3(creator.create(no_rb_root_cvt{mem_device(info)}));
     helper(obj3);
 
-    runtime_cvt obj4(creator.create(make_root_cvt<true>(mem_device(info))));
+    runtime_cvt obj4(creator.create(rb_root_cvt{mem_device(info)}));
     helper(obj4);
 
     dump_info("Done\n");

--- a/test/cvt/code_cvt/code_cvt_stdio_char.cpp
+++ b/test/cvt/code_cvt/code_cvt_stdio_char.cpp
@@ -11,7 +11,7 @@ void test_code_cvt_stdio_char_gen_1()
     dump_info("Test code_cvt<std_device> general case 1...");
     
     {
-        using CheckType = code_cvt<root_cvt<std_device<STDIN_FILENO>, true>, char32_t>;
+        using CheckType = code_cvt<rb_root_cvt<std_device<STDIN_FILENO>>, char32_t>;
         static_assert(io_converter<CheckType>);
         static_assert(std::is_same_v<CheckType::device_type, std_device<STDIN_FILENO>>);
         static_assert(std::is_same_v<CheckType::internal_type, char32_t>);
@@ -24,7 +24,7 @@ void test_code_cvt_stdio_char_gen_1()
     }
     
     {
-        using CheckType = code_cvt<root_cvt<std_device<STDOUT_FILENO>, true>, char32_t>;
+        using CheckType = code_cvt<rb_root_cvt<std_device<STDOUT_FILENO>>, char32_t>;
         static_assert(io_converter<CheckType>);
         static_assert(std::is_same_v<CheckType::device_type, std_device<STDOUT_FILENO>>);
         static_assert(std::is_same_v<CheckType::internal_type, char32_t>);
@@ -37,7 +37,7 @@ void test_code_cvt_stdio_char_gen_1()
     }
     
     {
-        using CheckType = code_cvt<root_cvt<std_device<STDERR_FILENO>, true>, wchar_t>;
+        using CheckType = code_cvt<rb_root_cvt<std_device<STDERR_FILENO>>, wchar_t>;
         static_assert(io_converter<CheckType>);
         static_assert(std::is_same_v<CheckType::device_type, std_device<STDERR_FILENO>>);
         static_assert(std::is_same_v<CheckType::internal_type, wchar_t>);
@@ -104,15 +104,15 @@ void test_code_cvt_stdio_char_gen_2()
         }
     };
 
-    using CheckType = code_cvt<root_cvt<std_device<STDIN_FILENO>, true>, char32_t>;
+    using CheckType = code_cvt<rb_root_cvt<std_device<STDIN_FILENO>>, char32_t>;
     {
         iguard g(e_lit);
-        CheckType obj{make_root_cvt<true>(std_device<STDIN_FILENO>{}), "zh_CN.UTF-8"};
+        CheckType obj{rb_root_cvt{std_device<STDIN_FILENO>{}}, "zh_CN.UTF-8"};
         helper(obj);
     }
     {
         iguard g(e_lit);
-        CheckType tmp{make_root_cvt<true>(std_device<STDIN_FILENO>{}), "zh_CN.UTF-8"};
+        CheckType tmp{rb_root_cvt{std_device<STDIN_FILENO>{}}, "zh_CN.UTF-8"};
         runtime_cvt obj{std::move(tmp)};
         helper(obj);
     }
@@ -168,24 +168,24 @@ void test_code_cvt_stdio_char_gen_3()
 
     {
         oguard<true> g;
-        using CheckType = code_cvt<root_cvt<std_device<STDOUT_FILENO>, true>, char32_t>;
-        CheckType obj(make_root_cvt<true>(std_device<STDOUT_FILENO>{}), "zh_CN.UTF-8");
+        using CheckType = code_cvt<rb_root_cvt<std_device<STDOUT_FILENO>>, char32_t>;
+        CheckType obj(rb_root_cvt{std_device<STDOUT_FILENO>{}}, "zh_CN.UTF-8");
         helper(obj);
         if (g.contents() != e_lit) throw std::runtime_error("code_cvt<std_device>::put_bos fail");
     }
     
     {
         oguard<false> g;
-        using CheckType = code_cvt<root_cvt<std_device<STDERR_FILENO>, true>, char32_t>;
-        CheckType obj(make_root_cvt<true>(std_device<STDERR_FILENO>{}), "zh_CN.UTF-8");
+        using CheckType = code_cvt<rb_root_cvt<std_device<STDERR_FILENO>>, char32_t>;
+        CheckType obj(rb_root_cvt{std_device<STDERR_FILENO>{}}, "zh_CN.UTF-8");
         helper(obj);
         if (g.contents() != e_lit) throw std::runtime_error("code_cvt<std_device>::put_bos fail");
     }
 
     {
         oguard<true> g;
-        using CheckType = code_cvt<root_cvt<std_device<STDOUT_FILENO>, true>, char32_t>;
-        CheckType tmp(make_root_cvt<true>(std_device<STDOUT_FILENO>{}), "zh_CN.UTF-8");
+        using CheckType = code_cvt<rb_root_cvt<std_device<STDOUT_FILENO>>, char32_t>;
+        CheckType tmp(rb_root_cvt{std_device<STDOUT_FILENO>{}}, "zh_CN.UTF-8");
         runtime_cvt obj{std::move(tmp)};
         helper(obj);
         if (g.contents() != e_lit) throw std::runtime_error("code_cvt<std_device>::put_bos fail");
@@ -193,8 +193,8 @@ void test_code_cvt_stdio_char_gen_3()
     
     {
         oguard<false> g;
-        using CheckType = code_cvt<root_cvt<std_device<STDERR_FILENO>, true>, char32_t>;
-        CheckType tmp(make_root_cvt<true>(std_device<STDERR_FILENO>{}), "zh_CN.UTF-8");
+        using CheckType = code_cvt<rb_root_cvt<std_device<STDERR_FILENO>>, char32_t>;
+        CheckType tmp(rb_root_cvt{std_device<STDERR_FILENO>{}}, "zh_CN.UTF-8");
         runtime_cvt obj{std::move(tmp)};
         helper(obj);
         if (g.contents() != e_lit) throw std::runtime_error("code_cvt<std_device>::put_bos fail");
@@ -214,15 +214,15 @@ void test_code_cvt_stdio_char_bos_1()
         obj.main_cont_beg();
     };
 
-    using CheckType = code_cvt<root_cvt<std_device<STDIN_FILENO>, true>, char32_t>;
+    using CheckType = code_cvt<rb_root_cvt<std_device<STDIN_FILENO>>, char32_t>;
     {
         iguard g("12345");
-        CheckType obj(make_root_cvt<true>(std_device<STDIN_FILENO>{}), "zh_CN.UTF-8");
+        CheckType obj(rb_root_cvt{std_device<STDIN_FILENO>{}}, "zh_CN.UTF-8");
         helper(obj);
     }
     {
         iguard g("12345");
-        CheckType tmp(make_root_cvt<true>(std_device<STDIN_FILENO>{}), "zh_CN.UTF-8");
+        CheckType tmp(rb_root_cvt{std_device<STDIN_FILENO>{}}, "zh_CN.UTF-8");
         runtime_cvt obj(std::move(tmp));
         helper(obj);
     }
@@ -251,15 +251,15 @@ void test_code_cvt_stdio_char_bos_2()
     info += '2'; info += '\x00'; info += '\x00'; info += '\x00';
     info += '3'; info += '\x00'; info += '\x00'; info += '\x00';
     
-    using CheckType = code_cvt<root_cvt<std_device<STDIN_FILENO>, true>, char32_t>;
+    using CheckType = code_cvt<rb_root_cvt<std_device<STDIN_FILENO>>, char32_t>;
     {
         iguard g(info);
-        CheckType obj(make_root_cvt<true>(std_device<STDIN_FILENO>{}), "zh_CN.UTF-8");
+        CheckType obj(rb_root_cvt{std_device<STDIN_FILENO>{}}, "zh_CN.UTF-8");
         helper(obj);
     }
     {
         iguard g(info);
-        CheckType tmp(make_root_cvt<true>(std_device<STDIN_FILENO>{}), "zh_CN.UTF-8");
+        CheckType tmp(rb_root_cvt{std_device<STDIN_FILENO>{}}, "zh_CN.UTF-8");
         runtime_cvt obj{std::move(tmp)};
         helper(obj);
     }
@@ -291,15 +291,15 @@ void test_code_cvt_stdio_char_bos_3()
     info += 'p'; info += '\x00'; info += '\x00'; info += '\x00';
     info += 'p'; info += '\x00'; info += '\x00'; info += '\x00';
 
-    using CheckType = code_cvt<root_cvt<std_device<STDIN_FILENO>, true>, char32_t>;
+    using CheckType = code_cvt<rb_root_cvt<std_device<STDIN_FILENO>>, char32_t>;
     {
         iguard g(info);
-        CheckType obj(make_root_cvt<true>(std_device<STDIN_FILENO>{}), "zh_CN.UTF-8");
+        CheckType obj(rb_root_cvt{std_device<STDIN_FILENO>{}}, "zh_CN.UTF-8");
         helper(obj);
     }
     {
         iguard g(info);
-        CheckType tmp(make_root_cvt<true>(std_device<STDIN_FILENO>{}), "zh_CN.UTF-8");
+        CheckType tmp(rb_root_cvt{std_device<STDIN_FILENO>{}}, "zh_CN.UTF-8");
         runtime_cvt obj{std::move(tmp)};
         helper(obj);
     }
@@ -320,24 +320,24 @@ void test_code_cvt_stdio_char_bos_4()
 
     {
         oguard<true> g;
-        using CheckType = code_cvt<root_cvt<std_device<STDOUT_FILENO>, true>, char32_t>;
-        CheckType obj(make_root_cvt<true>(std_device<STDOUT_FILENO>{}), "zh_CN.UTF-8");
+        using CheckType = code_cvt<rb_root_cvt<std_device<STDOUT_FILENO>>, char32_t>;
+        CheckType obj(rb_root_cvt{std_device<STDOUT_FILENO>{}}, "zh_CN.UTF-8");
         helper(obj);
         if (g.contents() != "") throw std::runtime_error("code_cvt<std_device>::bos fail");
     }
     
     {
         oguard<false> g;
-        using CheckType = code_cvt<root_cvt<std_device<STDERR_FILENO>, true>, char32_t>;
-        CheckType obj(make_root_cvt<true>(std_device<STDERR_FILENO>{}), "zh_CN.UTF-8");
+        using CheckType = code_cvt<rb_root_cvt<std_device<STDERR_FILENO>>, char32_t>;
+        CheckType obj(rb_root_cvt{std_device<STDERR_FILENO>{}}, "zh_CN.UTF-8");
         helper(obj);
         if (g.contents() != "") throw std::runtime_error("code_cvt<std_device>::bos fail");
     }
     
     {
         oguard<true> g;
-        using CheckType = code_cvt<root_cvt<std_device<STDOUT_FILENO>, true>, char32_t>;
-        CheckType tmp(make_root_cvt<true>(std_device<STDOUT_FILENO>{}), "zh_CN.UTF-8");
+        using CheckType = code_cvt<rb_root_cvt<std_device<STDOUT_FILENO>>, char32_t>;
+        CheckType tmp(rb_root_cvt{std_device<STDOUT_FILENO>{}}, "zh_CN.UTF-8");
         runtime_cvt obj(std::move(tmp));
         helper(obj);
         if (g.contents() != "") throw std::runtime_error("code_cvt<std_device>::bos fail");
@@ -345,8 +345,8 @@ void test_code_cvt_stdio_char_bos_4()
     
     {
         oguard<false> g;
-        using CheckType = code_cvt<root_cvt<std_device<STDERR_FILENO>, true>, char32_t>;
-        CheckType tmp(make_root_cvt<true>(std_device<STDERR_FILENO>{}), "zh_CN.UTF-8");
+        using CheckType = code_cvt<rb_root_cvt<std_device<STDERR_FILENO>>, char32_t>;
+        CheckType tmp(rb_root_cvt{std_device<STDERR_FILENO>{}}, "zh_CN.UTF-8");
         runtime_cvt obj(std::move(tmp));
         helper(obj);
         if (g.contents() != "") throw std::runtime_error("code_cvt<std_device>::bos fail");
@@ -376,24 +376,24 @@ void test_code_cvt_stdio_char_bos_5()
 
     {
         oguard<true> g;
-        using CheckType = code_cvt<root_cvt<std_device<STDOUT_FILENO>, true>, char32_t>;
-        CheckType obj(make_root_cvt<true>(std_device<STDOUT_FILENO>{}), "zh_CN.UTF-8");
+        using CheckType = code_cvt<rb_root_cvt<std_device<STDOUT_FILENO>>, char32_t>;
+        CheckType obj(rb_root_cvt{std_device<STDOUT_FILENO>{}}, "zh_CN.UTF-8");
         helper(obj);
         if (g.contents() != info) throw std::runtime_error("code_cvt<std_device>::bos fail");
     }
     
     {
         oguard<false> g;
-        using CheckType = code_cvt<root_cvt<std_device<STDERR_FILENO>, true>, char32_t>;
-        CheckType obj(make_root_cvt<true>(std_device<STDERR_FILENO>{}), "zh_CN.UTF-8");
+        using CheckType = code_cvt<rb_root_cvt<std_device<STDERR_FILENO>>, char32_t>;
+        CheckType obj(rb_root_cvt{std_device<STDERR_FILENO>{}}, "zh_CN.UTF-8");
         helper(obj);
         if (g.contents() != info) throw std::runtime_error("code_cvt<std_device>::bos fail");
     }
 
     {
         oguard<true> g;
-        using CheckType = code_cvt<root_cvt<std_device<STDOUT_FILENO>, true>, char32_t>;
-        CheckType tmp(make_root_cvt<true>(std_device<STDOUT_FILENO>{}), "zh_CN.UTF-8");
+        using CheckType = code_cvt<rb_root_cvt<std_device<STDOUT_FILENO>>, char32_t>;
+        CheckType tmp(rb_root_cvt{std_device<STDOUT_FILENO>{}}, "zh_CN.UTF-8");
         runtime_cvt obj(std::move(tmp));
         helper(obj);
         if (g.contents() != info) throw std::runtime_error("code_cvt<std_device>::bos fail");
@@ -401,8 +401,8 @@ void test_code_cvt_stdio_char_bos_5()
     
     {
         oguard<false> g;
-        using CheckType = code_cvt<root_cvt<std_device<STDERR_FILENO>, true>, char32_t>;
-        CheckType tmp(make_root_cvt<true>(std_device<STDERR_FILENO>{}), "zh_CN.UTF-8");
+        using CheckType = code_cvt<rb_root_cvt<std_device<STDERR_FILENO>>, char32_t>;
+        CheckType tmp(rb_root_cvt{std_device<STDERR_FILENO>{}}, "zh_CN.UTF-8");
         runtime_cvt obj(std::move(tmp));
         helper(obj);
         if (g.contents() != info) throw std::runtime_error("code_cvt<std_device>::bos fail");
@@ -431,24 +431,24 @@ void test_code_cvt_stdio_char_bos_6()
 
     {
         oguard<true> g;
-        using CheckType = code_cvt<root_cvt<std_device<STDOUT_FILENO>, true>, char32_t>;
-        CheckType obj(make_root_cvt<true>(std_device<STDOUT_FILENO>{}), "zh_CN.UTF-8");
+        using CheckType = code_cvt<rb_root_cvt<std_device<STDOUT_FILENO>>, char32_t>;
+        CheckType obj(rb_root_cvt{std_device<STDOUT_FILENO>{}}, "zh_CN.UTF-8");
         helper(obj);
         if (g.contents() != info) throw std::runtime_error("code_cvt<std_device>::bos fail");
     }
     
     {
         oguard<false> g;
-        using CheckType = code_cvt<root_cvt<std_device<STDERR_FILENO>, true>, char32_t>;
-        CheckType obj(make_root_cvt<true>(std_device<STDERR_FILENO>{}), "zh_CN.UTF-8");
+        using CheckType = code_cvt<rb_root_cvt<std_device<STDERR_FILENO>>, char32_t>;
+        CheckType obj(rb_root_cvt{std_device<STDERR_FILENO>{}}, "zh_CN.UTF-8");
         helper(obj);
         if (g.contents() != info) throw std::runtime_error("code_cvt<std_device>::bos fail");
     }
     
     {
         oguard<true> g;
-        using CheckType = code_cvt<root_cvt<std_device<STDOUT_FILENO>, true>, char32_t>;
-        CheckType tmp(make_root_cvt<true>(std_device<STDOUT_FILENO>{}), "zh_CN.UTF-8");
+        using CheckType = code_cvt<rb_root_cvt<std_device<STDOUT_FILENO>>, char32_t>;
+        CheckType tmp(rb_root_cvt{std_device<STDOUT_FILENO>{}}, "zh_CN.UTF-8");
         runtime_cvt obj(std::move(tmp));
         helper(obj);
         if (g.contents() != info) throw std::runtime_error("code_cvt<std_device>::bos fail");
@@ -456,8 +456,8 @@ void test_code_cvt_stdio_char_bos_6()
     
     {
         oguard<false> g;
-        using CheckType = code_cvt<root_cvt<std_device<STDERR_FILENO>, true>, char32_t>;
-        CheckType tmp(make_root_cvt<true>(std_device<STDERR_FILENO>{}), "zh_CN.UTF-8");
+        using CheckType = code_cvt<rb_root_cvt<std_device<STDERR_FILENO>>, char32_t>;
+        CheckType tmp(rb_root_cvt{std_device<STDERR_FILENO>{}}, "zh_CN.UTF-8");
         runtime_cvt obj(std::move(tmp));
         helper(obj);
         if (g.contents() != info) throw std::runtime_error("code_cvt<std_device>::bos fail");
@@ -516,15 +516,15 @@ void test_code_cvt_stdio_char_get_1()
         }
     };
 
-    using CheckType = code_cvt<root_cvt<std_device<STDIN_FILENO>, true>, char32_t>;
+    using CheckType = code_cvt<rb_root_cvt<std_device<STDIN_FILENO>>, char32_t>;
     {
         iguard g(e_lit);
-        CheckType obj{make_root_cvt<true>(std_device<STDIN_FILENO>{}), "zh_CN.UTF-8"};
+        CheckType obj{rb_root_cvt{std_device<STDIN_FILENO>{}}, "zh_CN.UTF-8"};
         helper(obj);
     }
     {
         iguard g(e_lit);
-        CheckType tmp{make_root_cvt<true>(std_device<STDIN_FILENO>{}), "zh_CN.UTF-8"};
+        CheckType tmp{rb_root_cvt{std_device<STDIN_FILENO>{}}, "zh_CN.UTF-8"};
         runtime_cvt obj(std::move(tmp));
         helper(obj);
     }
@@ -579,24 +579,24 @@ void test_code_cvt_stdio_char_put_1()
 
     {
         oguard<true> g;
-        using CheckType = code_cvt<root_cvt<std_device<STDOUT_FILENO>, true>, char32_t>;
-        CheckType obj(make_root_cvt<true>(std_device<STDOUT_FILENO>{}), "zh_CN.UTF-8");
+        using CheckType = code_cvt<rb_root_cvt<std_device<STDOUT_FILENO>>, char32_t>;
+        CheckType obj(rb_root_cvt{std_device<STDOUT_FILENO>{}}, "zh_CN.UTF-8");
         helper(obj);
         if (g.contents() != e_lit) throw std::runtime_error("code_cvt<std_device>::put_bos fail");
     }
     
     {
         oguard<false> g;
-        using CheckType = code_cvt<root_cvt<std_device<STDERR_FILENO>, true>, char32_t>;
-        CheckType obj(make_root_cvt<true>(std_device<STDERR_FILENO>{}), "zh_CN.UTF-8");
+        using CheckType = code_cvt<rb_root_cvt<std_device<STDERR_FILENO>>, char32_t>;
+        CheckType obj(rb_root_cvt{std_device<STDERR_FILENO>{}}, "zh_CN.UTF-8");
         helper(obj);
         if (g.contents() != e_lit) throw std::runtime_error("code_cvt<std_device>::put_bos fail");
     }
 
     {
         oguard<true> g;
-        using CheckType = code_cvt<root_cvt<std_device<STDOUT_FILENO>, true>, char32_t>;
-        CheckType tmp(make_root_cvt<true>(std_device<STDOUT_FILENO>{}), "zh_CN.UTF-8");
+        using CheckType = code_cvt<rb_root_cvt<std_device<STDOUT_FILENO>>, char32_t>;
+        CheckType tmp(rb_root_cvt{std_device<STDOUT_FILENO>{}}, "zh_CN.UTF-8");
         runtime_cvt obj(std::move(tmp));
         helper(obj);
         if (g.contents() != e_lit) throw std::runtime_error("code_cvt<std_device>::put_bos fail");
@@ -604,8 +604,8 @@ void test_code_cvt_stdio_char_put_1()
     
     {
         oguard<false> g;
-        using CheckType = code_cvt<root_cvt<std_device<STDERR_FILENO>, true>, char32_t>;
-        CheckType tmp(make_root_cvt<true>(std_device<STDERR_FILENO>{}), "zh_CN.UTF-8");
+        using CheckType = code_cvt<rb_root_cvt<std_device<STDERR_FILENO>>, char32_t>;
+        CheckType tmp(rb_root_cvt{std_device<STDERR_FILENO>{}}, "zh_CN.UTF-8");
         runtime_cvt obj(std::move(tmp));
         helper(obj);
         if (g.contents() != e_lit) throw std::runtime_error("code_cvt<std_device>::put_bos fail");
@@ -649,24 +649,24 @@ void test_code_cvt_stdio_char_put_2()
 
     {
         oguard<true> g;
-        using CheckType = code_cvt<root_cvt<std_device<STDOUT_FILENO>, true>, char32_t>;
-        CheckType obj(make_root_cvt<true>(std_device<STDOUT_FILENO>{}), "zh_CN.UTF-8");
+        using CheckType = code_cvt<rb_root_cvt<std_device<STDOUT_FILENO>>, char32_t>;
+        CheckType obj(rb_root_cvt{std_device<STDOUT_FILENO>{}}, "zh_CN.UTF-8");
         helper(obj);
         if (g.contents() != e_lit) throw std::runtime_error("code_cvt<std_device>::put_bos fail");
     }
     
     {
         oguard<false> g;
-        using CheckType = code_cvt<root_cvt<std_device<STDERR_FILENO>, true>, char32_t>;
-        CheckType obj(make_root_cvt<true>(std_device<STDERR_FILENO>{}), "zh_CN.UTF-8");
+        using CheckType = code_cvt<rb_root_cvt<std_device<STDERR_FILENO>>, char32_t>;
+        CheckType obj(rb_root_cvt{std_device<STDERR_FILENO>{}}, "zh_CN.UTF-8");
         helper(obj);
         if (g.contents() != e_lit) throw std::runtime_error("code_cvt<std_device>::put_bos fail");
     }
 
     {
         oguard<true> g;
-        using CheckType = code_cvt<root_cvt<std_device<STDOUT_FILENO>, true>, char32_t>;
-        CheckType tmp(make_root_cvt<true>(std_device<STDOUT_FILENO>{}), "zh_CN.UTF-8");
+        using CheckType = code_cvt<rb_root_cvt<std_device<STDOUT_FILENO>>, char32_t>;
+        CheckType tmp(rb_root_cvt{std_device<STDOUT_FILENO>{}}, "zh_CN.UTF-8");
         runtime_cvt obj(std::move(tmp));
         helper(obj);
         if (g.contents() != e_lit) throw std::runtime_error("code_cvt<std_device>::put_bos fail");
@@ -674,8 +674,8 @@ void test_code_cvt_stdio_char_put_2()
     
     {
         oguard<false> g;
-        using CheckType = code_cvt<root_cvt<std_device<STDERR_FILENO>, true>, char32_t>;
-        CheckType tmp(make_root_cvt<true>(std_device<STDERR_FILENO>{}), "zh_CN.UTF-8");
+        using CheckType = code_cvt<rb_root_cvt<std_device<STDERR_FILENO>>, char32_t>;
+        CheckType tmp(rb_root_cvt{std_device<STDERR_FILENO>{}}, "zh_CN.UTF-8");
         runtime_cvt obj(std::move(tmp));
         helper(obj);
         if (g.contents() != e_lit) throw std::runtime_error("code_cvt<std_device>::put_bos fail");

--- a/test/cvt/comp/zlib_cvt_char.cpp
+++ b/test/cvt/comp/zlib_cvt_char.cpp
@@ -29,7 +29,7 @@ void test_zlib_cvt_gen_1()
     dump_info("Test zlib_cvt general case 1...");
     
     {
-        using CheckType = Comp::zlib_cvt<root_cvt<mem_device<char>, true>>;
+        using CheckType = Comp::zlib_cvt<rb_root_cvt<mem_device<char>>>;
         static_assert(io_converter<CheckType>);
         static_assert(std::is_same_v<CheckType::device_type, mem_device<char>>);
         static_assert(std::is_same_v<CheckType::internal_type, char>);
@@ -42,7 +42,7 @@ void test_zlib_cvt_gen_1()
     }
     
     {
-        using CheckType = Comp::zlib_cvt<root_cvt<mem_device<char8_t>, false>>;
+        using CheckType = Comp::zlib_cvt<no_rb_root_cvt<mem_device<char8_t>>>;
         static_assert(io_converter<CheckType>);
         static_assert(std::is_same_v<CheckType::device_type, mem_device<char8_t>>);
         static_assert(std::is_same_v<CheckType::internal_type, char8_t>);
@@ -83,7 +83,7 @@ void test_zlib_cvt_gen_2()
         }
     
         {
-            T obj2{Comp::zlib_cvt{make_root_cvt<true>(mem_device(compress_res)), 0}};
+            T obj2{Comp::zlib_cvt{rb_root_cvt{mem_device(compress_res)}, 0}};
             if (obj2.bos() != io_status::input) throw std::runtime_error("zlib_cvt::bos response incorrect");
             obj2.main_cont_beg();
     
@@ -101,10 +101,10 @@ void test_zlib_cvt_gen_2()
         }
     };
 
-    Comp::zlib_cvt obj{make_root_cvt<true>(mem_device("")), 8};
+    Comp::zlib_cvt obj{rb_root_cvt{mem_device("")}, 8};
     helper(obj);
     
-    Comp::zlib_cvt tmp{make_root_cvt<true>(mem_device("")), 8};
+    Comp::zlib_cvt tmp{rb_root_cvt{mem_device("")}, 8};
     runtime_cvt obj2{std::move(tmp)};
     helper(obj2);
     dump_info("Done\n");
@@ -123,7 +123,7 @@ void test_zlib_cvt_gen_3()
             obj.main_cont_beg();
             obj.put(s_e_lit.data(), 1024);
             
-            T obj2(Comp::zlib_cvt{make_root_cvt<true>(mem_device("")), 8});
+            T obj2(Comp::zlib_cvt{rb_root_cvt{mem_device("")}, 8});
             obj2 = obj;
             obj.put(s_e_lit.data() + 1024, 4102 - 1024);
             obj2.put(s_e_lit.data() + 1024, 4102 - 1024);
@@ -137,7 +137,7 @@ void test_zlib_cvt_gen_3()
         }
     
         {
-            T obj2{Comp::zlib_cvt{make_root_cvt<true>(mem_device(compress_res)), 0}};
+            T obj2{Comp::zlib_cvt{rb_root_cvt{mem_device(compress_res)}, 0}};
             if (obj2.bos() != io_status::input) throw std::runtime_error("zlib_cvt::bos response incorrect");
             obj2.main_cont_beg();
     
@@ -146,7 +146,7 @@ void test_zlib_cvt_gen_3()
     
             if (obj2.get(out_buf1.data(), 1026) != 1026) throw std::runtime_error("zlib_cvt::get response incorrect");
     
-            T obj3(Comp::zlib_cvt{make_root_cvt<true>(mem_device("")), 8});
+            T obj3(Comp::zlib_cvt{rb_root_cvt{mem_device("")}, 8});
             obj3 = obj2;
             
             if (obj2.get(out_buf1.data() + 1026, 4102 - 1026) != 4102 - 1026) throw std::runtime_error("zlib_cvt::get response incorrect");
@@ -157,10 +157,10 @@ void test_zlib_cvt_gen_3()
         }
     };
 
-    Comp::zlib_cvt obj{make_root_cvt<true>(mem_device("")), 8};
+    Comp::zlib_cvt obj{rb_root_cvt{mem_device("")}, 8};
     helper(obj);
     
-    Comp::zlib_cvt tmp{make_root_cvt<true>(mem_device("")), 8};
+    Comp::zlib_cvt tmp{rb_root_cvt{mem_device("")}, 8};
     runtime_cvt obj2{std::move(tmp)};
     helper(obj2);
 
@@ -188,7 +188,7 @@ void test_zlib_cvt_gen_4()
         }
     
         {
-            T obj2{Comp::zlib_cvt{make_root_cvt<true>(mem_device(compress_res)), 0}};
+            T obj2{Comp::zlib_cvt{rb_root_cvt{mem_device(compress_res)}, 0}};
             if (obj2.bos() != io_status::input) throw std::runtime_error("zlib_cvt::bos response incorrect");
             obj2.main_cont_beg();
     
@@ -203,10 +203,10 @@ void test_zlib_cvt_gen_4()
         }
     };
 
-    Comp::zlib_cvt obj{make_root_cvt<true>(mem_device("")), 8};
+    Comp::zlib_cvt obj{rb_root_cvt{mem_device("")}, 8};
     helper(obj);
     
-    Comp::zlib_cvt tmp{make_root_cvt<true>(mem_device("")), 8};
+    Comp::zlib_cvt tmp{rb_root_cvt{mem_device("")}, 8};
     runtime_cvt obj2{std::move(tmp)};
     helper(obj2);
 
@@ -226,7 +226,7 @@ void test_zlib_cvt_gen_5()
             obj.main_cont_beg();
             obj.put(s_e_lit.data(), 1024);
     
-            T obj2(Comp::zlib_cvt{make_root_cvt<true>(mem_device("")), 8});
+            T obj2(Comp::zlib_cvt{rb_root_cvt{mem_device("")}, 8});
             obj2 = std::move(obj);
             obj2.put(s_e_lit.data() + 1024, 4102 - 1024);
             auto dev = obj2.detach();
@@ -235,14 +235,14 @@ void test_zlib_cvt_gen_5()
         }
     
         {
-            T obj2(Comp::zlib_cvt{make_root_cvt<true>(mem_device(compress_res)), 0});
+            T obj2(Comp::zlib_cvt{rb_root_cvt{mem_device(compress_res)}, 0});
             if (obj2.bos() != io_status::input) throw std::runtime_error("zlib_cvt::bos response incorrect");
             obj2.main_cont_beg();
     
             std::string out_buf; out_buf.resize(4102);
     
             if (obj2.get(out_buf.data(), 1026) != 1026) throw std::runtime_error("zlib_cvt::get response incorrect");
-            T obj3(Comp::zlib_cvt{make_root_cvt<true>(mem_device("")), 8});
+            T obj3(Comp::zlib_cvt{rb_root_cvt{mem_device("")}, 8});
             obj3 = std::move(obj2);
             
             if (obj3.get(out_buf.data() + 1026, 4102 - 1026) != 4102 - 1026) throw std::runtime_error("zlib_cvt::get response incorrect");
@@ -251,10 +251,10 @@ void test_zlib_cvt_gen_5()
         }
     };
 
-    Comp::zlib_cvt obj{make_root_cvt<true>(mem_device("")), 8};
+    Comp::zlib_cvt obj{rb_root_cvt{mem_device("")}, 8};
     helper(obj);
     
-    Comp::zlib_cvt tmp{make_root_cvt<true>(mem_device("")), 8};
+    Comp::zlib_cvt tmp{rb_root_cvt{mem_device("")}, 8};
     runtime_cvt obj2{std::move(tmp)};
     helper(obj2);
 
@@ -274,11 +274,11 @@ void test_zlib_cvt_bos_1()
         if (dev.str() != "\x78\x9c") throw std::runtime_error("zlib_cvt::put_bos fail");
     };
 
-    using CheckType = Comp::zlib_cvt<root_cvt<mem_device<char>, true>>;
-    CheckType obj(make_root_cvt<true>(mem_device("")), 6);
+    using CheckType = Comp::zlib_cvt<rb_root_cvt<mem_device<char>>>;
+    CheckType obj(rb_root_cvt{mem_device("")}, 6);
     helper(obj);
     
-    CheckType tmp(make_root_cvt<true>(mem_device("")), 6);
+    CheckType tmp(rb_root_cvt{mem_device("")}, 6);
     runtime_cvt obj2(std::move(tmp));
     helper(obj2);
 
@@ -302,11 +302,11 @@ void test_zlib_cvt_bos_2()
         if (dev.str() != "\x78\x9c""123") throw std::runtime_error("zlib_cvt::put_bos fail");
     };
 
-    using CheckType = Comp::zlib_cvt<root_cvt<mem_device<char>, true>>;
-    CheckType obj(make_root_cvt<true>(mem_device("")), 6);
+    using CheckType = Comp::zlib_cvt<rb_root_cvt<mem_device<char>>>;
+    CheckType obj(rb_root_cvt{mem_device("")}, 6);
     helper(obj);
 
-    CheckType tmp(make_root_cvt<true>(mem_device("")), 6);
+    CheckType tmp(rb_root_cvt{mem_device("")}, 6);
     runtime_cvt obj2(std::move(tmp));
     helper(obj2);
 
@@ -342,7 +342,7 @@ void test_zlib_cvt_io_1()
         }
         
         {
-            T obj2{Comp::zlib_cvt{make_root_cvt<true>(mem_device(compress_res)), 0}};
+            T obj2{Comp::zlib_cvt{rb_root_cvt{mem_device(compress_res)}, 0}};
             if (obj2.bos() != io_status::input) throw std::runtime_error("zlib_cvt::bos response incorrect");
             obj2.main_cont_beg();
     
@@ -353,10 +353,10 @@ void test_zlib_cvt_io_1()
         }
     };
 
-    Comp::zlib_cvt obj{make_root_cvt<true>(mem_device("")), 8};
+    Comp::zlib_cvt obj{rb_root_cvt{mem_device("")}, 8};
     helper(obj);
     
-    Comp::zlib_cvt tmp{make_root_cvt<true>(mem_device("")), 8};
+    Comp::zlib_cvt tmp{rb_root_cvt{mem_device("")}, 8};
     runtime_cvt obj2{std::move(tmp)};
     helper(obj2);
 
@@ -392,7 +392,7 @@ void test_zlib_cvt_io_2()
         }
         
         {
-            T obj2{Comp::zlib_cvt{make_root_cvt<true>(mem_device(compress_res)), 0}};
+            T obj2{Comp::zlib_cvt{rb_root_cvt{mem_device(compress_res)}, 0}};
             if (obj2.bos() != io_status::input) throw std::runtime_error("zlib_cvt::bos response incorrect");
             obj2.main_cont_beg();
     
@@ -403,10 +403,10 @@ void test_zlib_cvt_io_2()
         }
     };
 
-    Comp::zlib_cvt obj{make_root_cvt<true>(mem_device("")), 0};    // no compression
+    Comp::zlib_cvt obj{rb_root_cvt{mem_device("")}, 0};    // no compression
     helper(obj);
     
-    Comp::zlib_cvt tmp{make_root_cvt<true>(mem_device("")), 0};
+    Comp::zlib_cvt tmp{rb_root_cvt{mem_device("")}, 0};
     runtime_cvt obj2{std::move(tmp)};
     helper(obj2);
 
@@ -431,7 +431,7 @@ void test_zlib_cvt_io_3()
         }
         
         {
-            T obj2{Comp::zlib_cvt{make_root_cvt<true>(mem_device(compress_res)), 0}};
+            T obj2{Comp::zlib_cvt{rb_root_cvt{mem_device(compress_res)}, 0}};
             if (obj2.bos() != io_status::input) throw std::runtime_error("zlib_cvt::bos response incorrect");
             obj2.main_cont_beg();
     
@@ -458,10 +458,10 @@ void test_zlib_cvt_io_3()
     };
 
     Comp::zlib_cvt_creator<char> creator{6};
-    auto obj = creator.create(make_root_cvt<true>(mem_device("")));
+    auto obj = creator.create(rb_root_cvt{mem_device("")});
     helper(obj);
     
-    auto tmp = creator.create(make_root_cvt<true>(mem_device("")));
+    auto tmp = creator.create(rb_root_cvt{mem_device("")});
     runtime_cvt obj2(std::move(tmp));
     helper(obj2);
 
@@ -497,7 +497,7 @@ void test_zlib_cvt_flush_1()
         }
         
         {
-            T local_obj{Comp::zlib_cvt{make_root_cvt<true>(mem_device("")), 8}};
+            T local_obj{Comp::zlib_cvt{rb_root_cvt{mem_device("")}, 8}};
             if (local_obj.bos() != io_status::output) throw std::runtime_error("zlib_cvt::bos response incorrect");
             local_obj.main_cont_beg();
             
@@ -517,10 +517,10 @@ void test_zlib_cvt_flush_1()
     };
 
     Comp::zlib_cvt_creator<char> creator{8};
-    auto obj = creator.create(make_root_cvt<true>(mem_device("")));
+    auto obj = creator.create(rb_root_cvt{mem_device("")});
     helper(obj);
     
-    auto tmp = creator.create(make_root_cvt<true>(mem_device("")));
+    auto tmp = creator.create(rb_root_cvt{mem_device("")});
     runtime_cvt obj2(std::move(tmp));
     helper(obj2);
 
@@ -556,7 +556,7 @@ void test_zlib_cvt_flush_2()
         }
         
         {
-            T local_obj{Comp::zlib_cvt{make_root_cvt<true>(mem_device("")), 8}};
+            T local_obj{Comp::zlib_cvt{rb_root_cvt{mem_device("")}, 8}};
             if (local_obj.bos() != io_status::output) throw std::runtime_error("zlib_cvt::bos response incorrect");
             local_obj.main_cont_beg();
     
@@ -585,7 +585,7 @@ void test_zlib_cvt_flush_2()
         }
     
         {
-            T local_obj{Comp::zlib_cvt{make_root_cvt<true>(mem_device(compress_res)), 0}};
+            T local_obj{Comp::zlib_cvt{rb_root_cvt{mem_device(compress_res)}, 0}};
             if (local_obj.bos() != io_status::input) throw std::runtime_error("zlib_cvt::bos response incorrect");
             local_obj.main_cont_beg();
     
@@ -597,10 +597,10 @@ void test_zlib_cvt_flush_2()
     };
 
     Comp::zlib_cvt_creator<char> creator{8};
-    auto obj = creator.create(make_root_cvt<true>(mem_device("")));
+    auto obj = creator.create(rb_root_cvt{mem_device("")});
     helper(obj);
     
-    auto tmp = creator.create(make_root_cvt<true>(mem_device("")));
+    auto tmp = creator.create(rb_root_cvt{mem_device("")});
     runtime_cvt obj2(std::move(tmp));
     helper(obj2);
 
@@ -636,7 +636,7 @@ void test_zlib_cvt_reset_1()
         }
         
         {
-            T local_obj{Comp::zlib_cvt{make_root_cvt<true>(mem_device("")), 8}};
+            T local_obj{Comp::zlib_cvt{rb_root_cvt{mem_device("")}, 8}};
             if (local_obj.bos() != io_status::output) throw std::runtime_error("zlib_cvt::bos response incorrect");
             local_obj.main_cont_beg();
             
@@ -656,10 +656,10 @@ void test_zlib_cvt_reset_1()
     };
 
     Comp::zlib_cvt_creator<char> creator{8};
-    auto obj = creator.create(make_root_cvt<true>(mem_device("")));
+    auto obj = creator.create(rb_root_cvt{mem_device("")});
     helper(obj);
     
-    auto tmp = creator.create(make_root_cvt<true>(mem_device("")));
+    auto tmp = creator.create(rb_root_cvt{mem_device("")});
     runtime_cvt obj2(std::move(tmp));
     helper(obj2);
 

--- a/test/cvt/comp/zlib_cvt_wchar_t.cpp
+++ b/test/cvt/comp/zlib_cvt_wchar_t.cpp
@@ -84,7 +84,7 @@ void test_zlib_cvt_wchar_t_gen_2()
     
         {
             Comp::zlib_cvt_creator<wchar_t> creator{8};
-            T obj2{creator.create(make_root_cvt<true>(mem_device(compress_res)))};
+            T obj2{creator.create(rb_root_cvt{mem_device(compress_res)})};
             if (obj2.bos() != io_status::input) throw std::runtime_error("zlib_cvt::bos response incorrect");
             obj2.main_cont_beg();
     
@@ -103,10 +103,10 @@ void test_zlib_cvt_wchar_t_gen_2()
     };
 
     Comp::zlib_cvt_creator<wchar_t> creator{8};
-    auto obj = creator.create(make_root_cvt<true>(mem_device("")));
+    auto obj = creator.create(rb_root_cvt{mem_device("")});
     helper(obj);
 
-    runtime_cvt obj2{creator.create(make_root_cvt<true>(mem_device("")))};
+    runtime_cvt obj2{creator.create(rb_root_cvt{mem_device("")})};
     helper(obj2);
     dump_info("Done\n");
 }
@@ -125,7 +125,7 @@ void test_zlib_cvt_wchar_t_gen_3()
             obj.main_cont_beg();
             obj.put(s_e_lit.data(), 1024);
             
-            T obj2 = creator.create(make_root_cvt<true>(mem_device("")));
+            T obj2 = creator.create(rb_root_cvt{mem_device("")});
             obj2 = obj;
             obj.put(s_e_lit.data() + 1024, 4102 - 1024);
             obj2.put(s_e_lit.data() + 1024, 4102 - 1024);
@@ -139,7 +139,7 @@ void test_zlib_cvt_wchar_t_gen_3()
         }
     
         {
-            T obj2{creator.create(make_root_cvt<true>(mem_device(compress_res)))};
+            T obj2{creator.create(rb_root_cvt{mem_device(compress_res)})};
             if (obj2.bos() != io_status::input) throw std::runtime_error("zlib_cvt::bos response incorrect");
             obj2.main_cont_beg();
     
@@ -148,7 +148,7 @@ void test_zlib_cvt_wchar_t_gen_3()
     
             if (obj2.get(out_buf1.data(), 1026) != 1026) throw std::runtime_error("zlib_cvt::get response incorrect");
     
-            T obj3{creator.create(make_root_cvt<true>(mem_device("")))};
+            T obj3{creator.create(rb_root_cvt{mem_device("")})};
             obj3 = obj2;
             
             if (obj2.get(out_buf1.data() + 1026, 4102 - 1026) != 4102 - 1026) throw std::runtime_error("zlib_cvt::get response incorrect");
@@ -160,10 +160,10 @@ void test_zlib_cvt_wchar_t_gen_3()
     };
 
     Comp::zlib_cvt_creator<wchar_t> creator{8};
-    auto obj = creator.create(make_root_cvt<true>(mem_device("")));
+    auto obj = creator.create(rb_root_cvt{mem_device("")});
     helper(obj);
     
-    runtime_cvt obj2{creator.create(make_root_cvt<true>(mem_device("")))};
+    runtime_cvt obj2{creator.create(rb_root_cvt{mem_device("")})};
     helper(obj2);
 
     dump_info("Done\n");
@@ -191,7 +191,7 @@ void test_zlib_cvt_wchar_t_gen_4()
         }
     
         {
-            T obj2{creator.create(make_root_cvt<true>(mem_device(compress_res)))};
+            T obj2{creator.create(rb_root_cvt{mem_device(compress_res)})};
             if (obj2.bos() != io_status::input) throw std::runtime_error("zlib_cvt::bos response incorrect");
             obj2.main_cont_beg();
     
@@ -207,10 +207,10 @@ void test_zlib_cvt_wchar_t_gen_4()
     };
 
     Comp::zlib_cvt_creator<wchar_t> creator{8};
-    auto obj = creator.create(make_root_cvt<true>(mem_device("")));
+    auto obj = creator.create(rb_root_cvt{mem_device("")});
     helper(obj);
     
-    runtime_cvt obj2{creator.create(make_root_cvt<true>(mem_device("")))};
+    runtime_cvt obj2{creator.create(rb_root_cvt{mem_device("")})};
     helper(obj2);
 
     dump_info("Done\n");
@@ -230,7 +230,7 @@ void test_zlib_cvt_wchar_t_gen_5()
             obj.main_cont_beg();
             obj.put(s_e_lit.data(), 1024);
 
-            T obj2{creator.create(make_root_cvt<true>(mem_device("")))};
+            T obj2{creator.create(rb_root_cvt{mem_device("")})};
             obj2 = std::move(obj);
             obj2.put(s_e_lit.data() + 1024, 4102 - 1024);
             auto dev = obj2.detach();
@@ -239,14 +239,14 @@ void test_zlib_cvt_wchar_t_gen_5()
         }
     
         {
-            T obj2{creator.create(make_root_cvt<true>(mem_device(compress_res)))};
+            T obj2{creator.create(rb_root_cvt{mem_device(compress_res)})};
             if (obj2.bos() != io_status::input) throw std::runtime_error("zlib_cvt::bos response incorrect");
             obj2.main_cont_beg();
     
             std::wstring out_buf; out_buf.resize(4102);
     
             if (obj2.get(out_buf.data(), 1026) != 1026) throw std::runtime_error("zlib_cvt::get response incorrect");
-            T obj3{creator.create(make_root_cvt<true>(mem_device("")))};
+            T obj3{creator.create(rb_root_cvt{mem_device("")})};
             obj3 = std::move(obj2);
             
             if (obj3.get(out_buf.data() + 1026, 4102 - 1026) != 4102 - 1026) throw std::runtime_error("zlib_cvt::get response incorrect");
@@ -256,10 +256,10 @@ void test_zlib_cvt_wchar_t_gen_5()
     };
 
     Comp::zlib_cvt_creator<wchar_t> creator{8};
-    auto obj = creator.create(make_root_cvt<true>(mem_device("")));
+    auto obj = creator.create(rb_root_cvt{mem_device("")});
     helper(obj);
     
-    runtime_cvt obj2{creator.create(make_root_cvt<true>(mem_device("")))};
+    runtime_cvt obj2{creator.create(rb_root_cvt{mem_device("")})};
     helper(obj2);
 
     dump_info("Done\n");
@@ -279,10 +279,10 @@ void test_zlib_cvt_wchar_t_bos_1()
     };
 
     Comp::zlib_cvt_creator<wchar_t> creator{6};
-    auto obj(creator.create(make_root_cvt<true>(mem_device(""))));
+    auto obj(creator.create(rb_root_cvt{mem_device("")}));
     helper(obj);
     
-    runtime_cvt obj2{creator.create(make_root_cvt<true>(mem_device("")))};
+    runtime_cvt obj2{creator.create(rb_root_cvt{mem_device("")})};
     helper(obj2);
 
     dump_info("Done\n");
@@ -306,10 +306,10 @@ void test_zlib_cvt_wchar_t_bos_2()
     };
 
     Comp::zlib_cvt_creator<wchar_t> creator{6};
-    auto obj(creator.create(make_root_cvt<true>(mem_device(""))));
+    auto obj(creator.create(rb_root_cvt{mem_device("")}));
     helper(obj);
 
-    runtime_cvt obj2{creator.create(make_root_cvt<true>(mem_device("")))};
+    runtime_cvt obj2{creator.create(rb_root_cvt{mem_device("")})};
     helper(obj2);
 
     dump_info("Done\n");
@@ -345,7 +345,7 @@ void test_zlib_cvt_wchar_t_io_1()
         }
         
         {
-            T obj2{creator.create(make_root_cvt<true>(mem_device(compress_res)))};
+            T obj2{creator.create(rb_root_cvt{mem_device(compress_res)})};
             if (obj2.bos() != io_status::input) throw std::runtime_error("zlib_cvt::bos response incorrect");
             obj2.main_cont_beg();
     
@@ -357,10 +357,10 @@ void test_zlib_cvt_wchar_t_io_1()
     };
 
     Comp::zlib_cvt_creator<wchar_t> creator{8};
-    auto obj(creator.create(make_root_cvt<true>(mem_device(""))));
+    auto obj(creator.create(rb_root_cvt{mem_device("")}));
     helper(obj);
     
-    runtime_cvt obj2{creator.create(make_root_cvt<true>(mem_device("")))};
+    runtime_cvt obj2{creator.create(rb_root_cvt{mem_device("")})};
     helper(obj2);
 
     dump_info("Done\n");
@@ -396,7 +396,7 @@ void test_zlib_cvt_wchar_t_io_2()
         }
         
         {
-            T obj2{creator.create(make_root_cvt<true>(mem_device(compress_res)))};
+            T obj2{creator.create(rb_root_cvt{mem_device(compress_res)})};
             if (obj2.bos() != io_status::input) throw std::runtime_error("zlib_cvt::bos response incorrect");
             obj2.main_cont_beg();
     
@@ -408,10 +408,10 @@ void test_zlib_cvt_wchar_t_io_2()
     };
 
     Comp::zlib_cvt_creator<wchar_t> creator{0};         // no compression
-    auto obj(creator.create(make_root_cvt<true>(mem_device(""))));
+    auto obj(creator.create(rb_root_cvt{mem_device("")}));
     helper(obj);
     
-    runtime_cvt obj2{creator.create(make_root_cvt<true>(mem_device("")))};
+    runtime_cvt obj2{creator.create(rb_root_cvt{mem_device("")})};
     helper(obj2);
 
     dump_info("Done\n");
@@ -436,7 +436,7 @@ void test_zlib_cvt_wchar_t_io_3()
         
         {
             Comp::zlib_cvt_creator<wchar_t> creator{0};
-            T obj2{creator.create(make_root_cvt<true>(mem_device(compress_res)))};
+            T obj2{creator.create(rb_root_cvt{mem_device(compress_res)})};
             if (obj2.bos() != io_status::input) throw std::runtime_error("zlib_cvt::bos response incorrect");
             obj2.main_cont_beg();
     
@@ -463,10 +463,10 @@ void test_zlib_cvt_wchar_t_io_3()
     };
 
     Comp::zlib_cvt_creator<wchar_t> creator{6};
-    auto obj(creator.create(make_root_cvt<true>(mem_device(""))));
+    auto obj(creator.create(rb_root_cvt{mem_device("")}));
     helper(obj);
     
-    runtime_cvt obj2{creator.create(make_root_cvt<true>(mem_device("")))};
+    runtime_cvt obj2{creator.create(rb_root_cvt{mem_device("")})};
     helper(obj2);
 
     dump_info("Done\n");
@@ -502,7 +502,7 @@ void test_zlib_cvt_wchar_t_flush_1()
         
         {
             Comp::zlib_cvt_creator<wchar_t> creator{8};
-            T local_obj(creator.create(make_root_cvt<true>(mem_device(""))));
+            T local_obj(creator.create(rb_root_cvt{mem_device("")}));
             if (local_obj.bos() != io_status::output) throw std::runtime_error("zlib_cvt::bos response incorrect");
             local_obj.main_cont_beg();
             
@@ -522,10 +522,10 @@ void test_zlib_cvt_wchar_t_flush_1()
     };
 
     Comp::zlib_cvt_creator<wchar_t> creator{8};
-    auto obj(creator.create(make_root_cvt<true>(mem_device(""))));
+    auto obj(creator.create(rb_root_cvt{mem_device("")}));
     helper(obj);
 
-    runtime_cvt obj2{creator.create(make_root_cvt<true>(mem_device("")))};
+    runtime_cvt obj2{creator.create(rb_root_cvt{mem_device("")})};
     helper(obj2);
 
     dump_info("Done\n");
@@ -561,7 +561,7 @@ void test_zlib_cvt_wchar_t_flush_2()
         
         {
             Comp::zlib_cvt_creator<wchar_t> creator{8};
-            T local_obj(creator.create(make_root_cvt<true>(mem_device(""))));
+            T local_obj(creator.create(rb_root_cvt{mem_device("")}));
             if (local_obj.bos() != io_status::output) throw std::runtime_error("zlib_cvt::bos response incorrect");
             local_obj.main_cont_beg();
     
@@ -591,7 +591,7 @@ void test_zlib_cvt_wchar_t_flush_2()
     
         {
             Comp::zlib_cvt_creator<wchar_t> creator{0};
-            T local_obj(creator.create(make_root_cvt<true>(mem_device(compress_res))));
+            T local_obj(creator.create(rb_root_cvt{mem_device(compress_res)}));
             if (local_obj.bos() != io_status::input) throw std::runtime_error("zlib_cvt::bos response incorrect");
             local_obj.main_cont_beg();
     
@@ -603,10 +603,10 @@ void test_zlib_cvt_wchar_t_flush_2()
     };
 
     Comp::zlib_cvt_creator<wchar_t> creator{8};
-    auto obj(creator.create(make_root_cvt<true>(mem_device(""))));
+    auto obj(creator.create(rb_root_cvt{mem_device("")}));
     helper(obj);
     
-    runtime_cvt obj2{creator.create(make_root_cvt<true>(mem_device("")))};
+    runtime_cvt obj2{creator.create(rb_root_cvt{mem_device("")})};
     helper(obj2);
 
     dump_info("Done\n");
@@ -642,7 +642,7 @@ void test_zlib_cvt_wchar_t_reset_1()
         
         {
             Comp::zlib_cvt_creator<wchar_t> creator{8};
-            T local_obj(creator.create(make_root_cvt<true>(mem_device(""))));
+            T local_obj(creator.create(rb_root_cvt{mem_device("")}));
             if (local_obj.bos() != io_status::output) throw std::runtime_error("zlib_cvt::bos response incorrect");
             local_obj.main_cont_beg();
             
@@ -662,10 +662,10 @@ void test_zlib_cvt_wchar_t_reset_1()
     };
 
     Comp::zlib_cvt_creator<wchar_t> creator{8};
-    auto obj = creator.create(make_root_cvt<true>(mem_device("")));
+    auto obj = creator.create(rb_root_cvt{mem_device("")});
     helper(obj);
     
-    auto tmp = creator.create(make_root_cvt<true>(mem_device("")));
+    auto tmp = creator.create(rb_root_cvt{mem_device("")});
     runtime_cvt obj2(std::move(tmp));
     helper(obj2);
 

--- a/test/cvt/crypt/chacha20_cvt.cpp
+++ b/test/cvt/crypt/chacha20_cvt.cpp
@@ -10,7 +10,7 @@ void test_chacha20_cvt_gen_1()
     dump_info("Test chacha20_cvt general case 1...");
     
     {
-        using CheckType = Crypt::chacha20_cvt<root_cvt<mem_device<char>, true>>;
+        using CheckType = Crypt::chacha20_cvt<rb_root_cvt<mem_device<char>>>;
         static_assert(IOv2::io_converter<CheckType>);
         static_assert(std::is_same_v<CheckType::device_type, mem_device<char>>);
         static_assert(std::is_same_v<CheckType::internal_type, char>);
@@ -22,7 +22,7 @@ void test_chacha20_cvt_gen_1()
     }
     
     {
-        using CheckType = Crypt::chacha20_cvt<root_cvt<mem_device<char8_t>, false>>;
+        using CheckType = Crypt::chacha20_cvt<no_rb_root_cvt<mem_device<char8_t>>>;
         static_assert(IOv2::io_converter<CheckType>);
         static_assert(std::is_same_v<CheckType::device_type, mem_device<char8_t>>);
         static_assert(std::is_same_v<CheckType::internal_type, char8_t>);
@@ -81,7 +81,7 @@ void test_chacha20_cvt_gen_2()
         }
     
         {
-            T local_obj(Crypt::chacha20_cvt{make_root_cvt<true>(mem_device(enc_msg)), "liwei"});
+            T local_obj(Crypt::chacha20_cvt{rb_root_cvt{mem_device(enc_msg)}, "liwei"});
             if (local_obj.bos() != io_status::input) throw std::runtime_error("chacha20::bos response incorrect");
             local_obj.main_cont_beg();
             
@@ -109,11 +109,11 @@ void test_chacha20_cvt_gen_2()
         }
     };
 
-    using CheckType = Crypt::chacha20_cvt<root_cvt<mem_device<char>, true>>;
-    CheckType obj(make_root_cvt<true>(mem_device("")), "liwei");
+    using CheckType = Crypt::chacha20_cvt<rb_root_cvt<mem_device<char>>>;
+    CheckType obj(rb_root_cvt{mem_device("")}, "liwei");
     helper(obj);
 
-    CheckType tmp(make_root_cvt<true>(mem_device("")), "liwei");
+    CheckType tmp(rb_root_cvt{mem_device("")}, "liwei");
     runtime_cvt obj2(std::move(tmp));
     helper(obj2);
 
@@ -137,7 +137,7 @@ void test_chacha20_cvt_put_1()
         e_lit[i+6] = (i / 7) % 127 + 1;
     }
 
-    using CheckType = Crypt::chacha20_cvt<root_cvt<mem_device<char>, true>>;
+    using CheckType = Crypt::chacha20_cvt<rb_root_cvt<mem_device<char>>>;
 
     auto out_helper = [&e_lit](auto& obj1, auto& obj2)
     {
@@ -169,15 +169,15 @@ void test_chacha20_cvt_put_1()
         if (r1 == r2) throw std::runtime_error("chacha20::put response incorrect");
     };
 
-    using CheckType = Crypt::chacha20_cvt<root_cvt<mem_device<char>, true>>;
+    using CheckType = Crypt::chacha20_cvt<rb_root_cvt<mem_device<char>>>;
     {
-        CheckType obj1(make_root_cvt<true>(mem_device("")), "liwei");
-        CheckType obj2(make_root_cvt<true>(mem_device("")), "liwei");
+        CheckType obj1(rb_root_cvt{mem_device("")}, "liwei");
+        CheckType obj2(rb_root_cvt{mem_device("")}, "liwei");
         out_helper(obj1, obj2);
     }
     {
-        CheckType tmp1(make_root_cvt<true>(mem_device("")), "liwei");
-        CheckType tmp2(make_root_cvt<true>(mem_device("")), "liwei");
+        CheckType tmp1(rb_root_cvt{mem_device("")}, "liwei");
+        CheckType tmp2(rb_root_cvt{mem_device("")}, "liwei");
         runtime_cvt obj1(std::move(tmp1));
         runtime_cvt obj2(std::move(tmp2));
         out_helper(obj1, obj2);
@@ -228,7 +228,7 @@ void test_chacha20_cvt_io_1()
         }
     
         {
-            T local_obj(Crypt::chacha20_cvt{make_root_cvt<true>(mem_device(enc_msg)), "liwei"});
+            T local_obj(Crypt::chacha20_cvt{rb_root_cvt{mem_device(enc_msg)}, "liwei"});
             if (local_obj.bos() != io_status::input) throw std::runtime_error("chacha20_cvt::bos response incorrect");
             local_obj.main_cont_beg();
             
@@ -240,11 +240,11 @@ void test_chacha20_cvt_io_1()
         }
     };
 
-    using CheckType = Crypt::chacha20_cvt<root_cvt<mem_device<char>, true>>;
-    CheckType obj(make_root_cvt<true>(mem_device("")), "liwei");
+    using CheckType = Crypt::chacha20_cvt<rb_root_cvt<mem_device<char>>>;
+    CheckType obj(rb_root_cvt{mem_device("")}, "liwei");
     helper(obj);
 
-    CheckType tmp(make_root_cvt<true>(mem_device("")), "liwei");
+    CheckType tmp(rb_root_cvt{mem_device("")}, "liwei");
     runtime_cvt obj2(std::move(tmp));
     helper(obj2);
     
@@ -259,10 +259,10 @@ void test_chacha20_cvt_key_1()
     std::string msg = "Hello, world! This is a test message for ChaCha20.";
     std::string enc_msg;
 
-    using CheckType = Crypt::chacha20_cvt<root_cvt<mem_device<char>, true>>;
+    using CheckType = Crypt::chacha20_cvt<rb_root_cvt<mem_device<char>>>;
 
     {
-        CheckType obj(make_root_cvt<true>(mem_device("")), "key1");
+        CheckType obj(rb_root_cvt{mem_device("")}, "key1");
         obj.bos();
         obj.main_cont_beg();
         obj.put(msg.data(), msg.size());
@@ -270,7 +270,7 @@ void test_chacha20_cvt_key_1()
     }
 
     {
-        CheckType obj(make_root_cvt<true>(mem_device(enc_msg)), "key1");
+        CheckType obj(rb_root_cvt{mem_device(enc_msg)}, "key1");
         obj.bos();
         obj.main_cont_beg();
         std::string dec_msg;
@@ -280,7 +280,7 @@ void test_chacha20_cvt_key_1()
     }
 
     {
-        CheckType obj(make_root_cvt<true>(mem_device(enc_msg)), "key2");
+        CheckType obj(rb_root_cvt{mem_device(enc_msg)}, "key2");
         obj.bos();
         obj.main_cont_beg();
         std::string dec_msg;

--- a/test/cvt/crypt/charchar20_cvt_wchar_t.cpp
+++ b/test/cvt/crypt/charchar20_cvt_wchar_t.cpp
@@ -82,7 +82,7 @@ void test_chacha20_cvt_wchar_t_gen_2()
         }
     
         {
-            T local_obj(creator.create(make_root_cvt<true>(mem_device(enc_msg))));
+            T local_obj(creator.create(rb_root_cvt{mem_device(enc_msg)}));
             if (local_obj.bos() != io_status::input) throw std::runtime_error("chacha20::bos response incorrect");
             local_obj.main_cont_beg();
             
@@ -111,10 +111,10 @@ void test_chacha20_cvt_wchar_t_gen_2()
     };
 
     Crypt::chacha20_cvt_creator<wchar_t> creator("liwei");
-    auto obj = creator.create(make_root_cvt<true>(mem_device("")));
+    auto obj = creator.create(rb_root_cvt{mem_device("")});
     helper(obj);
 
-    runtime_cvt obj2(creator.create(make_root_cvt<true>(mem_device(""))));
+    runtime_cvt obj2(creator.create(rb_root_cvt{mem_device("")}));
     helper(obj2);
 
     dump_info("Done\n");
@@ -169,13 +169,13 @@ void test_chacha20_cvt_wchar_t_put_1()
 
     Crypt::chacha20_cvt_creator<wchar_t> creator("liwei");
     {
-        auto obj1 = creator.create(make_root_cvt<true>(mem_device("")));
-        auto obj2 = creator.create(make_root_cvt<true>(mem_device("")));
+        auto obj1 = creator.create(rb_root_cvt{mem_device("")});
+        auto obj2 = creator.create(rb_root_cvt{mem_device("")});
         out_helper(obj1, obj2);
     }
     {
-        runtime_cvt obj1(creator.create(make_root_cvt<true>(mem_device(""))));
-        runtime_cvt obj2(creator.create(make_root_cvt<true>(mem_device(""))));
+        runtime_cvt obj1(creator.create(rb_root_cvt{mem_device("")}));
+        runtime_cvt obj2(creator.create(rb_root_cvt{mem_device("")}));
         out_helper(obj1, obj2);
     }
     dump_info("Done\n");
@@ -225,7 +225,7 @@ void test_chacha20_cvt_wchar_t_io_1()
         }
     
         {
-            T local_obj(creator.create(make_root_cvt<true>(mem_device(enc_msg))));
+            T local_obj(creator.create(rb_root_cvt{mem_device(enc_msg)}));
             if (local_obj.bos() != io_status::input) throw std::runtime_error("chacha20_cvt::bos response incorrect");
             local_obj.main_cont_beg();
             
@@ -238,10 +238,10 @@ void test_chacha20_cvt_wchar_t_io_1()
     };
 
     Crypt::chacha20_cvt_creator<wchar_t> creator("liwei");
-    auto obj = creator.create(make_root_cvt<true>(mem_device("")));
+    auto obj = creator.create(rb_root_cvt{mem_device("")});
     helper(obj);
 
-    runtime_cvt obj2(creator.create(make_root_cvt<true>(mem_device(""))));
+    runtime_cvt obj2(creator.create(rb_root_cvt{mem_device("")}));
     helper(obj2);
     
     dump_info("Done\n");

--- a/test/cvt/crypt/md5_cvt.cpp
+++ b/test/cvt/crypt/md5_cvt.cpp
@@ -21,7 +21,7 @@ void test_md5_cvt_gen_1()
     dump_info("Test md5_cvt general case 1...");
     
     {
-        using CheckType = Crypt::hash_cvt<root_cvt<mem_device<char>, true>>;
+        using CheckType = Crypt::hash_cvt<rb_root_cvt<mem_device<char>>>;
         static_assert(IOv2::io_converter<CheckType>);
         static_assert(std::is_same_v<CheckType::device_type, mem_device<char>>);
         static_assert(std::is_same_v<CheckType::internal_type, char>);
@@ -33,7 +33,7 @@ void test_md5_cvt_gen_1()
     }
     
     {
-        using CheckType = Crypt::hash_cvt<root_cvt<mem_device<char8_t>, false>>;
+        using CheckType = Crypt::hash_cvt<no_rb_root_cvt<mem_device<char8_t>>>;
         static_assert(IOv2::io_converter<CheckType>);
         static_assert(std::is_same_v<CheckType::device_type, mem_device<char8_t>>);
         static_assert(std::is_same_v<CheckType::internal_type, char8_t>);
@@ -66,10 +66,10 @@ void test_md5_cvt_gen_2()
     };
 
     Crypt::hash_cvt_creator<char> creator(Crypt::hash_algo::MD5);
-    auto obj = creator.create(make_root_cvt<true>(mem_device{""}));
+    auto obj = creator.create(rb_root_cvt{mem_device{""}});
     helper(obj);
 
-    auto tmp = creator.create(make_root_cvt<true>(mem_device{""}));
+    auto tmp = creator.create(rb_root_cvt{mem_device{""}});
     runtime_cvt obj2(std::move(tmp));
     helper(obj2);
 
@@ -87,7 +87,7 @@ void test_md5_cvt_gen_3()
         if (obj.bos() != io_status::output) throw std::runtime_error("md5_cvt<mem_device>::bos response incorrect");
         obj.main_cont_beg();
         obj.put("he", 2);
-        T obj2(creator.create(make_root_cvt<true>(mem_device{""})));
+        T obj2(creator.create(rb_root_cvt{mem_device{""}}));
         obj2 = obj;
         obj2.put("llo", 3);
         auto dev = obj2.detach();
@@ -96,10 +96,10 @@ void test_md5_cvt_gen_3()
         if (dev2.str() == hello_md5_hex_low) throw std::runtime_error("md5_cvt<mem_device>::put response incorrect");
     };
 
-    auto obj = creator.create(make_root_cvt<true>(mem_device{""}));
+    auto obj = creator.create(rb_root_cvt{mem_device{""}});
     helper(obj);
 
-    auto tmp = creator.create(make_root_cvt<true>(mem_device{""}));
+    auto tmp = creator.create(rb_root_cvt{mem_device{""}});
     runtime_cvt obj2(std::move(tmp));
     helper(obj2);
 
@@ -123,10 +123,10 @@ void test_md5_cvt_gen_4()
     };
 
     Crypt::hash_cvt_creator<char> creator(Crypt::hash_algo::MD5);
-    auto obj = creator.create(make_root_cvt<true>(mem_device{""}));
+    auto obj = creator.create(rb_root_cvt{mem_device{""}});
     helper(obj);
 
-    auto tmp = creator.create(make_root_cvt<true>(mem_device{""}));
+    auto tmp = creator.create(rb_root_cvt{mem_device{""}});
     runtime_cvt obj2(std::move(tmp));
     helper(obj2);
 
@@ -144,17 +144,17 @@ void test_md5_cvt_gen_5()
         if (obj.bos() != io_status::output) throw std::runtime_error("md5_cvt<mem_device>::bos response incorrect");
         obj.main_cont_beg();
         obj.put("he", 2);
-        T obj2(creator.create(make_root_cvt<true>(mem_device{""})));
+        T obj2(creator.create(rb_root_cvt{mem_device{""}}));
         obj2 = std::move(obj);
         obj2.put("llo", 3);
         auto dev = obj2.detach();
         if (dev.str() != hello_md5_hex_low) throw std::runtime_error("md5_cvt<mem_device>::put response incorrect");
     };
 
-    auto obj = creator.create(make_root_cvt<true>(mem_device{""}));
+    auto obj = creator.create(rb_root_cvt{mem_device{""}});
     helper(obj);
 
-    auto tmp = creator.create(make_root_cvt<true>(mem_device{""}));
+    auto tmp = creator.create(rb_root_cvt{mem_device{""}});
     runtime_cvt obj2(std::move(tmp));
     helper(obj2);
 
@@ -176,10 +176,10 @@ void test_md5_cvt_put_1()
     };
 
     Crypt::hash_cvt_creator<char> creator(Crypt::hash_algo::MD5);
-    auto obj = creator.create(make_root_cvt<true>(mem_device{""}));
+    auto obj = creator.create(rb_root_cvt{mem_device{""}});
     helper(obj);
 
-    auto tmp = creator.create(make_root_cvt<true>(mem_device{""}));
+    auto tmp = creator.create(rb_root_cvt{mem_device{""}});
     runtime_cvt obj2(std::move(tmp));
     helper(obj2);
     
@@ -230,10 +230,10 @@ void test_md5_cvt_put_2()
     };
 
     Crypt::hash_cvt_creator<char> creator(Crypt::hash_algo::MD5);
-    auto obj = creator.create(make_root_cvt<true>(mem_device{""}));
+    auto obj = creator.create(rb_root_cvt{mem_device{""}});
     helper(obj);
 
-    auto tmp = creator.create(make_root_cvt<true>(mem_device{""}));
+    auto tmp = creator.create(rb_root_cvt{mem_device{""}});
     runtime_cvt obj2(std::move(tmp));
     helper(obj2);
 
@@ -270,10 +270,10 @@ void test_md5_cvt_put_3()
     };
 
     Crypt::hash_cvt_creator<char> creator(Crypt::hash_algo::MD5);
-    auto obj = creator.create(make_root_cvt<true>(mem_device{""}));
+    auto obj = creator.create(rb_root_cvt{mem_device{""}});
     helper(obj);
 
-    auto tmp = creator.create(make_root_cvt<true>(mem_device{""}));
+    auto tmp = creator.create(rb_root_cvt{mem_device{""}});
     runtime_cvt obj2(std::move(tmp));
     helper(obj2);
 
@@ -296,10 +296,10 @@ void test_md5_cvt_put_4()
     };
 
     Crypt::hash_cvt_creator<char> creator(Crypt::hash_algo::MD5);
-    auto obj = creator.create(make_root_cvt<true>(mem_device{""}));
+    auto obj = creator.create(rb_root_cvt{mem_device{""}});
     helper(obj);
 
-    auto tmp = creator.create(make_root_cvt<true>(mem_device{""}));
+    auto tmp = creator.create(rb_root_cvt{mem_device{""}});
     runtime_cvt obj2(std::move(tmp));
     helper(obj2);
 
@@ -350,10 +350,10 @@ void test_md5_cvt_put_5()
     };
     
     Crypt::hash_cvt_creator<char8_t> creator(Crypt::hash_algo::MD5);
-    auto obj = creator.create(make_root_cvt<true>(mem_device{u8""}));
+    auto obj = creator.create(rb_root_cvt{mem_device{u8""}});
     helper(obj);
 
-    auto tmp = creator.create(make_root_cvt<true>(mem_device{u8""}));
+    auto tmp = creator.create(rb_root_cvt{mem_device{u8""}});
     runtime_cvt obj2(std::move(tmp));
     helper(obj2);
 

--- a/test/cvt/crypt/sha256_cvt.cpp
+++ b/test/cvt/crypt/sha256_cvt.cpp
@@ -35,10 +35,10 @@ void test_sha256_cvt_gen_1()
     };
 
     Crypt::hash_cvt_creator<char> creator(Crypt::hash_algo::SHA256);
-    auto obj = creator.create(make_root_cvt<true>(mem_device{""}));
+    auto obj = creator.create(rb_root_cvt{mem_device{""}});
     helper(obj);
 
-    auto tmp = creator.create(make_root_cvt<true>(mem_device{""}));
+    auto tmp = creator.create(rb_root_cvt{mem_device{""}});
     runtime_cvt obj2(std::move(tmp));
     helper(obj2);
 
@@ -56,7 +56,7 @@ void test_sha256_cvt_gen_2()
         if (obj.bos() != io_status::output) throw std::runtime_error("sha256_cvt<mem_device>::bos response incorrect");
         obj.main_cont_beg();
         obj.put("he", 2);
-        T obj2(creator.create(make_root_cvt<true>(mem_device{""})));
+        T obj2(creator.create(rb_root_cvt{mem_device{""}}));
         obj2 = obj;
         obj2.put("llo", 3);
         auto dev = obj2.detach();
@@ -65,10 +65,10 @@ void test_sha256_cvt_gen_2()
         if (dev2.str() == hello_hex_low) throw std::runtime_error("sha256_cvt<mem_device>::put response incorrect");
     };
 
-    auto obj = creator.create(make_root_cvt<true>(mem_device{""}));
+    auto obj = creator.create(rb_root_cvt{mem_device{""}});
     helper(obj);
 
-    auto tmp = creator.create(make_root_cvt<true>(mem_device{""}));
+    auto tmp = creator.create(rb_root_cvt{mem_device{""}});
     runtime_cvt obj2(std::move(tmp));
     helper(obj2);
 
@@ -92,10 +92,10 @@ void test_sha256_cvt_gen_3()
     };
 
     Crypt::hash_cvt_creator<char> creator(Crypt::hash_algo::SHA256);
-    auto obj = creator.create(make_root_cvt<true>(mem_device{""}));
+    auto obj = creator.create(rb_root_cvt{mem_device{""}});
     helper(obj);
 
-    auto tmp = creator.create(make_root_cvt<true>(mem_device{""}));
+    auto tmp = creator.create(rb_root_cvt{mem_device{""}});
     runtime_cvt obj2(std::move(tmp));
     helper(obj2);
 
@@ -113,17 +113,17 @@ void test_sha256_cvt_gen_4()
         if (obj.bos() != io_status::output) throw std::runtime_error("sha256_cvt<mem_device>::bos response incorrect");
         obj.main_cont_beg();
         obj.put("he", 2);
-        T obj2(creator.create(make_root_cvt<true>(mem_device{""})));
+        T obj2(creator.create(rb_root_cvt{mem_device{""}}));
         obj2 = std::move(obj);
         obj2.put("llo", 3);
         auto dev = obj2.detach();
         if (dev.str() != hello_hex_low) throw std::runtime_error("sha256_cvt<mem_device>::put response incorrect");
     };
 
-    auto obj = creator.create(make_root_cvt<true>(mem_device{""}));
+    auto obj = creator.create(rb_root_cvt{mem_device{""}});
     helper(obj);
 
-    auto tmp = creator.create(make_root_cvt<true>(mem_device{""}));
+    auto tmp = creator.create(rb_root_cvt{mem_device{""}});
     runtime_cvt obj2(std::move(tmp));
     helper(obj2);
 
@@ -145,10 +145,10 @@ void test_sha256_cvt_put_1()
     };
 
     Crypt::hash_cvt_creator<char> creator(Crypt::hash_algo::SHA256);
-    auto obj = creator.create(make_root_cvt<true>(mem_device{""}));
+    auto obj = creator.create(rb_root_cvt{mem_device{""}});
     helper(obj);
 
-    auto tmp = creator.create(make_root_cvt<true>(mem_device{""}));
+    auto tmp = creator.create(rb_root_cvt{mem_device{""}});
     runtime_cvt obj2(std::move(tmp));
     helper(obj2);
 
@@ -199,10 +199,10 @@ void test_sha256_cvt_put_2()
     };
 
     Crypt::hash_cvt_creator<char> creator(Crypt::hash_algo::SHA256);
-    auto obj = creator.create(make_root_cvt<true>(mem_device{""}));
+    auto obj = creator.create(rb_root_cvt{mem_device{""}});
     helper(obj);
 
-    auto tmp = creator.create(make_root_cvt<true>(mem_device{""}));
+    auto tmp = creator.create(rb_root_cvt{mem_device{""}});
     runtime_cvt obj2(std::move(tmp));
     helper(obj2);
 
@@ -239,10 +239,10 @@ void test_sha256_cvt_put_3()
     };
 
     Crypt::hash_cvt_creator<char> creator(Crypt::hash_algo::SHA256);
-    auto obj = creator.create(make_root_cvt<true>(mem_device{""}));
+    auto obj = creator.create(rb_root_cvt{mem_device{""}});
     helper(obj);
 
-    auto tmp = creator.create(make_root_cvt<true>(mem_device{""}));
+    auto tmp = creator.create(rb_root_cvt{mem_device{""}});
     runtime_cvt obj2(std::move(tmp));
     helper(obj2);
 
@@ -265,10 +265,10 @@ void test_sha256_cvt_put_4()
     };
 
     Crypt::hash_cvt_creator<char> creator(Crypt::hash_algo::SHA256);
-    auto obj = creator.create(make_root_cvt<true>(mem_device{""}));
+    auto obj = creator.create(rb_root_cvt{mem_device{""}});
     helper(obj);
 
-    auto tmp = creator.create(make_root_cvt<true>(mem_device{""}));
+    auto tmp = creator.create(rb_root_cvt{mem_device{""}});
     runtime_cvt obj2(std::move(tmp));
     helper(obj2);
 
@@ -319,10 +319,10 @@ void test_sha256_cvt_put_5()
     };
 
     Crypt::hash_cvt_creator<char8_t> creator(Crypt::hash_algo::SHA256);
-    auto obj = creator.create(make_root_cvt<true>(mem_device{u8""}));
+    auto obj = creator.create(rb_root_cvt{mem_device{u8""}});
     helper(obj);
 
-    auto tmp = creator.create(make_root_cvt<true>(mem_device{u8""}));
+    auto tmp = creator.create(rb_root_cvt{mem_device{u8""}});
     runtime_cvt obj2(std::move(tmp));
     helper(obj2);
     

--- a/test/cvt/crypt/vigener_cvt.cpp
+++ b/test/cvt/crypt/vigener_cvt.cpp
@@ -11,7 +11,7 @@ void test_vigenere_cvt_gen_1()
     dump_info("Test vigenere_cvt general case 1...");
     
     {
-        using CheckType = Crypt::Classic::vigenere_cvt<root_cvt<mem_device<char>, true>>;
+        using CheckType = Crypt::Classic::vigenere_cvt<rb_root_cvt<mem_device<char>>>;
         static_assert(IOv2::io_converter<CheckType>);
         static_assert(std::is_same_v<CheckType::device_type, mem_device<char>>);
         static_assert(std::is_same_v<CheckType::internal_type, char>);
@@ -23,7 +23,7 @@ void test_vigenere_cvt_gen_1()
     }
     
     {
-        using CheckType = Crypt::Classic::vigenere_cvt<root_cvt<mem_device<char32_t>, false>>;
+        using CheckType = Crypt::Classic::vigenere_cvt<no_rb_root_cvt<mem_device<char32_t>>>;
         static_assert(IOv2::io_converter<CheckType>);
         static_assert(std::is_same_v<CheckType::device_type, mem_device<char32_t>>);
         static_assert(std::is_same_v<CheckType::internal_type, char32_t>);
@@ -42,7 +42,7 @@ void test_vigenere_cvt_gen_2()
     using namespace IOv2;
     dump_info("Test vigenere_cvt<mem_device> general case 2...");
     
-    using CheckType = Crypt::Classic::vigenere_cvt<root_cvt<mem_device<char>, true>>;
+    using CheckType = Crypt::Classic::vigenere_cvt<rb_root_cvt<mem_device<char>>>;
     
     auto helper1 = [](auto& obj)
     {
@@ -68,11 +68,11 @@ void test_vigenere_cvt_gen_2()
     
     {
         mem_device dev{"hello"}; dev.drseek(0);
-        CheckType obj{make_root_cvt<true>(std::move(dev)), "abcdef"};
+        CheckType obj{rb_root_cvt{std::move(dev)}, "abcdef"};
         helper1(obj);
 
         mem_device dev2{"hello"}; dev2.drseek(0);
-        CheckType tmp{make_root_cvt<true>(std::move(dev2)), "abcdef"};
+        CheckType tmp{rb_root_cvt{std::move(dev2)}, "abcdef"};
         runtime_cvt obj2(std::move(tmp));
         helper1(obj2);
     }
@@ -81,7 +81,7 @@ void test_vigenere_cvt_gen_2()
     {
         if (obj.bos() != io_status::output) throw std::runtime_error("vigenere_cvt<mem_device>::bos response incorrect");
         obj.main_cont_beg();
-        T obj2{Crypt::Classic::vigenere_cvt{make_root_cvt<true>(mem_device("")), "abcdef"}};
+        T obj2{Crypt::Classic::vigenere_cvt{rb_root_cvt{mem_device("")}, "abcdef"}};
         obj2 = obj;
         if (obj2.device().str() != "hello") throw std::runtime_error("vigenere_cvt<mem_device> copy assignment response incorrect");
         
@@ -102,11 +102,11 @@ void test_vigenere_cvt_gen_2()
 
     {
         mem_device dev{"hello"}; dev.drseek(0);
-        CheckType obj{make_root_cvt<true>(std::move(dev)), "abcdef"};
+        CheckType obj{rb_root_cvt{std::move(dev)}, "abcdef"};
         helper2(obj);
 
         mem_device dev2{"hello"}; dev2.drseek(0);
-        CheckType tmp{make_root_cvt<true>(std::move(dev2)), "abcdef"};
+        CheckType tmp{rb_root_cvt{std::move(dev2)}, "abcdef"};
         runtime_cvt obj2(std::move(tmp));
         helper2(obj2);
     }
@@ -120,11 +120,11 @@ void test_vigenere_cvt_gen_2()
     };
     {
         mem_device dev{"hello"}; dev.drseek(0);
-        CheckType obj{make_root_cvt<true>(std::move(dev)), "abcdef"};
+        CheckType obj{rb_root_cvt{std::move(dev)}, "abcdef"};
         helper3(obj);
 
         mem_device dev2{"hello"}; dev2.drseek(0);
-        CheckType tmp{make_root_cvt<true>(std::move(dev2)), "abcdef"};
+        CheckType tmp{rb_root_cvt{std::move(dev2)}, "abcdef"};
         runtime_cvt obj2(std::move(tmp));
         helper3(obj2);
     }
@@ -133,17 +133,17 @@ void test_vigenere_cvt_gen_2()
     {
         if (obj.bos() != io_status::output) throw std::runtime_error("vigenere_cvt<mem_device>::bos response incorrect");
         obj.main_cont_beg();
-        T obj2{Crypt::Classic::vigenere_cvt{make_root_cvt<true>(mem_device("")), "abcdef"}};
+        T obj2{Crypt::Classic::vigenere_cvt{rb_root_cvt{mem_device("")}, "abcdef"}};
         obj2 = std::move(obj);
         if (obj2.device().str() != "hello") throw std::runtime_error("vigenere_cvt<mem_device> move assignment response incorrect");
     };
     {
         mem_device dev{"hello"}; dev.drseek(0);
-        CheckType obj{make_root_cvt<true>(std::move(dev)), "abcdef"};
+        CheckType obj{rb_root_cvt{std::move(dev)}, "abcdef"};
         helper4(obj);
 
         mem_device dev2{"hello"}; dev2.drseek(0);
-        CheckType tmp{make_root_cvt<true>(std::move(dev2)), "abcdef"};
+        CheckType tmp{rb_root_cvt{std::move(dev2)}, "abcdef"};
         runtime_cvt obj2(std::move(tmp));
         helper4(obj2);
     }
@@ -155,7 +155,7 @@ void test_vigenere_cvt_get_1()
 {
     using namespace IOv2;
     dump_info("Test vigenere_cvt::get case 1...");
-    using CheckType = Crypt::Classic::vigenere_cvt<root_cvt<mem_device<char>, true>>;
+    using CheckType = Crypt::Classic::vigenere_cvt<rb_root_cvt<mem_device<char>>>;
 
     std::string e_lit; e_lit.resize(4102);
     std::string i_lit; i_lit.resize(4102);
@@ -196,10 +196,10 @@ void test_vigenere_cvt_get_1()
             if (out_buf[i] != i_lit[i]) throw std::runtime_error("vigenere_cvt::get response incorrect");
     };
 
-    CheckType obj{make_root_cvt<true>(mem_device(e_lit)), "liweixy"};
+    CheckType obj{rb_root_cvt{mem_device(e_lit)}, "liweixy"};
     helper(obj);
     
-    CheckType tmp{make_root_cvt<true>(mem_device(e_lit)), "liweixy"};
+    CheckType tmp{rb_root_cvt{mem_device(e_lit)}, "liweixy"};
     runtime_cvt obj2{std::move(tmp)};
     helper(obj2);
 
@@ -210,7 +210,7 @@ void test_vigenere_cvt_get_nra_1()
 {
     using namespace IOv2;
     dump_info("Test vigenere_cvt::get_nra case 1...");
-    using CheckType = Crypt::Classic::vigenere_cvt<root_cvt<mem_device<char>, false>>;
+    using CheckType = Crypt::Classic::vigenere_cvt<no_rb_root_cvt<mem_device<char>>>;
 
     std::string e_lit; e_lit.resize(4102);
     std::string i_lit; i_lit.resize(4102);
@@ -252,10 +252,10 @@ void test_vigenere_cvt_get_nra_1()
             if (out_buf[i] != i_lit[i]) throw std::runtime_error("vigenere_cvt::get response incorrect");
     };
 
-    CheckType obj{make_root_cvt<false>(mem_device(e_lit)), "liweixy"};
+    CheckType obj{no_rb_root_cvt{mem_device(e_lit)}, "liweixy"};
     helper(obj);
     
-    CheckType tmp{make_root_cvt<false>(mem_device(e_lit)), "liweixy"};
+    CheckType tmp{no_rb_root_cvt{mem_device(e_lit)}, "liweixy"};
     runtime_cvt obj2{std::move(tmp)};
     helper(obj2);
 
@@ -266,7 +266,7 @@ void test_vigenere_cvt_put_1()
 {
     using namespace IOv2;
     dump_info("Test vigenere_cvt::put case 1...");
-    using CheckType = Crypt::Classic::vigenere_cvt<root_cvt<mem_device<char>, true>>;
+    using CheckType = Crypt::Classic::vigenere_cvt<rb_root_cvt<mem_device<char>>>;
 
     std::string e_lit; e_lit.resize(4102);
     std::string i_lit; i_lit.resize(4102);
@@ -306,10 +306,10 @@ void test_vigenere_cvt_put_1()
             if (dev.str()[i] != i_lit[i]) throw std::runtime_error("vigenere_cvt::get response incorrect");
     };
 
-    CheckType obj{make_root_cvt<true>(mem_device("")), "liweixy"};
+    CheckType obj{rb_root_cvt{mem_device("")}, "liweixy"};
     helper(obj);
     
-    CheckType tmp{make_root_cvt<true>(mem_device("")), "liweixy"};
+    CheckType tmp{rb_root_cvt{mem_device("")}, "liweixy"};
     runtime_cvt obj2{std::move(tmp)};
     helper(obj2);
 
@@ -337,15 +337,15 @@ void test_vigenere_cvt_seek_1()
         if ((obj.get(&ch, 1) != 1) || (ch != '3' - 'w')) throw std::runtime_error("vigenere_cvt::get fail");
     };
     
-    using CheckType = Crypt::Classic::vigenere_cvt<root_cvt<mem_device<char>, true>>;
+    using CheckType = Crypt::Classic::vigenere_cvt<rb_root_cvt<mem_device<char>>>;
     {
         mem_device dev("12345");
-        CheckType obj(make_root_cvt<true>(dev), "liwei");
+        CheckType obj(rb_root_cvt{dev}, "liwei");
         helper(obj);
     }
     {
         mem_device dev("12345");
-        CheckType tmp(make_root_cvt<true>(dev), "liwei");
+        CheckType tmp(rb_root_cvt{dev}, "liwei");
         runtime_cvt obj(std::move(tmp));
         helper(obj);
     }
@@ -387,10 +387,10 @@ void test_vigenere_cvt_seek_2()
     };
 
     Crypt::Classic::vigenere_cvt_creator<char> creator("liwei");
-    auto obj = creator.create(make_root_cvt<true>(mem_device("123abcdefg")));
+    auto obj = creator.create(rb_root_cvt{mem_device("123abcdefg")});
     helper(obj);
 
-    auto tmp = creator.create(make_root_cvt<true>(mem_device("123abcdefg")));
+    auto tmp = creator.create(rb_root_cvt{mem_device("123abcdefg")});
     runtime_cvt obj2(std::move(tmp));
     helper(obj2);
 

--- a/test/cvt/cvt_io/test_root_cvt_io.cpp
+++ b/test/cvt/cvt_io/test_root_cvt_io.cpp
@@ -33,10 +33,10 @@ void test_root_cvt_mem_input_1()
         VERIFY(std::string(ptr, ptr + len) == "456");
     };
 
-    auto obj1 = make_root_cvt<true>(mem_device{"123456"});
+    auto obj1 = rb_root_cvt{mem_device{"123456"}};
     helper(obj1);
 
-    auto obj2 = make_root_cvt<false>(mem_device{"123456"});
+    auto obj2 = no_rb_root_cvt{mem_device{"123456"}};
     helper(obj2);
 
     dump_info("Done\n");
@@ -69,10 +69,10 @@ void test_root_cvt_mem_input_2()
         VERIFY(std::string(ptr, ptr + len) == "45678");
     };
 
-    auto obj1 = make_root_cvt<true>(mem_device{"0123456789"});
+    auto obj1 = rb_root_cvt{mem_device{"0123456789"}};
     helper(obj1);
 
-    auto obj2 = make_root_cvt<false>(mem_device{"0123456789"});
+    auto obj2 = no_rb_root_cvt{mem_device{"0123456789"}};
     helper(obj2);
 
     dump_info("Done\n");
@@ -111,10 +111,10 @@ void test_root_cvt_mem_input_3()
         VERIFY(res == ref);
     };
 
-    auto obj1 = make_root_cvt<true>(mem_device{ref});
+    auto obj1 = rb_root_cvt{mem_device{ref}};
     helper(obj1);
 
-    auto obj2 = make_root_cvt<false>(mem_device{ref});
+    auto obj2 = no_rb_root_cvt{mem_device{ref}};
     helper(obj2);
 
     dump_info("Done\n");
@@ -150,10 +150,10 @@ void test_root_cvt_mem_output_1()
         VERIFY(obj.detach().str() == "1234567");
     };
 
-    auto obj1 = make_root_cvt<true>(mem_device{""});
+    auto obj1 = rb_root_cvt{mem_device{""}};
     helper(obj1);
 
-    auto obj2 = make_root_cvt<false>(mem_device{""});
+    auto obj2 = no_rb_root_cvt{mem_device{""}};
     helper(obj2);
 
     dump_info("Done\n");
@@ -192,10 +192,10 @@ void test_root_cvt_mem_output_2()
         VERIFY(obj.detach().str() == "1234567");
     };
 
-    auto obj1 = make_root_cvt<true>(mem_device{""});
+    auto obj1 = rb_root_cvt{mem_device{""}};
     helper(obj1);
 
-    auto obj2 = make_root_cvt<false>(mem_device{""});
+    auto obj2 = no_rb_root_cvt{mem_device{""}};
     helper(obj2);
 
 
@@ -236,10 +236,10 @@ void test_root_cvt_mem_output_3()
         VERIFY(obj.detach().str() == ref);
     };
 
-    auto obj1 = make_root_cvt<true>(mem_device{""});
+    auto obj1 = rb_root_cvt{mem_device{""}};
     helper(obj1);
 
-    auto obj2 = make_root_cvt<false>(mem_device{""});
+    auto obj2 = no_rb_root_cvt{mem_device{""}};
     helper(obj2);
 
     dump_info("Done\n");
@@ -279,10 +279,10 @@ void test_root_cvt_mem_saturate_input_1()
         VERIFY(res == ref);
     };
 
-    auto obj1 = make_root_cvt<true>(snatchy_device<char, 3>{ref});
+    auto obj1 = rb_root_cvt{snatchy_device<char, 3>{ref}};
     helper(obj1);
 
-    auto obj2 = make_root_cvt<false>(snatchy_device<char, 3>{ref});
+    auto obj2 = no_rb_root_cvt{snatchy_device<char, 3>{ref}};
     helper(obj2);
 
     dump_info("Done\n");

--- a/test/cvt/cvt_pipe_creator/test_cvt_pipe_creator.cpp
+++ b/test/cvt/cvt_pipe_creator/test_cvt_pipe_creator.cpp
@@ -62,12 +62,12 @@ void test_cvt_pipe_creator_put_1()
                    code_cvt_creator<char, char32_t>("zh_CN.UTF-8");
 
     {
-        auto obj = creator.create(make_root_cvt<true>(mem_device("")));
+        auto obj = creator.create(rb_root_cvt{mem_device("")});
         helper(obj);
     }
 
     {
-        auto tmp = creator.create(make_root_cvt<true>(mem_device("")));
+        auto tmp = creator.create(rb_root_cvt{mem_device("")});
         runtime_cvt obj(std::move(tmp));
         helper(obj);
     }
@@ -118,7 +118,7 @@ void test_cvt_pipe_creator_put_2()
                        (Comp::zlib_cvt_creator<char>(6) | 
                         code_cvt_creator<char, char32_t>("zh_CN.UTF-8"));
 
-        auto obj = creator.create(make_root_cvt<true>(mem_device("")));
+        auto obj = creator.create(rb_root_cvt{mem_device("")});
         hash_res = helper(obj);
     }
 
@@ -128,7 +128,7 @@ void test_cvt_pipe_creator_put_2()
                        Comp::zlib_cvt_creator<char>(6) | 
                        code_cvt_creator<char, char32_t>("zh_CN.UTF-8");
 
-        auto tmp = creator.create(make_root_cvt<true>(mem_device("")));
+        auto tmp = creator.create(rb_root_cvt{mem_device("")});
         runtime_cvt obj{std::move(tmp)};
         if (hash_res != helper(obj)) throw std::runtime_error("cvt_pipe response incorrect");
     }
@@ -180,7 +180,7 @@ void test_cvt_pipe_creator_put_3()
                        (Crypt::hash_cvt_creator<char>(Crypt::hash_algo::MD5) |
                         code_cvt_creator<char, char32_t>("zh_CN.UTF-8"));
 
-        auto obj = creator.create(make_root_cvt<true>(mem_device("")));
+        auto obj = creator.create(rb_root_cvt{mem_device("")});
         hash_res = helper(obj);
     }
 
@@ -190,7 +190,7 @@ void test_cvt_pipe_creator_put_3()
                        (Crypt::hash_cvt_creator<char>(Crypt::hash_algo::MD5) |
                         code_cvt_creator<char, char32_t>("zh_CN.UTF-8"));
 
-        auto tmp = creator.create(make_root_cvt<true>(mem_device("")));
+        auto tmp = creator.create(rb_root_cvt{mem_device("")});
         runtime_cvt obj{std::move(tmp)};
         if (hash_res != helper(obj)) throw std::runtime_error("cvt_pipe response incorrect");
     }
@@ -253,12 +253,12 @@ void test_cvt_pipe_creator_get_1()
                    code_cvt_creator<char, char32_t>("zh_CN.UTF-8");
 
     {
-        auto obj = creator.create(make_root_cvt<true>(mem_device(e_lit)));
+        auto obj = creator.create(rb_root_cvt{mem_device(e_lit)});
         helper(obj);
     }
     
     {
-        auto tmp = creator.create(make_root_cvt<true>(mem_device(e_lit)));
+        auto tmp = creator.create(rb_root_cvt{mem_device(e_lit)});
         runtime_cvt obj{std::move(tmp)};
         helper(obj);
     }
@@ -293,7 +293,7 @@ void test_cvt_pipe_creator_io_1()
         auto dev = obj.detach();
         e_lit = dev.str();
         
-        T obj2 = p_creator.create(make_root_cvt<true>(mem_device(e_lit)));
+        T obj2 = p_creator.create(rb_root_cvt{mem_device(e_lit)});
         std::u32string ilit2; ilit2.resize(4102 * 2);
         if (obj2.bos() != io_status::input) throw std::runtime_error("cvt_pipe::bos response incorrect");
         obj2.main_cont_beg();
@@ -302,10 +302,10 @@ void test_cvt_pipe_creator_io_1()
         if (ilit2.substr(0, 4102 / 7 * 3) != i_lit) throw std::runtime_error("cvt_pipe io response incorrect");
     };
     
-    auto obj = creator.create(make_root_cvt<true>(mem_device("")));
+    auto obj = creator.create(rb_root_cvt{mem_device("")});
     helper(obj, creator);
 
-    auto tmp = creator.create(make_root_cvt<true>(mem_device("")));
+    auto tmp = creator.create(rb_root_cvt{mem_device("")});
     runtime_cvt obj2{std::move(tmp)};
     helper(obj2, creator);
 
@@ -340,7 +340,7 @@ void test_cvt_pipe_creator_io_2()
         auto dev = obj.detach();
         e_lit = dev.str();
         
-        T obj2 = p_creator.create(make_root_cvt<true>(mem_device(e_lit)));
+        T obj2 = p_creator.create(rb_root_cvt{mem_device(e_lit)});
         std::u32string ilit2; ilit2.resize(4102 * 2);
         if (obj2.bos() != io_status::input) throw std::runtime_error("cvt_pipe::bos response incorrect");
         obj2.main_cont_beg();
@@ -349,10 +349,10 @@ void test_cvt_pipe_creator_io_2()
         if (ilit2.substr(0, 4102 / 7 * 3) != i_lit) throw std::runtime_error("cvt_pipe io response incorrect");
     };
 
-    auto obj = creator.create(make_root_cvt<true>(mem_device("")));
+    auto obj = creator.create(rb_root_cvt{mem_device("")});
     helper(obj, creator);
 
-    auto tmp = creator.create(make_root_cvt<true>(mem_device("")));
+    auto tmp = creator.create(rb_root_cvt{mem_device("")});
     runtime_cvt obj2{std::move(tmp)};
     helper(obj2, creator);
     

--- a/test/cvt/root_cvt/root_cvt_file.cpp
+++ b/test/cvt/root_cvt/root_cvt_file.cpp
@@ -14,7 +14,7 @@ void test_root_cvt_file_gen_1()
     dump_info("Test root_cvt<file_device> general case 1...");
     
     {
-        using CheckType = root_cvt<basic_file_device<true, true, char>, false>;
+        using CheckType = no_rb_root_cvt<basic_file_device<true, true, char>>;
         static_assert(io_converter<CheckType>);
         static_assert(std::is_same_v<CheckType::device_type, basic_file_device<true, true, char>>);
         static_assert(std::is_same_v<CheckType::internal_type, char>);
@@ -27,7 +27,7 @@ void test_root_cvt_file_gen_1()
     }
     
     {
-        using CheckType = root_cvt<basic_file_device<true, true, char8_t>, true>;
+        using CheckType = rb_root_cvt<basic_file_device<true, true, char8_t>>;
         static_assert(io_converter<CheckType>);
         static_assert(std::is_same_v<CheckType::device_type, basic_file_device<true, true, char8_t>>);
         static_assert(std::is_same_v<CheckType::internal_type, char8_t>);
@@ -40,7 +40,7 @@ void test_root_cvt_file_gen_1()
     }
     
     {
-        using CheckType = root_cvt<basic_file_device<true, false, char>, false>;
+        using CheckType = no_rb_root_cvt<basic_file_device<true, false, char>>;
         static_assert(!cvt_cpt::support_put<CheckType>);
         static_assert(cvt_cpt::support_get<CheckType>);
         static_assert(cvt_cpt::support_positioning<CheckType>);
@@ -48,7 +48,7 @@ void test_root_cvt_file_gen_1()
     }
     
     {
-        using CheckType = root_cvt<basic_file_device<false, true, char>, true>;
+        using CheckType = rb_root_cvt<basic_file_device<false, true, char>>;
         static_assert(cvt_cpt::support_put<CheckType>);
         static_assert(!cvt_cpt::support_get<CheckType>);
         static_assert(cvt_cpt::support_positioning<CheckType>);
@@ -76,7 +76,7 @@ void test_root_cvt_file_gen_2()
         file_guard g1("test_file", "hello");
         basic_file_device<true, true, char> dev("test_file");
         dev.drseek(0);
-        auto obj = make_root_cvt<true>(std::move(dev));
+        auto obj = rb_root_cvt{std::move(dev)};
         helper1(obj);
         if (g1.contents() != "hello world") throw std::runtime_error("root_cvt<file_device> output incorrect");
     }
@@ -85,7 +85,7 @@ void test_root_cvt_file_gen_2()
         file_guard g1("test_file", "hello");
         basic_file_device<false, true, char> dev("test_file");
         dev.drseek(0);
-        auto obj = make_root_cvt<true>(std::move(dev));
+        auto obj = rb_root_cvt{std::move(dev)};
         helper1(obj);
         if (g1.contents() != " world") throw std::runtime_error("root_cvt<file_device> output incorrect");
     }
@@ -94,7 +94,7 @@ void test_root_cvt_file_gen_2()
         file_guard g1("test_file", "hello");
         basic_file_device<true, true, char> dev("test_file");
         dev.drseek(0);
-        auto tmp = make_root_cvt<true>(std::move(dev));
+        auto tmp = rb_root_cvt{std::move(dev)};
         runtime_cvt obj(std::move(tmp));
         helper1(obj);
         if (g1.contents() != "hello world") throw std::runtime_error("root_cvt<file_device> output incorrect");
@@ -104,7 +104,7 @@ void test_root_cvt_file_gen_2()
         file_guard g1("test_file", "hello");
         basic_file_device<false, true, char> dev("test_file");
         dev.drseek(0);
-        auto tmp = make_root_cvt<true>(std::move(dev));
+        auto tmp = rb_root_cvt{std::move(dev)};
         runtime_cvt obj(std::move(tmp));
         helper1(obj);
         if (g1.contents() != " world") throw std::runtime_error("root_cvt<file_device> output incorrect");
@@ -116,7 +116,7 @@ void test_root_cvt_file_gen_2()
         obj.main_cont_beg();
 
         using dev_type = typename T::device_type;
-        T obj2{make_root_cvt<true>(dev_type{})};
+        T obj2{rb_root_cvt{dev_type{}}};
         obj2 = std::move(obj);
         obj2.put(" world", 6);
     };
@@ -125,7 +125,7 @@ void test_root_cvt_file_gen_2()
         file_guard g1("test_file", "hello");
         basic_file_device<true, true, char> dev("test_file");
         dev.drseek(0);
-        auto obj = make_root_cvt<true>(std::move(dev));
+        auto obj = rb_root_cvt{std::move(dev)};
         helper2(obj);
         if (g1.contents() != "hello world") throw std::runtime_error("root_cvt<file_device> output incorrect");
     }
@@ -134,7 +134,7 @@ void test_root_cvt_file_gen_2()
         file_guard g1("test_file", "hello");
         basic_file_device<false, true, char> dev("test_file");
         dev.drseek(0);
-        auto obj = make_root_cvt<true>(std::move(dev));
+        auto obj = rb_root_cvt{std::move(dev)};
         helper2(obj);
         if (g1.contents() != " world") throw std::runtime_error("root_cvt<file_device> output incorrect");
     }
@@ -143,7 +143,7 @@ void test_root_cvt_file_gen_2()
         file_guard g1("test_file", "hello");
         basic_file_device<true, true, char> dev("test_file");
         dev.drseek(0);
-        auto tmp = make_root_cvt<true>(std::move(dev));
+        auto tmp = rb_root_cvt{std::move(dev)};
         runtime_cvt obj(std::move(tmp));
         helper2(obj);
         if (g1.contents() != "hello world") throw std::runtime_error("root_cvt<file_device> output incorrect");
@@ -153,7 +153,7 @@ void test_root_cvt_file_gen_2()
         file_guard g1("test_file", "hello");
         basic_file_device<false, true, char> dev("test_file");
         dev.drseek(0);
-        auto tmp = make_root_cvt<true>(std::move(dev));
+        auto tmp = rb_root_cvt{std::move(dev)};
         runtime_cvt obj(std::move(tmp));
         helper2(obj);
         if (g1.contents() != " world") throw std::runtime_error("root_cvt<file_device> output incorrect");
@@ -187,21 +187,21 @@ void test_root_cvt_file_gen_3()
     {
         file_guard g1("test_file", "hello world");
         basic_file_device<true, true, char> dev("test_file");
-        auto obj = make_root_cvt<true>(std::move(dev));
+        auto obj = rb_root_cvt{std::move(dev)};
         helper1(obj);
     }
     
     {
         file_guard g1("test_file", "hello world");
         basic_file_device<true, false, char> dev("test_file");
-        auto obj = make_root_cvt<true>(std::move(dev));
+        auto obj = rb_root_cvt{std::move(dev)};
         helper1(obj);
     }
     
     {
         file_guard g1("test_file", "hello world");
         basic_file_device<true, true, char> dev("test_file");
-        auto tmp = make_root_cvt<true>(std::move(dev));
+        auto tmp = rb_root_cvt{std::move(dev)};
         runtime_cvt obj(std::move(tmp));
         helper1(obj);
     }
@@ -209,7 +209,7 @@ void test_root_cvt_file_gen_3()
     {
         file_guard g1("test_file", "hello world");
         basic_file_device<true, false, char> dev("test_file");
-        auto tmp = make_root_cvt<true>(std::move(dev));
+        auto tmp = rb_root_cvt{std::move(dev)};
         runtime_cvt obj(std::move(tmp));
         helper1(obj);
     }
@@ -224,7 +224,7 @@ void test_root_cvt_file_gen_3()
         if (obj.tell() != 5) throw std::runtime_error("root_cvt<std_device>::tell response incorrect");
 
         using dev_type = typename T::device_type;
-        T obj2{make_root_cvt<true>(dev_type{})};
+        T obj2{rb_root_cvt{dev_type{}}};
         obj2 = std::move(obj);
 
         if (obj2.tell() != 5) throw std::runtime_error("root_cvt<std_device>::tell response incorrect");
@@ -237,21 +237,21 @@ void test_root_cvt_file_gen_3()
     {
         file_guard g1("test_file", "hello world");
         basic_file_device<true, true, char> dev("test_file");
-        auto obj = make_root_cvt<true>(std::move(dev));
+        auto obj = rb_root_cvt{std::move(dev)};
         helper2(obj);
     }
     
     {
         file_guard g1("test_file", "hello world");
         basic_file_device<true, false, char> dev("test_file");
-        auto obj = make_root_cvt<true>(std::move(dev));
+        auto obj = rb_root_cvt{std::move(dev)};
         helper2(obj);
     }
     
     {
         file_guard g1("test_file", "hello world");
         basic_file_device<true, true, char> dev("test_file");
-        auto tmp = make_root_cvt<true>(std::move(dev));
+        auto tmp = rb_root_cvt{std::move(dev)};
         runtime_cvt obj(std::move(tmp));
         helper2(obj);
     }
@@ -259,7 +259,7 @@ void test_root_cvt_file_gen_3()
     {
         file_guard g1("test_file", "hello world");
         basic_file_device<true, false, char> dev("test_file");
-        auto tmp = make_root_cvt<true>(std::move(dev));
+        auto tmp = rb_root_cvt{std::move(dev)};
         runtime_cvt obj(std::move(tmp));
         helper2(obj);
     }
@@ -312,21 +312,21 @@ void test_root_cvt_file_get_1()
     {
         file_guard g1("test_file", e_lit);
         basic_file_device<true, true, char> dev("test_file");
-        auto obj = make_root_cvt<true>(std::move(dev));
+        auto obj = rb_root_cvt{std::move(dev)};
         helper(obj);
     }
     
     {
         file_guard g1("test_file", e_lit);
         basic_file_device<true, false, char> dev("test_file");
-        auto obj = make_root_cvt<true>(std::move(dev));
+        auto obj = rb_root_cvt{std::move(dev)};
         helper(obj);
     }
     
     {
         file_guard g1("test_file", e_lit);
         basic_file_device<true, true, char> dev("test_file");
-        auto tmp = make_root_cvt<true>(std::move(dev));
+        auto tmp = rb_root_cvt{std::move(dev)};
         runtime_cvt obj(std::move(tmp));
         helper(obj);
     }
@@ -334,7 +334,7 @@ void test_root_cvt_file_get_1()
     {
         file_guard g1("test_file", e_lit);
         basic_file_device<true, false, char> dev("test_file");
-        auto tmp = make_root_cvt<true>(std::move(dev));
+        auto tmp = rb_root_cvt{std::move(dev)};
         runtime_cvt obj(std::move(tmp));
         helper(obj);
     }
@@ -387,21 +387,21 @@ void test_root_cvt_file_get_nra_1()
     {
         file_guard g1("test_file", e_lit);
         basic_file_device<true, true, char> dev("test_file");
-        auto obj = make_root_cvt<false>(std::move(dev));
+        auto obj = no_rb_root_cvt{std::move(dev)};
         helper(obj);
     }
     
     {
         file_guard g1("test_file", e_lit);
         basic_file_device<true, false, char> dev("test_file");
-        auto obj = make_root_cvt<false>(std::move(dev));
+        auto obj = no_rb_root_cvt{std::move(dev)};
         helper(obj);
     }
 
     {
         file_guard g1("test_file", e_lit);
         basic_file_device<true, true, char> dev("test_file");
-        auto tmp = make_root_cvt<false>(std::move(dev));
+        auto tmp = no_rb_root_cvt{std::move(dev)};
         runtime_cvt obj(std::move(tmp));
         helper(obj);
     }
@@ -409,7 +409,7 @@ void test_root_cvt_file_get_nra_1()
     {
         file_guard g1("test_file", e_lit);
         basic_file_device<true, false, char> dev("test_file");
-        auto tmp = make_root_cvt<false>(std::move(dev));
+        auto tmp = no_rb_root_cvt{std::move(dev)};
         runtime_cvt obj(std::move(tmp));
         helper(obj);
     }
@@ -455,7 +455,7 @@ void test_root_cvt_file_put_1()
     {
         file_guard g1("test_file", "");
         basic_file_device<true, true, char> dev("test_file", file_open_flag::trunc);
-        auto obj = make_root_cvt<true>(std::move(dev));
+        auto obj = rb_root_cvt{std::move(dev)};
         helper(obj);
         obj.detach();
         if (g1.contents() != e_lit) throw std::runtime_error("root_cvt<file_device>::put response incorrect");
@@ -464,7 +464,7 @@ void test_root_cvt_file_put_1()
     {
         file_guard g1("test_file");
         basic_file_device<false, true, char> dev("test_file");
-        auto obj = make_root_cvt<true>(std::move(dev));
+        auto obj = rb_root_cvt{std::move(dev)};
         helper(obj);
         obj.detach();
         if (g1.contents() != e_lit) throw std::runtime_error("root_cvt<file_device>::put response incorrect");
@@ -473,7 +473,7 @@ void test_root_cvt_file_put_1()
     {
         file_guard g1("test_file", "");
         basic_file_device<true, true, char> dev("test_file", file_open_flag::trunc);
-        auto tmp = make_root_cvt<true>(std::move(dev));
+        auto tmp = rb_root_cvt{std::move(dev)};
         runtime_cvt obj(std::move(tmp));
         helper(obj);
         obj.detach();
@@ -483,7 +483,7 @@ void test_root_cvt_file_put_1()
     {
         file_guard g1("test_file");
         basic_file_device<false, true, char> dev("test_file");
-        auto tmp = make_root_cvt<true>(std::move(dev));
+        auto tmp = rb_root_cvt{std::move(dev)};
         runtime_cvt obj(std::move(tmp));
         helper(obj);
         obj.detach();
@@ -517,21 +517,21 @@ void test_root_cvt_file_seek_1()
     {
         file_guard g1("test_file", "12345");
         basic_file_device<true, true, char> dev("test_file");
-        auto obj = make_root_cvt<true>(std::move(dev));
+        auto obj = rb_root_cvt{std::move(dev)};
         helper(obj);
     }
     
     {
         file_guard g1("test_file", "12345");
         basic_file_device<true, false, char> dev("test_file");
-        auto obj = make_root_cvt<true>(std::move(dev));
+        auto obj = rb_root_cvt{std::move(dev)};
         helper(obj);
     }
 
     {
         file_guard g1("test_file", "12345");
         basic_file_device<true, true, char> dev("test_file");
-        auto tmp = make_root_cvt<true>(std::move(dev));
+        auto tmp = rb_root_cvt{std::move(dev)};
         runtime_cvt obj(std::move(tmp));
         helper(obj);
     }
@@ -539,7 +539,7 @@ void test_root_cvt_file_seek_1()
     {
         file_guard g1("test_file", "12345");
         basic_file_device<true, false, char> dev("test_file");
-        auto tmp = make_root_cvt<true>(std::move(dev));
+        auto tmp = rb_root_cvt{std::move(dev)};
         runtime_cvt obj(std::move(tmp));
         helper(obj);
     }
@@ -585,21 +585,21 @@ void test_root_cvt_file_seek_2()
     {
         file_guard g1("test_file", "123abcdefg");
         basic_file_device<true, true, char> dev("test_file");
-        auto obj = make_root_cvt<true>(std::move(dev));
+        auto obj = rb_root_cvt{std::move(dev)};
         helper(obj);
     }
     
     {
         file_guard g1("test_file", "123abcdefg");
         basic_file_device<true, false, char> dev("test_file");
-        auto obj = make_root_cvt<true>(std::move(dev));
+        auto obj = rb_root_cvt{std::move(dev)};
         helper(obj);
     }
 
     {
         file_guard g1("test_file", "123abcdefg");
         basic_file_device<true, true, char> dev("test_file");
-        auto tmp = make_root_cvt<true>(std::move(dev));
+        auto tmp = rb_root_cvt{std::move(dev)};
         runtime_cvt obj(std::move(tmp));
         helper(obj);
     }
@@ -607,7 +607,7 @@ void test_root_cvt_file_seek_2()
     {
         file_guard g1("test_file", "123abcdefg");
         basic_file_device<true, false, char> dev("test_file");
-        auto tmp = make_root_cvt<true>(std::move(dev));
+        auto tmp = rb_root_cvt{std::move(dev)};
         runtime_cvt obj(std::move(tmp));
         helper(obj);
     }
@@ -650,7 +650,7 @@ void test_root_cvt_file_reset_1()
         file_guard g1("test_file1", "");
         file_guard g2("test_file2", "");
         basic_file_device<false, true, char> dev("test_file1");
-        auto obj = make_root_cvt<true>(std::move(dev));
+        auto obj = rb_root_cvt{std::move(dev)};
         helper(obj, g1, g2);
     }
     
@@ -658,7 +658,7 @@ void test_root_cvt_file_reset_1()
         file_guard g1("test_file1", "");
         file_guard g2("test_file2", "");
         basic_file_device<false, true, char> dev("test_file1");
-        auto tmp = make_root_cvt<true>(std::move(dev));
+        auto tmp = rb_root_cvt{std::move(dev)};
         runtime_cvt obj(std::move(tmp));
         helper(obj, g1, g2);
     }
@@ -700,26 +700,26 @@ void test_root_cvt_file_device_1()
     };
     {
         basic_file_device<false, true, char> dev;
-        auto obj = make_root_cvt<true>(std::move(dev));
+        auto obj = rb_root_cvt{std::move(dev)};
         helper(obj);
     }
     
     {
         basic_file_device<false, true, char> dev;
-        auto tmp = make_root_cvt<true>(std::move(dev));
+        auto tmp = rb_root_cvt{std::move(dev)};
         runtime_cvt obj(std::move(tmp));
         helper(obj);
     }
 
     {
         basic_file_device<true, true, char> dev;
-        auto obj = make_root_cvt<true>(std::move(dev));
+        auto obj = rb_root_cvt{std::move(dev)};
         helper(obj);
     }
     
     {
         basic_file_device<true, true, char> dev;
-        auto tmp = make_root_cvt<true>(std::move(dev));
+        auto tmp = rb_root_cvt{std::move(dev)};
         runtime_cvt obj(std::move(tmp));
         helper(obj);
     }
@@ -745,12 +745,12 @@ void test_root_cvt_file_detach_1()
 
     file_guard g("test_file1", "12345678");
     {
-        auto obj = make_root_cvt<true>(ifile_device<char>("test_file1"));
+        auto obj = rb_root_cvt{ifile_device<char>("test_file1")};
         helper(obj);
     }
     
     {
-        runtime_cvt obj(make_root_cvt<true>(ifile_device<char>("test_file1")));
+        runtime_cvt obj(rb_root_cvt{ifile_device<char>("test_file1")});
         helper(obj);
     }
     dump_info("Done\n");
@@ -773,12 +773,12 @@ void test_root_cvt_file_detach_2()
 
     file_guard g("test_file1", "");
     {
-        auto obj = make_root_cvt<true>(ofile_device<char>("test_file1"));
+        auto obj = rb_root_cvt{ofile_device<char>("test_file1")};
         helper(obj);
     }
     
     {
-        runtime_cvt obj(make_root_cvt<true>(ofile_device<char>("test_file1")));
+        runtime_cvt obj(rb_root_cvt{ofile_device<char>("test_file1")});
         helper(obj);
     }
     dump_info("Done\n");
@@ -804,12 +804,12 @@ void test_root_cvt_file_attach_1()
 
     file_guard g("test_file1", "12345678");
     {
-        auto obj = make_root_cvt<true>(ifile_device<char>("test_file1"));
+        auto obj = rb_root_cvt{ifile_device<char>("test_file1")};
         helper(obj);
     }
     
     {
-        runtime_cvt obj(make_root_cvt<true>(ifile_device<char>("test_file1")));
+        runtime_cvt obj(rb_root_cvt{ifile_device<char>("test_file1")});
         helper(obj);
     }
     dump_info("Done\n");
@@ -833,12 +833,12 @@ void test_root_cvt_file_attach_2()
 
     file_guard g("test_file1", "");
     {
-        auto obj = make_root_cvt<true>(ofile_device<char>("test_file1"));
+        auto obj = rb_root_cvt{ofile_device<char>("test_file1")};
         helper(obj);
     }
     
     {
-        runtime_cvt obj(make_root_cvt<true>(ofile_device<char>("test_file1")));
+        runtime_cvt obj(rb_root_cvt{ofile_device<char>("test_file1")});
         helper(obj);
     }
     dump_info("Done\n");

--- a/test/cvt/root_cvt/root_cvt_mem.cpp
+++ b/test/cvt/root_cvt/root_cvt_mem.cpp
@@ -12,7 +12,7 @@ void test_root_cvt_mem_gen_1()
     dump_info("Test root_cvt<mem_device> general case 1...");
     
     {
-        using CheckType = root_cvt<mem_device<char>, false>;
+        using CheckType = no_rb_root_cvt<mem_device<char>>;
         static_assert(io_converter<CheckType>);
         static_assert(std::is_same_v<CheckType::device_type, mem_device<char>>);
         static_assert(std::is_same_v<CheckType::internal_type, char>);
@@ -24,7 +24,7 @@ void test_root_cvt_mem_gen_1()
     }
     
     {
-        using CheckType = root_cvt<mem_device<char32_t>, true>;
+        using CheckType = rb_root_cvt<mem_device<char32_t>>;
         static_assert(io_converter<CheckType>);
         static_assert(std::is_same_v<CheckType::device_type, mem_device<char32_t>>);
         static_assert(std::is_same_v<CheckType::internal_type, char32_t>);
@@ -62,7 +62,7 @@ void test_root_cvt_mem_gen_2()
             auto obj = ori_obj;
             if (obj.bos() != io_status::output) throw std::runtime_error("root_cvt<mem_device>::bos response incorrect");
             obj.main_cont_beg();
-            decltype(obj) obj2{make_root_cvt<true>(mem_device(""))};
+            decltype(obj) obj2{rb_root_cvt{mem_device("")}};
             obj2 = obj;
             if (obj2.device().str() != "hello") throw std::runtime_error("root_cvt<mem_device> copy assignment response incorrect");
             
@@ -84,14 +84,14 @@ void test_root_cvt_mem_gen_2()
             auto obj = ori_obj;
             if (obj.bos() != io_status::output) throw std::runtime_error("root_cvt<mem_device>::bos response incorrect");
             obj.main_cont_beg();
-            decltype(obj) obj2{make_root_cvt<true>(mem_device(""))};
+            decltype(obj) obj2{rb_root_cvt{mem_device("")}};
             obj2 = std::move(obj);
             if (obj2.device().str() != "hello") throw std::runtime_error("root_cvt<mem_device> move assignment response incorrect");
         }
     };
 
     mem_device dev{"hello"}; dev.drseek(0);
-    auto obj1 = make_root_cvt<true>(std::move(dev));
+    auto obj1 = rb_root_cvt{std::move(dev)};
     helper(obj1);
     
     runtime_cvt obj2(std::move(obj1));
@@ -137,7 +137,7 @@ void test_root_cvt_mem_gen_3()
             if (str != "hello") throw std::runtime_error("root_cvt<std_device>::get response incorrect");
             if (obj.tell() != 5) throw std::runtime_error("root_cvt<std_device>::tell response incorrect");
             
-            decltype(obj) obj2{make_root_cvt<true>(mem_device(""))};
+            decltype(obj) obj2{rb_root_cvt{mem_device("")}};
             obj2 = obj;
             if (obj2.tell() != 5) throw std::runtime_error("root_cvt<std_device>::tell response incorrect");
             str.resize(6);
@@ -177,7 +177,7 @@ void test_root_cvt_mem_gen_3()
             if (str != "hello") throw std::runtime_error("root_cvt<std_device>::get response incorrect");
             if (obj.tell() != 5) throw std::runtime_error("root_cvt<std_device>::tell response incorrect");
             
-            decltype(obj) obj2{make_root_cvt<true>(mem_device(""))};
+            decltype(obj) obj2{rb_root_cvt{mem_device("")}};
             obj2 = std::move(obj);
             if (obj2.tell() != 5) throw std::runtime_error("root_cvt<std_device>::tell response incorrect");
             str.resize(6);
@@ -187,7 +187,7 @@ void test_root_cvt_mem_gen_3()
         }
     };
 
-    auto obj1 = make_root_cvt<true>(mem_device("hello world"));
+    auto obj1 = rb_root_cvt{mem_device("hello world")};
     helper(obj1);
 
     runtime_cvt obj2(std::move(obj1));
@@ -237,10 +237,10 @@ void test_root_cvt_mem_get_1()
             if (out_buf[i] != e_lit[i]) throw std::runtime_error("root_cvt<mem_device>::get response incorrect");
     };
 
-    auto obj1 = make_root_cvt<true>(mem_device(e_lit));
+    auto obj1 = rb_root_cvt{mem_device(e_lit)};
     helper(obj1);
     
-    runtime_cvt obj2(make_root_cvt<true>(mem_device(e_lit)));
+    runtime_cvt obj2(rb_root_cvt{mem_device(e_lit)});
     helper(obj2);
 
     dump_info("Done\n");
@@ -288,10 +288,10 @@ void test_root_cvt_mem_get_nra_1()
             if (out_buf[i] != e_lit[i]) throw std::runtime_error("root_cvt<mem_device>::get response incorrect");
     };
 
-    auto obj1 = make_root_cvt<false>(mem_device(e_lit));
+    auto obj1 = no_rb_root_cvt{mem_device(e_lit)};
     helper(obj1);
     
-    runtime_cvt obj2(make_root_cvt<false>(mem_device(e_lit)));
+    runtime_cvt obj2(no_rb_root_cvt{mem_device(e_lit)});
     helper(obj2);
 
     dump_info("Done\n");
@@ -337,10 +337,10 @@ void test_root_cvt_mem_put_1()
         if (dev.str() != e_lit) throw std::runtime_error("root_cvt<mem_device>::put response incorrect");
     };
 
-    auto obj1 = make_root_cvt<true>(mem_device(""));
+    auto obj1 = rb_root_cvt{mem_device("")};
     helper(obj1);
     
-    runtime_cvt obj2(make_root_cvt<true>(mem_device("")));
+    runtime_cvt obj2(rb_root_cvt{mem_device("")});
     helper(obj2);
 
     dump_info("Done\n");
@@ -366,10 +366,10 @@ void test_root_cvt_mem_seek_1()
         if ((obj.get(&ch, 1) != 1) || (ch != '3')) throw std::runtime_error("root_cvt<mem_device>::get fail");
     };
 
-    auto obj1 = make_root_cvt<true>(mem_device("12345"));
+    auto obj1 = rb_root_cvt{mem_device("12345")};
     helper(obj1);
 
-    runtime_cvt obj2(make_root_cvt<true>(mem_device("12345")));
+    runtime_cvt obj2(rb_root_cvt{mem_device("12345")});
     helper(obj2);
 
     dump_info("Done\n");
@@ -408,10 +408,10 @@ void test_root_cvt_mem_seek_2()
         VERIFY(obj.tell() == 5);
     };
 
-    auto obj1 = make_root_cvt<true>(mem_device("123abcdefg"));
+    auto obj1 = rb_root_cvt{mem_device("123abcdefg")};
     helper(obj1);
 
-    runtime_cvt obj2(make_root_cvt<true>(mem_device("123abcdefg")));
+    runtime_cvt obj2(rb_root_cvt{mem_device("123abcdefg")});
     helper(obj2);
 
     dump_info("Done\n");
@@ -446,10 +446,10 @@ void test_root_cvt_mem_reset_1()
         if (new_dev.str() != "liwei cpp") throw std::runtime_error("root_cvt<mem_device>::put incorrect");
     };
 
-    auto obj1 = make_root_cvt<true>(mem_device(""));
+    auto obj1 = rb_root_cvt{mem_device("")};
     helper(obj1);
 
-    runtime_cvt obj2(make_root_cvt<true>(mem_device("")));
+    runtime_cvt obj2(rb_root_cvt{mem_device("")});
     helper(obj2);
     dump_info("Done\n");
 }
@@ -482,12 +482,12 @@ void test_root_cvt_mem_device_1()
         if (f2.str() != "123") throw std::runtime_error("root_cvt<file_device> output incorrect");
     };
     {
-        auto obj = make_root_cvt<true>(mem_device(""));
+        auto obj = rb_root_cvt{mem_device("")};
         helper(obj);
     }
     
     {
-        auto tmp = make_root_cvt<true>(mem_device(""));
+        auto tmp = rb_root_cvt{mem_device("")};
         runtime_cvt obj(std::move(tmp));
         helper(obj);
     }
@@ -510,12 +510,12 @@ void test_root_cvt_mem_detach_1()
         VERIFY(dev.dtell() == 1);
     };
     {
-        auto obj = make_root_cvt<true>(mem_device("12345678"));
+        auto obj = rb_root_cvt{mem_device("12345678")};
         helper(obj);
     }
     
     {
-        runtime_cvt obj(make_root_cvt<true>(mem_device("12345678")));
+        runtime_cvt obj(rb_root_cvt{mem_device("12345678")});
         helper(obj);
     }
     dump_info("Done\n");
@@ -535,12 +535,12 @@ void test_root_cvt_mem_detach_2()
         VERIFY(dev.dtell() == 3);
     };
     {
-        auto obj = make_root_cvt<true>(mem_device(""));
+        auto obj = rb_root_cvt{mem_device("")};
         helper(obj);
     }
     
     {
-        runtime_cvt obj(make_root_cvt<true>(mem_device("")));
+        runtime_cvt obj(rb_root_cvt{mem_device("")});
         helper(obj);
     }
     dump_info("Done\n");
@@ -562,12 +562,12 @@ void test_root_cvt_mem_attach_1()
         VERIFY(dev.dtell() == 1);
     };
     {
-        auto obj = make_root_cvt<true>(mem_device("12345678"));
+        auto obj = rb_root_cvt{mem_device("12345678")};
         helper(obj);
     }
     
     {
-        runtime_cvt obj(make_root_cvt<true>(mem_device("12345678")));
+        runtime_cvt obj(rb_root_cvt{mem_device("12345678")});
         helper(obj);
     }
     dump_info("Done\n");
@@ -587,12 +587,12 @@ void test_root_cvt_mem_attach_2()
         VERIFY(dev.dtell() == 3);
     };
     {
-        auto obj = make_root_cvt<true>(mem_device(""));
+        auto obj = rb_root_cvt{mem_device("")};
         helper(obj);
     }
     
     {
-        runtime_cvt obj(make_root_cvt<true>(mem_device("")));
+        runtime_cvt obj(rb_root_cvt{mem_device("")});
         helper(obj);
     }
     dump_info("Done\n");
@@ -605,7 +605,7 @@ void test_root_cvt_mem_self_assignment()
     
     {
         mem_device dev{"hello"}; dev.drseek(0);
-        auto obj = make_root_cvt<true>(std::move(dev));
+        auto obj = rb_root_cvt{std::move(dev)};
         VERIFY(obj.bos() == io_status::output); 
         obj.main_cont_beg();
         obj.put(" world", 6);
@@ -625,7 +625,7 @@ void test_root_cvt_mem_self_assignment()
     
     {
         mem_device dev{"hello"}; dev.drseek(0);
-        runtime_cvt obj(make_root_cvt<true>(std::move(dev)));
+        runtime_cvt obj(rb_root_cvt{std::move(dev)});
         VERIFY(obj.bos() == io_status::output); 
         obj.main_cont_beg();
         obj.put(" world", 6);

--- a/test/cvt/root_cvt/root_cvt_std.cpp
+++ b/test/cvt/root_cvt/root_cvt_std.cpp
@@ -12,7 +12,7 @@ void test_root_cvt_std_gen_1()
     dump_info("Test root_cvt<std_device> general case 1...");
     
     {
-        using CheckType = root_cvt<std_device<STDIN_FILENO>, false>;
+        using CheckType = no_rb_root_cvt<std_device<STDIN_FILENO>>;
         static_assert(io_converter<CheckType>);
         static_assert(std::is_same_v<CheckType::device_type, std_device<STDIN_FILENO>>);
         static_assert(std::is_same_v<CheckType::internal_type, char>);
@@ -25,7 +25,7 @@ void test_root_cvt_std_gen_1()
     }
     
     {
-        using CheckType = root_cvt<std_device<STDOUT_FILENO>, true>;
+        using CheckType = rb_root_cvt<std_device<STDOUT_FILENO>>;
         static_assert(io_converter<CheckType>);
         static_assert(std::is_same_v<CheckType::device_type, std_device<STDOUT_FILENO>>);
         static_assert(std::is_same_v<CheckType::internal_type, char>);
@@ -58,10 +58,10 @@ void test_root_cvt_std_gen_2()
         if (g.contents() != "hello world") throw std::runtime_error("root_cvt<std_device> move constructor response incorrect");
     };
     {
-        auto obj1 = make_root_cvt<true>(std_device<STDOUT_FILENO>{});
+        auto obj1 = rb_root_cvt{std_device<STDOUT_FILENO>{}};
         helper1(obj1);
 
-        runtime_cvt obj2(make_root_cvt<true>(std_device<STDOUT_FILENO>{}));
+        runtime_cvt obj2(rb_root_cvt{std_device<STDOUT_FILENO>{}});
         helper1(obj2);
     }
 
@@ -71,7 +71,7 @@ void test_root_cvt_std_gen_2()
         if (obj.bos() != io_status::output) throw std::runtime_error("root_cvt<std_device>::bos response incorrect");
         obj.main_cont_beg();
         obj.put("hello", 5);
-        T obj2{make_root_cvt<true>(std_device<STDOUT_FILENO>{})};
+        T obj2{rb_root_cvt{std_device<STDOUT_FILENO>{}}};
         obj2 = std::move(obj);
         
         obj2.put(" world", 6);
@@ -80,10 +80,10 @@ void test_root_cvt_std_gen_2()
     };
 
     {
-        auto obj1 = make_root_cvt<true>(std_device<STDOUT_FILENO>{});
+        auto obj1 = rb_root_cvt{std_device<STDOUT_FILENO>{}};
         helper2(obj1);
 
-        runtime_cvt obj2(make_root_cvt<true>(std_device<STDOUT_FILENO>{}));
+        runtime_cvt obj2(rb_root_cvt{std_device<STDOUT_FILENO>{}});
         helper2(obj2);
     }
     dump_info("Done\n");
@@ -109,10 +109,10 @@ void test_root_cvt_std_gen_3()
         if (str != " world") throw std::runtime_error("root_cvt<std_device>::get response incorrect");
     };
     {
-        auto obj1 = make_root_cvt<true>(std_device<STDIN_FILENO>{});
+        auto obj1 = rb_root_cvt{std_device<STDIN_FILENO>{}};
         helper1(obj1);
 
-        runtime_cvt obj2(make_root_cvt<true>(std_device<STDIN_FILENO>{}));
+        runtime_cvt obj2(rb_root_cvt{std_device<STDIN_FILENO>{}});
         helper1(obj2);
     }
     
@@ -125,17 +125,17 @@ void test_root_cvt_std_gen_3()
         if (obj.get(str.data(), 5) != 5) throw std::runtime_error("root_cvt<std_device>::get response incorrect");
         if (str != "hello") throw std::runtime_error("root_cvt<std_device>::get response incorrect");
         
-        T obj2{make_root_cvt<true>(std_device<STDIN_FILENO>{})};
+        T obj2{rb_root_cvt{std_device<STDIN_FILENO>{}}};
         obj2 = std::move(obj);
         str.resize(6);
         if (obj2.get(str.data(), 6) != 6) throw std::runtime_error("root_cvt<std_device>::get response incorrect");
         if (str != " world") throw std::runtime_error("root_cvt<std_device>::get response incorrect");
     };
     {
-        auto obj1 = make_root_cvt<true>(std_device<STDIN_FILENO>{});
+        auto obj1 = rb_root_cvt{std_device<STDIN_FILENO>{}};
         helper2(obj1);
 
-        runtime_cvt obj2(make_root_cvt<true>(std_device<STDIN_FILENO>{}));
+        runtime_cvt obj2(rb_root_cvt{std_device<STDIN_FILENO>{}});
         helper2(obj2);
     }
     dump_info("Done\n");
@@ -186,12 +186,12 @@ void test_root_cvt_std_get_1()
 
     {
         iguard g(e_lit);
-        auto obj = make_root_cvt<true>(std_device<STDIN_FILENO>{});
+        auto obj = rb_root_cvt{std_device<STDIN_FILENO>{}};
         helper(obj);
     }
     {
         iguard g(e_lit);
-        runtime_cvt obj2{make_root_cvt<true>(std_device<STDIN_FILENO>{})};
+        runtime_cvt obj2{rb_root_cvt{std_device<STDIN_FILENO>{}}};
         helper(obj2);
     }
 
@@ -243,12 +243,12 @@ void test_root_cvt_std_get_nra_1()
 
     {
         iguard g(e_lit);
-        auto obj = make_root_cvt<false>(std_device<STDIN_FILENO>{});
+        auto obj = no_rb_root_cvt{std_device<STDIN_FILENO>{}};
         helper(obj);
     }
     {
         iguard g(e_lit);
-        runtime_cvt obj2{make_root_cvt<false>(std_device<STDIN_FILENO>{})};
+        runtime_cvt obj2{no_rb_root_cvt{std_device<STDIN_FILENO>{}}};
         helper(obj2);
     }
 
@@ -295,7 +295,7 @@ void test_root_cvt_std_put_1()
     {
         oguard<true> g;
         {
-            auto obj = make_root_cvt<false>(std_device<STDOUT_FILENO>{});
+            auto obj = no_rb_root_cvt{std_device<STDOUT_FILENO>{}};
             helper(obj);
         }
         if (g.contents() != e_lit) throw std::runtime_error("root_cvt<std_device>::put_bos fail");
@@ -303,7 +303,7 @@ void test_root_cvt_std_put_1()
 
     {
         oguard<false> g;
-        auto obj = make_root_cvt<false>(std_device<STDERR_FILENO>{});
+        auto obj = no_rb_root_cvt{std_device<STDERR_FILENO>{}};
         helper(obj);
         if (g.contents() != e_lit) throw std::runtime_error("root_cvt<std_device>::put_bos fail");
     }
@@ -311,7 +311,7 @@ void test_root_cvt_std_put_1()
     {
         oguard<true> g;
         {
-            runtime_cvt obj(make_root_cvt<false>(std_device<STDOUT_FILENO>{}));
+            runtime_cvt obj(no_rb_root_cvt{std_device<STDOUT_FILENO>{}});
             helper(obj);
         }
         if (g.contents() != e_lit) throw std::runtime_error("root_cvt<std_device>::put_bos fail");
@@ -319,7 +319,7 @@ void test_root_cvt_std_put_1()
 
     {
         oguard<false> g;
-        runtime_cvt obj(make_root_cvt<false>(std_device<STDERR_FILENO>{}));
+        runtime_cvt obj(no_rb_root_cvt{std_device<STDERR_FILENO>{}});
         helper(obj);
         if (g.contents() != e_lit) throw std::runtime_error("root_cvt<std_device>::put_bos fail");
     }


### PR DESCRIPTION
…tter readability

- Introduced rb_root_cvt (Read-Buffered) and no_rb_root_cvt naming.
- Removed make_root_cvt factory function in favor of direct constructor calls with CTAD.
- Updated all occurrences in core headers (cvt_facilities.h, root_cvt.h, messages_details.h, io_concepts.h, streambuf.h).
- Synchronized hundreds of test cases to use the new class names.
- Leveraged C++20 concepts for more generic root_cvt_reader/writer helpers.