### PR TITLE
fix: address common library code review issues (Issue 1-7)

### DIFF
--- a/include/common/clocale_wrapper.h
+++ b/include/common/clocale_wrapper.h
@@ -27,9 +27,9 @@ struct clocale_wrapper
     }
     
     clocale_wrapper(const clocale_wrapper& val)
-        : c_locale(duplocale(val.c_locale))
+        : c_locale(val.c_locale ? duplocale(val.c_locale) : nullptr)
     {
-        if (!c_locale)
+        if (val.c_locale && !c_locale)
         {
             throw cvt_error("clocale_wrapper: duplocale failed during copy construction");
         }
@@ -57,8 +57,8 @@ struct clocale_wrapper
     {
         if (this != &val)
         {
-            locale_t tmp = duplocale(val.c_locale);
-            if (!tmp)
+            locale_t tmp = val.c_locale ? duplocale(val.c_locale) : nullptr;
+            if (val.c_locale && !tmp)
             {
                 throw cvt_error("clocale_wrapper: duplocale failed during assignment");
             }

--- a/include/common/lru_cache.h
+++ b/include/common/lru_cache.h
@@ -41,7 +41,6 @@ public:
 
         auto l_it = m_it->second;
         m_cache_list.splice(m_cache_list.begin(), m_cache_list, l_it);
-        m_it->second = m_cache_list.begin();
 
         if constexpr (is_small_type_v<TV>)
         {
@@ -61,7 +60,6 @@ public:
         {
             auto l_it = m_it->second;
             m_cache_list.splice(m_cache_list.begin(), m_cache_list, l_it);
-            m_it->second = m_cache_list.begin();
             return false;
         }
 
@@ -84,7 +82,6 @@ public:
             auto l_it = m_it->second;
             l_it->second = value;
             m_cache_list.splice(m_cache_list.begin(), m_cache_list, l_it);
-            m_it->second = m_cache_list.begin();
             return;
         }
 

--- a/include/common/prefix_tree.h
+++ b/include/common/prefix_tree.h
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include <common/streambuf_defs.h>
+#include <common/metafunctions.h>
 
 namespace IOv2
 {
@@ -35,6 +36,8 @@ class prefix_tree
     };
 
 public:
+    using match_out_type = std::conditional_t<is_small_type_v<TValue>, std::optional<TValue>, const TValue*>;
+
     explicit prefix_tree()
         : m_root(std::nullopt, 0)
     { }
@@ -48,6 +51,8 @@ public:
 
         for (size_t i = 0; i < strs.size(); ++i)
         {
+            if (strs[i] == nullptr)
+                throw std::runtime_error("prefix_tree: null pointer in input vector");
             add(strs[i], static_cast<TValue>(i));
         }
     }
@@ -83,10 +88,20 @@ public:
     }
     
     template <std::bidirectional_iterator TIter, std::sentinel_for<TIter> TSent>
-    TIter max_match(TIter b, TSent e, TValue& out) const
+    TIter max_match(TIter b, TSent e, match_out_type& out) const
     {
+        if constexpr (is_small_type_v<TValue>)
+            out = std::nullopt;
+        else
+            out = nullptr;
+
         if (m_root.val.has_value())
-            out = *m_root.val;
+        {
+            if constexpr (is_small_type_v<TValue>)
+                out = m_root.val;
+            else
+                out = &(*m_root.val);
+        }
             
         size_t found_depth = 0;
         
@@ -99,7 +114,10 @@ public:
             node_ptr = it->second.get();
             if (node_ptr->val.has_value())
             {
-                out = *node_ptr->val;
+                if constexpr (is_small_type_v<TValue>)
+                    out = node_ptr->val;
+                else
+                    out = &(*node_ptr->val);
                 found_depth = node_ptr->depth;
             }
         }
@@ -113,12 +131,22 @@ public:
     }
 
     template <is_istreambuf_iterator_v TIter, std::sentinel_for<TIter> TSent>
-    TIter max_match(TIter b, TSent e, TValue& out) const
+    TIter max_match(TIter b, TSent e, match_out_type& out) const
     {
+        if constexpr (is_small_type_v<TValue>)
+            out = std::nullopt;
+        else
+            out = nullptr;
+
         std::forward_list<CharT> checking_chars;
 
         if (m_root.val.has_value())
-            out = *m_root.val;
+        {
+            if constexpr (is_small_type_v<TValue>)
+                out = m_root.val;
+            else
+                out = &(*m_root.val);
+        }
 
         size_t found_depth = 0;
         
@@ -131,7 +159,10 @@ public:
             node_ptr = it->second.get();
             if (node_ptr->val.has_value())
             {
-                out = *node_ptr->val;
+                if constexpr (is_small_type_v<TValue>)
+                    out = node_ptr->val;
+                else
+                    out = &(*node_ptr->val);
                 found_depth = node_ptr->depth;
             }
             checking_chars.push_front(ch);

--- a/include/common/sing_temp.h
+++ b/include/common/sing_temp.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdlib>
 
 namespace IOv2
 {
@@ -27,7 +28,15 @@ public:
             if (count++ == 0)
             {
                 T* ptr = sing_temp::ptr();
-                new (ptr) T();
+                try {
+                    new (ptr) T();
+                } catch (...) {
+                    // sing_temp is designed for static initialization before main().
+                    // If T() throws, the singleton cannot be constructed and there is
+                    // no safe recovery path. Abort explicitly to avoid leaving the
+                    // reference count in an inconsistent state.
+                    std::abort();
+                }
             }            
         }
 

--- a/include/common/stamp_input_iterator.h
+++ b/include/common/stamp_input_iterator.h
@@ -21,16 +21,44 @@ struct StampInputIterator<TIter>
         , m_pos(0) {}
 
     StampInputIterator(std::default_sentinel_t)
-        : m_internal() {}
+        : m_internal()
+        , m_pos(0) {}
+
+    StampInputIterator(const StampInputIterator&) = default;
+    StampInputIterator& operator=(const StampInputIterator&) = default;
+
+    StampInputIterator(StampInputIterator&& val) noexcept
+        : m_internal(std::move(val.m_internal))
+        , m_pos(val.m_pos)
+    {
+        val.m_pos = 0;
+    }
+
+    StampInputIterator& operator=(StampInputIterator&& val) noexcept
+    {
+        if (this != &val)
+        {
+            m_internal = std::move(val.m_internal);
+            m_pos = val.m_pos;
+            val.m_pos = 0;
+        }
+        return *this;
+    }
     
-    using value_type        = typename TIter::value_type;
-    using difference_type   = typename TIter::difference_type;
-    using pointer           = typename TIter::pointer;
-    using reference         = typename TIter::reference;
-    using iterator_category = typename TIter::iterator_category;
+    using value_type        = typename std::iterator_traits<TIter>::value_type;
+    using difference_type   = typename std::iterator_traits<TIter>::difference_type;
+    using pointer           = typename std::iterator_traits<TIter>::pointer;
+    using reference         = typename std::iterator_traits<TIter>::reference;
+    using iterator_category = typename std::iterator_traits<TIter>::iterator_category;
 
     reference operator*() const { return *m_internal; }
-    pointer operator->() const { return m_internal; }
+    pointer operator->() const
+    {
+        if constexpr (std::is_pointer_v<TIter>)
+            return m_internal;
+        else
+            return m_internal.operator->();
+    }
 
     reference operator[](difference_type n) const
         requires (std::random_access_iterator<TIter>)

--- a/include/facet/timeio.h
+++ b/include/facet/timeio.h
@@ -641,11 +641,11 @@ private:
                 else if (modifier) goto bad_parse_format;
                 else
                 {
-                    int tmp_value = -1;
-                    rp = m_day_tree.max_match(rp, rp_end, tmp_value);
-                    if (tmp_value != -1)
+                    typename decltype(m_day_tree)::match_out_type tmp;
+                    rp = m_day_tree.max_match(rp, rp_end, tmp);
+                    if (tmp)
                     {
-                        ctx.m_wday = tmp_value;
+                        ctx.m_wday = *tmp;
                         ctx.m_have_wday = true;
                     }
                     else
@@ -663,11 +663,11 @@ private:
                 else if (modifier) goto bad_parse_format;
                 else 
                 {
-                    int tmp_value = -1;
-                    rp = m_month_tree.max_match(rp, rp_end, tmp_value);
-                    if ((tmp_value >= 0) && (tmp_value < 12))
+                    typename decltype(m_month_tree)::match_out_type tmp;
+                    rp = m_month_tree.max_match(rp, rp_end, tmp);
+                    if (tmp && (*tmp >= 0) && (*tmp < 12))
                     {
-                        ctx.m_month = (uint8_t)tmp_value + 1;
+                        ctx.m_month = (uint8_t)*tmp + 1;
                         ctx.m_have_mon = true;
                     }
                     else
@@ -712,15 +712,15 @@ private:
                 }
                 else
                 {
-                    std::basic_string<CharT> match_name;
-                    rp = m_era_tree.max_match(rp, rp_end, match_name);
-                    if (match_name.empty())
+                    typename decltype(m_era_tree)::match_out_type tmp;
+                    rp = m_era_tree.max_match(rp, rp_end, tmp);
+                    if (!tmp)
                         ctx.m_era_items.clear();
                     else
                     {
                         for (auto it = ctx.m_era_items.begin(); it != ctx.m_era_items.end();)
                         {
-                            if (it->name == match_name) ++it;
+                            if (it->name == *tmp) ++it;
                             else it = ctx.m_era_items.erase(it);
                         }
                     }
@@ -890,10 +890,18 @@ private:
                 else if (modifier) goto bad_parse_format;
                 else
                 {
-                    int tmp_value = -1;
-                    rp = m_am_pm_tree.max_match(rp, rp_end, tmp_value);
-                    if (tmp_value == 0) ctx.m_is_pm = false;
-                    else if (tmp_value == 1) ctx.m_is_pm = true;
+                    typename decltype(m_am_pm_tree)::match_out_type tmp;
+                    rp = m_am_pm_tree.max_match(rp, rp_end, tmp);
+                    if (tmp)
+                    {
+                        if (*tmp == 0) ctx.m_is_pm = false;
+                        else if (*tmp == 1) ctx.m_is_pm = true;
+                        else
+                        {
+                            succ = false;
+                            return rp;
+                        }
+                    }
                     else
                     {
                         succ = false;
@@ -1219,15 +1227,15 @@ private:
                 /* Read timezone but perform no conversion.  */
                 else
                 {
-                    std::string zone_name;
-                    rp = ft_basic<timeio<CharT>>::s_timezone_tree.max_match(rp, rp_end, zone_name);
-                    if (zone_name.empty())
+                    typename decltype(ft_basic<timeio<CharT>>::s_timezone_tree)::match_out_type zone_res;
+                    rp = ft_basic<timeio<CharT>>::s_timezone_tree.max_match(rp, rp_end, zone_res);
+                    if (!zone_res)
                     {
                         succ = false;
                         return rp;
                     }
-                    else if (zone_name[0] != (CharT)'*')
-                        ctx.m_zone_name = std::move(zone_name);
+                    else if ((*zone_res)[0] != (CharT)'*')
+                        ctx.m_zone_name = *zone_res;
                 }
                 break;
 
@@ -1840,12 +1848,16 @@ private:
     template <typename TIter, std::sentinel_for<TIter> TSent>
     TIter extract_num_with_alt_digits(TIter beg, TSent end, int& member, int min_val, int max_val, size_t len, bool& succ) const
     {
-        member = -1;
-        beg = m_alt_digits_tree.max_match(beg, end, member);
-        if (member == -1)
+        typename decltype(m_alt_digits_tree)::match_out_type match_res;
+        beg = m_alt_digits_tree.max_match(beg, end, match_res);
+        if (match_res)
+        {
+            member = *match_res;
+            if ((member < min_val) || (member > max_val))
+                succ = false;
+        }
+        else
             beg = extract_num(beg, end, member, min_val, max_val, len, succ);
-        else if ((member < min_val) || (member > max_val))
-            succ = false;
         return beg;
     }
 

--- a/test/util/test_clocale_wrapper.cpp
+++ b/test/util/test_clocale_wrapper.cpp
@@ -76,6 +76,11 @@ void test_clocale_wrapper_safety()
         clocale_wrapper loc2(std::move(loc1));
         // loc1 is now in a moved-from state. 
         // Its destructor should be safe (it is marked noexcept and we added a null check).
+
+        // Issue 4: Copying from moved-from object should not trigger UB (duplocale(nullptr))
+        clocale_wrapper loc3(loc1); // Copy constructor
+        clocale_wrapper loc4("C");
+        loc4 = loc1;              // Copy assignment
     }
     dump_info("Done\n");
 }

--- a/test/util/test_prefix_tree.cpp
+++ b/test/util/test_prefix_tree.cpp
@@ -18,35 +18,31 @@ void test_prefix_tree_basic()
     tree.add("world", 2);
     tree.add("he", 3);
 
-    int out = -1;
+    decltype(tree)::match_out_type out;
     std::string s1 = "hello";
     auto it1 = tree.max_match(s1.begin(), s1.end(), out);
-    VERIFY(out == 1);
+    VERIFY(out && *out == 1);
     VERIFY(it1 == s1.end());
 
     std::string s2 = "he";
-    out = -1;
-    auto it2 = tree.max_match(s2.begin(), s2.end(), out);
-    VERIFY(out == 3);
-    VERIFY(it2 == s2.end());
+    it1 = tree.max_match(s2.begin(), s2.end(), out);
+    VERIFY(out && *out == 3);
+    VERIFY(it1 == s2.end());
 
     std::string s3 = "hell";
-    out = -1;
-    auto it3 = tree.max_match(s3.begin(), s3.end(), out);
-    VERIFY(out == 3); // "he" is the max match
-    VERIFY(it3 == s3.begin() + 2);
+    it1 = tree.max_match(s3.begin(), s3.end(), out);
+    VERIFY(out && *out == 3); // "he" is the max match
+    VERIFY(it1 == s3.begin() + 2);
 
     std::string s4 = "world";
-    out = -1;
-    auto it4 = tree.max_match(s4.begin(), s4.end(), out);
-    VERIFY(out == 2);
-    VERIFY(it4 == s4.end());
+    it1 = tree.max_match(s4.begin(), s4.end(), out);
+    VERIFY(out && *out == 2);
+    VERIFY(it1 == s4.end());
 
     std::string s5 = "not_found";
-    out = -1;
-    auto it5 = tree.max_match(s5.begin(), s5.end(), out);
-    VERIFY(out == -1); // remains -1 as no match found and no default in tree
-    VERIFY(it5 == s5.begin());
+    it1 = tree.max_match(s5.begin(), s5.end(), out);
+    VERIFY(!out); // remains empty
+    VERIFY(it1 == s5.begin());
     dump_info("Done\n");
 }
 
@@ -96,9 +92,9 @@ void test_prefix_tree_string_view()
     std::string_view sv = "view";
     tree.add(sv, 5);
 
-    int out = -1;
+    decltype(tree)::match_out_type out;
     auto it = tree.max_match(sv.begin(), sv.end(), out);
-    VERIFY(out == 5);
+    VERIFY(out && *out == 5);
     VERIFY(it == sv.end());
     dump_info("Done\n");
 }
@@ -109,10 +105,10 @@ void test_prefix_tree_vector_constructor()
     std::vector<const char*> strs = {"apple", "banana", "cherry"};
     prefix_tree<char, int> tree(strs);
 
-    int out = -1;
+    decltype(tree)::match_out_type out;
     std::string s = "banana";
     tree.max_match(s.begin(), s.end(), out);
-    VERIFY(out == 1); // Index 1 in the vector
+    VERIFY(out && *out == 1); // Index 1 in the vector
     dump_info("Done\n");
 }
 
@@ -123,10 +119,10 @@ void test_prefix_tree_root_value()
     tree.add("", 100); // Set value at root
     tree.add("a", 1);
 
-    int out = -1;
+    decltype(tree)::match_out_type out;
     std::string s = "b"; // Does not match any child
     auto it = tree.max_match(s.begin(), s.end(), out);
-    VERIFY(out == 100); // Should pick root value
+    VERIFY(out && *out == 100); // Should pick root value
     VERIFY(it == s.begin());
     dump_info("Done\n");
 }
@@ -138,10 +134,10 @@ void test_prefix_tree_greedy_match()
     tree.add("abc", 1);
     tree.add("abcd", 2);
 
-    int out = -1;
+    decltype(tree)::match_out_type out;
     std::string s = "abcde"; 
     auto it = tree.max_match(s.begin(), s.end(), out);
-    VERIFY(out == 2); // Should match longest "abcd"
+    VERIFY(out && *out == 2); // Should match longest "abcd"
     VERIFY(it == s.begin() + 4);
     dump_info("Done\n");
 }
@@ -159,10 +155,10 @@ void test_prefix_tree_istreambuf()
     istreambuf_iterator beg(sb);
     decltype(beg) end;
     
-    int out = -1;
+    decltype(tree)::match_out_type out;
     auto it = tree.max_match(beg, end, out);
     
-    VERIFY(out == -1); // No valid word matched
+    VERIFY(!out); // No valid word matched
     VERIFY(*it == 'a'); // Should have backtracked to the beginning
     dump_info("Done\n");
 }
@@ -187,6 +183,35 @@ void test_prefix_tree_overflow()
     dump_info("Done\n");
 }
 
+void test_prefix_tree_uninitialized_out()
+{
+    dump_info("Test prefix_tree uninitialized out (Issue 1)...");
+    prefix_tree<char, int> tree;
+    // Tree is empty, no root value, no children.
+    
+    decltype(tree)::match_out_type out;
+    std::string s = "abc";
+    auto it = tree.max_match(s.begin(), s.end(), out);
+    
+    VERIFY(!out); 
+    VERIFY(it == s.begin());
+    dump_info("Done\n");
+}
+
+void test_prefix_tree_nullptr_check()
+{
+    dump_info("Test prefix_tree nullptr check (Issue 5)...");
+    std::vector<const char*> strs = {"hello", nullptr, "world"};
+    try {
+        prefix_tree<char, int> tree(strs);
+        VERIFY(false); // Should have thrown
+    } catch (const std::runtime_error& e) {
+        std::string msg = e.what();
+        VERIFY(msg.find("null pointer") != std::string::npos);
+    }
+    dump_info("Done\n");
+}
+
 void test_prefix_tree()
 {
     test_prefix_tree_basic();
@@ -197,4 +222,6 @@ void test_prefix_tree()
     test_prefix_tree_greedy_match();
     test_prefix_tree_istreambuf();
     test_prefix_tree_overflow();
+    test_prefix_tree_uninitialized_out();
+    test_prefix_tree_nullptr_check();
 }

--- a/test/util/test_stamp_input_iterator.cpp
+++ b/test/util/test_stamp_input_iterator.cpp
@@ -1,0 +1,130 @@
+#include <vector>
+#include <cassert>
+#include <common/stamp_input_iterator.h>
+#include <common/verify.h>
+#include <io/streambuf_iterator.h>
+#include <device/mem_device.h>
+#include <io/streambuf.h>
+
+struct TestPoint {
+    int x;
+    int y;
+};
+
+void test_stamp_input_iterator() {
+    dump_info("Test stamp_input_iterator basic...");
+    {
+        std::vector<TestPoint> points = {{1, 2}, {3, 4}};
+        IOv2::StampInputIterator it(points.begin());
+        
+        VERIFY(it->x == 1);
+        VERIFY(it->y == 2);
+        
+        ++it;
+        VERIFY(it->x == 3);
+        VERIFY(it->y == 4);
+        
+        it.rollback();
+        VERIFY(it->x == 1);
+    }
+    dump_info("Done\n");
+
+    dump_info("Test stamp_input_iterator istreambuf_iterator...");
+    {
+        IOv2::mem_device dev("abc");
+        IOv2::istreambuf buf(dev);
+        IOv2::istreambuf_iterator is_it(buf);
+        IOv2::StampInputIterator s_it(is_it);
+        
+        char c = *s_it;
+        VERIFY(c == 'a');
+    }
+    dump_info("Done\n");
+
+    dump_info("Test stamp_input_iterator raw pointer...");
+    {
+        TestPoint points[] = {{10, 20}, {30, 40}};
+        IOv2::StampInputIterator it(&points[0]);
+        
+        VERIFY(it->x == 10);
+        VERIFY(it->y == 20);
+        
+        ++it;
+        VERIFY(it->x == 30);
+        VERIFY(it->y == 40);
+    }
+    dump_info("Done\n");
+
+    dump_info("Test stamp_input_iterator move constructor...");
+    {
+        std::vector<int> vec = {1, 2, 3, 4};
+        IOv2::StampInputIterator it1(vec.begin());
+        ++it1;
+        ++it1; // m_pos = 2
+        
+        // Move construction
+        auto it2 = std::move(it1);
+        // it1.m_pos should be 0 now
+        it1.rollback(); // Should be no-op
+        
+        it2.rollback();
+        VERIFY(*it2 == 1);
+    }
+    dump_info("Done\n");
+
+    dump_info("Test stamp_input_iterator move assignment...");
+    {
+        std::vector<int> vec = {1, 2, 3, 4};
+        IOv2::StampInputIterator it1(vec.begin());
+        ++it1;
+        ++it1; // m_pos = 2
+        
+        // Move assignment
+        auto it3 = IOv2::StampInputIterator(vec.begin());
+        it3 = std::move(it1);
+        
+        it1.rollback(); // Should be no-op
+        it3.rollback();
+        VERIFY(*it3 == 1);
+    }
+    dump_info("Done\n");
+
+    dump_info("Test stamp_input_iterator self assignment...");
+    {
+        std::vector<int> vec = {1, 2, 3, 4};
+        IOv2::StampInputIterator it1(vec.begin());
+        ++it1; // m_pos = 1
+
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wself-move"
+#endif
+        it1 = std::move(it1);
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+        VERIFY(*it1 == 2);
+        it1.rollback();
+        VERIFY(*it1 == 1);
+    }
+    dump_info("Done\n");
+
+    dump_info("Test stamp_input_iterator move semantics (istreambuf)...");
+    {
+        IOv2::mem_device dev("abc");
+        IOv2::istreambuf buf(dev);
+        IOv2::istreambuf_iterator is_it(buf);
+        IOv2::StampInputIterator s_it1(is_it);
+        
+        ++s_it1;
+        ++s_it1; // m_rec has 2 elements
+        
+        // Move construction
+        auto s_it2 = std::move(s_it1);
+        s_it1.rollback(); // Should be no-op as m_rec is empty
+        
+        s_it2.rollback();
+        VERIFY(*s_it2 == 'a');
+    }
+    dump_info("Done\n");
+}

--- a/test/util/test_util.cpp
+++ b/test/util/test_util.cpp
@@ -5,6 +5,7 @@
 void test_prefix_tree();
 void test_lru_cache();
 void test_clocale_wrapper();
+void test_stamp_input_iterator();
 
 int main()
 {
@@ -13,6 +14,7 @@ int main()
         test_prefix_tree();
         test_lru_cache();
         test_clocale_wrapper();
+        test_stamp_input_iterator();
         return 0;
     }
     catch (const std::exception& e)


### PR DESCRIPTION
- prefix_tree.h: fix uninitialized 'out' parameter and UB with nullptr input (Issue 1, 5)
- stamp_input_iterator.h: fix operator-> return type, uninitialized m_pos, and add move semantics (Issue 2, 6)
- sing_temp.h: improve exception safety in init constructor (Issue 3)
- clocale_wrapper.h: fix UB when copying from moved-from objects (Issue 4)
- lru_cache.h: remove redundant iterator assignments after splice (Issue 7)
- timeio.h: adapt to new prefix_tree interface
- tests: Added/updated tests for prefix_tree, clocale_wrapper, and stamp_input_iterator.