### PR TITLE
chore(common): apply P0 tasks for [[nodiscard]] and type constraints

### DIFF
--- a/include/common/lru_cache.h
+++ b/include/common/lru_cache.h
@@ -10,6 +10,10 @@
 namespace IOv2
 {
 template <typename TK, typename TV, size_t Capacity>
+    requires std::is_copy_constructible_v<TK>  // Key must be copyable for storage
+          && std::is_copy_constructible_v<TV>  // Value must be copyable for storage
+          && std::equality_comparable<TK>      // Key needs operator== for hash map
+          && requires { std::hash<TK>{}; }     // Key must be hashable
 class lru_cache
 {
     static_assert(Capacity > 0, "Capacity must be greater than 0");
@@ -24,7 +28,7 @@ public:
     lru_cache& operator=(const lru_cache&) = delete;
 
 public:
-    return_type get(key_param_type key)
+    [[nodiscard]] return_type get(key_param_type key)
     {
         auto m_it = m_cache_map.find(key);
         if (m_it == m_cache_map.end())
@@ -52,7 +56,7 @@ public:
         }
     }
 
-    bool try_put(key_param_type key, val_param_type value)
+    [[nodiscard]] bool try_put(key_param_type key, val_param_type value)
     {
         auto m_it = m_cache_map.find(key);
 

--- a/include/common/prefix_tree.h
+++ b/include/common/prefix_tree.h
@@ -24,6 +24,10 @@ namespace IOv2
 template <typename CharT, typename TValue>
 class prefix_tree
 {
+    // 🟡 Prevents confusing compile errors
+    static_assert(std::equality_comparable<CharT>, "CharT must be equality comparable");
+    static_assert(requires { std::hash<CharT>{}; }, "CharT must be hashable");
+
     struct node
     {
         std::unordered_map<CharT, std::unique_ptr<node>> children;
@@ -43,6 +47,7 @@ public:
     { }
 
     prefix_tree(const std::vector<const CharT*>& strs)
+        requires std::is_integral_v<TValue>
         : prefix_tree()
     {
         if (strs.size() > 0 &&
@@ -88,7 +93,7 @@ public:
     }
     
     template <std::bidirectional_iterator TIter, std::sentinel_for<TIter> TSent>
-    TIter max_match(TIter b, TSent e, match_out_type& out) const
+    [[nodiscard]] TIter max_match(TIter b, TSent e, match_out_type& out) const
     {
         if constexpr (is_small_type_v<TValue>)
             out = std::nullopt;
@@ -131,7 +136,7 @@ public:
     }
 
     template <is_istreambuf_iterator_v TIter, std::sentinel_for<TIter> TSent>
-    TIter max_match(TIter b, TSent e, match_out_type& out) const
+    [[nodiscard]] TIter max_match(TIter b, TSent e, match_out_type& out) const
     {
         if constexpr (is_small_type_v<TValue>)
             out = std::nullopt;

--- a/include/common/sing_temp.h
+++ b/include/common/sing_temp.h
@@ -24,6 +24,9 @@ public:
     {
         init()
         {
+            static_assert(std::is_class_v<T>, "sing_temp: T must be a class type");
+            static_assert(!std::is_abstract_v<T>, "sing_temp: T cannot be abstract");
+
             auto& count = RefCount();
             if (count++ == 0)
             {
@@ -50,7 +53,7 @@ public:
             }
         }
 
-        static auto& RefCount()
+        [[nodiscard]] static auto& RefCount()
         {
             static unsigned count{0};
             return count;
@@ -67,8 +70,11 @@ protected:
     sing_temp& operator=(const sing_temp&) = delete;
     
 public:
-    static T* ptr()
+    [[nodiscard]] static T* ptr()
     {
+        static_assert(std::is_class_v<T>, "sing_temp: T must be a class type");
+        static_assert(!std::is_abstract_v<T>, "sing_temp: T cannot be abstract");
+
         alignas(T) static char sing_buf[sizeof(T)];
         return reinterpret_cast<T*>(sing_buf);
     }

--- a/include/common/stamp_input_iterator.h
+++ b/include/common/stamp_input_iterator.h
@@ -51,8 +51,8 @@ struct StampInputIterator<TIter>
     using reference         = typename std::iterator_traits<TIter>::reference;
     using iterator_category = typename std::iterator_traits<TIter>::iterator_category;
 
-    reference operator*() const { return *m_internal; }
-    pointer operator->() const
+    [[nodiscard]] reference operator*() const { return *m_internal; }
+    [[nodiscard]] pointer operator->() const
     {
         if constexpr (std::is_pointer_v<TIter>)
             return m_internal;
@@ -60,14 +60,14 @@ struct StampInputIterator<TIter>
             return m_internal.operator->();
     }
 
-    reference operator[](difference_type n) const
+    [[nodiscard]] reference operator[](difference_type n) const
         requires (std::random_access_iterator<TIter>)
     { return m_internal[n]; }
     
     StampInputIterator& operator++() { ++m_internal; ++m_pos; return *this; }
-    StampInputIterator operator++(int) { StampInputIterator tmp = *this; ++(*this); return tmp; }
+    [[nodiscard]] StampInputIterator operator++(int) { StampInputIterator tmp = *this; ++(*this); return tmp; }
     StampInputIterator& operator--() { --m_internal; --m_pos; return *this; }
-    StampInputIterator operator--(int) { StampInputIterator tmp = *this; --(*this); return tmp; }
+    [[nodiscard]] StampInputIterator operator--(int) { StampInputIterator tmp = *this; --(*this); return tmp; }
     
     StampInputIterator& operator+=(difference_type n)
         requires (std::random_access_iterator<TIter>)
@@ -96,7 +96,7 @@ struct StampInputIterator<TIter>
     friend bool operator>=(const StampInputIterator& a, const StampInputIterator& b)
         requires (std::random_access_iterator<TIter>) { return a.m_internal >= b.m_internal; };
     
-    friend StampInputIterator operator+(const StampInputIterator& it, difference_type n)
+    [[nodiscard]] friend StampInputIterator operator+(const StampInputIterator& it, difference_type n)
         requires (std::random_access_iterator<TIter>)
     {
         StampInputIterator tmp = it;
@@ -104,13 +104,13 @@ struct StampInputIterator<TIter>
         return tmp;
     }
     
-    friend StampInputIterator operator+(difference_type n, const StampInputIterator& it)
+    [[nodiscard]] friend StampInputIterator operator+(difference_type n, const StampInputIterator& it)
         requires (std::random_access_iterator<TIter>)
     {
         return it + n;
     }
 
-    friend StampInputIterator operator-(const StampInputIterator& it, difference_type n)
+    [[nodiscard]] friend StampInputIterator operator-(const StampInputIterator& it, difference_type n)
         requires (std::random_access_iterator<TIter>)
     {
         StampInputIterator tmp = it;
@@ -118,7 +118,7 @@ struct StampInputIterator<TIter>
         return tmp;
     }
     
-    friend difference_type operator-(const StampInputIterator& lhs, const StampInputIterator& rhs)
+    [[nodiscard]] friend difference_type operator-(const StampInputIterator& lhs, const StampInputIterator& rhs)
         requires (std::random_access_iterator<TIter>)
     {
         return lhs.m_internal - rhs.m_internal;
@@ -130,7 +130,7 @@ struct StampInputIterator<TIter>
         m_pos = 0;
     }
     
-    TIter internal() const { return m_internal; }
+    [[nodiscard]] TIter internal() const { return m_internal; }
 private:
     TIter           m_internal;
     difference_type m_pos;
@@ -165,8 +165,8 @@ struct StampInputIterator<TIter>
     using value_type        = typename TIter::value_type;
     using difference_type   = typename TIter::difference_type;
 
-    auto operator*() const { return *m_internal; }
-    auto operator->() const { return m_internal; }
+    [[nodiscard]] auto operator*() const { return *m_internal; }
+    [[nodiscard]] auto operator->() const { return m_internal; }
 
     StampInputIterator& operator++()
     {
@@ -174,7 +174,7 @@ struct StampInputIterator<TIter>
         ++m_internal;
         return *this;
     }
-    StampInputIterator operator++(int) { StampInputIterator tmp = *this; ++(*this); return tmp; }
+    [[nodiscard]] StampInputIterator operator++(int) { StampInputIterator tmp = *this; ++(*this); return tmp; }
 
     StampInputIterator& operator--()
     {
@@ -185,7 +185,7 @@ struct StampInputIterator<TIter>
         m_rec.pop_front();
         return *this;
     }
-    StampInputIterator operator--(int) { StampInputIterator tmp = *this; --(*this); return tmp; }
+    [[nodiscard]] StampInputIterator operator--(int) { StampInputIterator tmp = *this; --(*this); return tmp; }
 
     friend bool operator==(const StampInputIterator& a, const StampInputIterator& b) { return a.m_internal == b.m_internal; };
     friend bool operator!=(const StampInputIterator& a, const StampInputIterator& b) { return a.m_internal != b.m_internal; };  
@@ -198,7 +198,7 @@ struct StampInputIterator<TIter>
         }
     }
     
-    TIter internal() const { return m_internal; }
+    [[nodiscard]] TIter internal() const { return m_internal; }
 private:
     TIter m_internal;
     std::forward_list<value_type> m_rec;


### PR DESCRIPTION
- Add [[nodiscard]] to critical functions in lru_cache, prefix_tree, sing_temp, and stamp_input_iterator.
- Implement multiline requires clauses for type constraints in lru_cache and sing_temp.
- Fix UB in prefix_tree by constraining TValue to integral types in the vector constructor.
- Adjust sing_temp constraints to support CRTP and private destructors in singletons.