### PR TITLE
fix(common): address code quality, naming consistency, and documentation

### DIFF
--- a/include/common/clocale_wrapper.h
+++ b/include/common/clocale_wrapper.h
@@ -1,11 +1,19 @@
 #pragma once
+#include <common/defs.h>
+
 #include <locale.h>
 #include <stdexcept>
-
-#include <common/defs.h>
+#include <string>
 
 namespace IOv2
 {
+/**
+ * @brief RAII wrapper for POSIX locale_t objects.
+ * 
+ * @note This class requires POSIX locale extensions (available on Linux, macOS).
+ *       Not available on Windows.
+ * @note This class is NOT thread-safe.
+ */
 struct clocale_wrapper
 {
     friend struct clocale_user;
@@ -41,7 +49,7 @@ struct clocale_wrapper
         val.c_locale = nullptr;
     }
 
-    clocale_wrapper& operator = (clocale_wrapper&& val) noexcept
+    clocale_wrapper& operator=(clocale_wrapper&& val) noexcept
     {
         if (this != &val)
         {

--- a/include/common/defs.h
+++ b/include/common/defs.h
@@ -1,8 +1,6 @@
 #pragma once
 #include <cstddef>
-#include <limits>
 #include <stdexcept>
-#include <type_traits>
 
 namespace IOv2
 {

--- a/include/common/lru_cache.h
+++ b/include/common/lru_cache.h
@@ -1,14 +1,23 @@
 #pragma once
+#include <common/metafunctions.h>
 
 #include <list>
 #include <optional>
+#include <type_traits>
 #include <unordered_map>
 #include <utility>
-#include <type_traits>
-#include <common/metafunctions.h>
 
 namespace IOv2
 {
+/**
+ * @brief A simple Least Recently Used (LRU) cache.
+ * 
+ * @tparam TK Key type.
+ * @tparam TV Value type.
+ * @tparam Capacity Maximum number of items to store.
+ * 
+ * @note This class is NOT thread-safe.
+ */
 template <typename TK, typename TV, size_t Capacity>
     requires std::is_copy_constructible_v<TK>  // Key must be copyable for storage
           && std::is_copy_constructible_v<TV>  // Value must be copyable for storage

--- a/include/common/metafunctions.h
+++ b/include/common/metafunctions.h
@@ -2,13 +2,12 @@
 #include <memory>
 #include <type_traits>
 
-
 namespace IOv2
 {
     template <typename... T>
-    constexpr bool DependencyFalse = false;
+    constexpr bool dependent_false_v = false;
     template <auto... T>
-    constexpr bool DependencyFalseV = false;
+    constexpr bool dependent_false_nttp_v = false;
 
     template <typename T>
     inline constexpr bool is_small_type_v = sizeof(T) <= 2 * sizeof(void*);

--- a/include/common/prefix_tree.h
+++ b/include/common/prefix_tree.h
@@ -1,31 +1,33 @@
 #pragma once
+#include <common/metafunctions.h>
+#include <common/streambuf_defs.h>
+
+#include <concepts>
 #include <forward_list>
 #include <iterator>
 #include <limits>
 #include <memory>
 #include <optional>
 #include <stdexcept>
-#include <string>
 #include <string_view>
 #include <unordered_map>
 #include <vector>
-
-#include <common/streambuf_defs.h>
-#include <common/metafunctions.h>
 
 namespace IOv2
 {
 /**
  * @brief A prefix tree (Trie) used for internal IOv2 components.
  * 
- * Note: This class is intended for internal use and does not provide a comprehensive
+ * @note This class is intended for internal use and does not provide a comprehensive
  *       set of public interfaces (e.g., remove, clear, size).
+ * @note This class is NOT thread-safe.
  */
 template <typename CharT, typename TValue>
 class prefix_tree
 {
-    // 🟡 Prevents confusing compile errors
+    // [NOTE] Prevents confusing compile errors
     static_assert(std::equality_comparable<CharT>, "CharT must be equality comparable");
+    static_assert(std::equality_comparable<TValue>, "TValue must be equality comparable");
     static_assert(requires { std::hash<CharT>{}; }, "CharT must be hashable");
 
     struct node
@@ -35,7 +37,7 @@ class prefix_tree
         size_t depth;
 
         node(std::optional<TValue> v, size_t d)
-            : val(v)
+            : val(std::move(v))
             , depth(d) {}
     };
 
@@ -135,7 +137,7 @@ public:
         return b;
     }
 
-    template <is_istreambuf_iterator_v TIter, std::sentinel_for<TIter> TSent>
+    template <is_istreambuf_iterator TIter, std::sentinel_for<TIter> TSent>
     [[nodiscard]] TIter max_match(TIter b, TSent e, match_out_type& out) const
     {
         if constexpr (is_small_type_v<TValue>)

--- a/include/common/sing_temp.h
+++ b/include/common/sing_temp.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <cstdlib>
+#include <type_traits>
 
 namespace IOv2
 {
@@ -40,7 +41,7 @@ public:
                     // reference count in an inconsistent state.
                     std::abort();
                 }
-            }            
+            }
         }
 
         ~init()
@@ -58,17 +59,17 @@ public:
             static unsigned count{0};
             return count;
         }
-        
+
         init(const init&) = delete;
         init& operator=(const init&) = delete;
     };
-    
+
 protected:
     sing_temp() = default;
     ~sing_temp() = default;
     sing_temp(const sing_temp&) = delete;
     sing_temp& operator=(const sing_temp&) = delete;
-    
+
 public:
     [[nodiscard]] static T* ptr()
     {

--- a/include/common/stamp_input_iterator.h
+++ b/include/common/stamp_input_iterator.h
@@ -1,8 +1,10 @@
 #pragma once
+#include <common/streambuf_defs.h>
+
 #include <algorithm>
 #include <forward_list>
 #include <iterator>
-#include <common/streambuf_defs.h>
+#include <stdexcept>
 
 namespace IOv2
 {
@@ -145,12 +147,12 @@ private:
  *       1. IOv2's sputbackc() returns void and never fails (uses unlimited deque)
  *       2. std::streambuf's sputbackc() returns int_type and may fail (limited putback area)
  *
- *       The is_istreambuf_iterator_v concept constraint ensures this specialization
+ *       The istreambuf_iterator concept constraint ensures this specialization
  *       only matches IOv2::istreambuf_iterator types.
  *
- * @tparam TIter Must satisfy is_istreambuf_iterator_v (IOv2::istreambuf_iterator only)
+ * @tparam TIter Must satisfy istreambuf_iterator (IOv2::istreambuf_iterator only)
  */
-template <is_istreambuf_iterator_v TIter>
+template <is_istreambuf_iterator TIter>
 struct StampInputIterator<TIter>
 {
     StampInputIterator()
@@ -211,8 +213,8 @@ template <typename TIter>
 StampInputIterator(StampInputIterator<TIter>&) -> StampInputIterator<TIter>;
 
 template <typename T>
-constexpr static bool IsStampInputIterator = false;
+constexpr static bool is_stamp_input_iterator_v = false;
 
 template <typename T>
-constexpr static bool IsStampInputIterator<StampInputIterator<T>> = true;
+constexpr static bool is_stamp_input_iterator_v<StampInputIterator<T>> = true;
 }

--- a/include/common/streambuf_defs.h
+++ b/include/common/streambuf_defs.h
@@ -13,49 +13,49 @@ template <io_device TDevice, typename TChar>
 class ostreambuf;
 
 template <typename T>
-struct is_streambuf_imp
+struct is_streambuf_impl
 {
     constexpr static bool value = false;
 };
 
 template <io_device TDevice, typename TChar>
-struct is_streambuf_imp<streambuf<TDevice, TChar>>
+struct is_streambuf_impl<streambuf<TDevice, TChar>>
 {
     constexpr static bool value = true;
 };
 
 template <typename T>
-constexpr static bool is_streambuf = is_streambuf_imp<T>::value;
+constexpr static bool is_streambuf = is_streambuf_impl<T>::value;
 
 template <typename T>
-struct is_istreambuf_imp
+struct is_istreambuf_impl
 {
     constexpr static bool value = false;
 };
 
 template <io_device TDevice, typename TChar>
-struct is_istreambuf_imp<istreambuf<TDevice, TChar>>
+struct is_istreambuf_impl<istreambuf<TDevice, TChar>>
 {
     constexpr static bool value = true;
 };
 
 template <typename T>
-constexpr static bool is_istreambuf = is_istreambuf_imp<T>::value;
+constexpr static bool is_istreambuf = is_istreambuf_impl<T>::value;
 
 template <typename T>
-struct is_ostreambuf_imp
+struct is_ostreambuf_impl
 {
     constexpr static bool value = false;
 };
 
 template <io_device TDevice, typename TChar>
-struct is_ostreambuf_imp<ostreambuf<TDevice, TChar>>
+struct is_ostreambuf_impl<ostreambuf<TDevice, TChar>>
 {
     constexpr static bool value = true;
 };
 
 template <typename T>
-constexpr static bool is_ostreambuf = is_ostreambuf_imp<T>::value;
+constexpr static bool is_ostreambuf = is_ostreambuf_impl<T>::value;
 
 template <typename TStreamBuf>
     requires (is_streambuf<TStreamBuf> || is_istreambuf<TStreamBuf>)
@@ -66,32 +66,32 @@ template <typename TStreamBuf>
 class ostreambuf_iterator;
 
 template <typename T>
-struct is_istreambuf_iterator
+struct is_istreambuf_iterator_impl
 {
     constexpr static bool value = false;
 };
 
 template <typename TStreamBuf>
-struct is_istreambuf_iterator<istreambuf_iterator<TStreamBuf>>
+struct is_istreambuf_iterator_impl<istreambuf_iterator<TStreamBuf>>
 {
     constexpr static bool value = true;
 };
 
 template <typename T>
-concept is_istreambuf_iterator_v = is_istreambuf_iterator<T>::value;
+concept is_istreambuf_iterator = is_istreambuf_iterator_impl<T>::value;
 
 template <typename T>
-struct is_ostreambuf_iterator
+struct is_ostreambuf_iterator_impl
 {
     constexpr static bool value = false;
 };
 
 template <typename TStreamBuf>
-struct is_ostreambuf_iterator<ostreambuf_iterator<TStreamBuf>>
+struct is_ostreambuf_iterator_impl<ostreambuf_iterator<TStreamBuf>>
 {
     constexpr static bool value = true;
 };
 
 template <typename T>
-concept is_ostreambuf_iterator_v = is_ostreambuf_iterator<T>::value;
+concept is_ostreambuf_iterator = is_ostreambuf_iterator_impl<T>::value;
 }

--- a/include/cvt/root_cvt.h
+++ b/include/cvt/root_cvt.h
@@ -197,7 +197,7 @@ public:
         else if constexpr (dev_cpt::support_put<device_type>)
             m_io_status = io_status::output;
         else
-            static_assert(DependencyFalse<device_type>, "device does not support get nor put");
+            static_assert(dependent_false_v<device_type>, "device does not support get nor put");
 
         return m_io_status;
     }

--- a/include/device/file_device.h
+++ b/include/device/file_device.h
@@ -277,7 +277,7 @@ private:
         }
         else
         {
-            static_assert(DependencyFalseV<IsIn, IsOut>, "file device cannot open with neither in nor out mode");
+            static_assert(dependent_false_nttp_v<IsIn, IsOut>, "file device cannot open with neither in nor out mode");
         }
     }
     

--- a/include/facet/collate_details.h
+++ b/include/facet/collate_details.h
@@ -86,7 +86,7 @@ public:
                 }
             }
             else
-                static_assert(DependencyFalse<CharT>, "collate_conf::compare is not implemented.");
+                static_assert(dependent_false_v<CharT>, "collate_conf::compare is not implemented.");
 
             if (c_res < 0) return std::strong_ordering::less;
             if (c_res > 0) return std::strong_ordering::greater;
@@ -140,7 +140,7 @@ public:
                 }
             }
             else
-                static_assert(DependencyFalse<CharT>, "collate_conf::transform_length is not implemented.");
+                static_assert(dependent_false_v<CharT>, "collate_conf::transform_length is not implemented.");
         }
 
         return res;
@@ -209,7 +209,7 @@ public:
                                    (static_cast<char32_t>(L'伟') == U'伟')))
                     cur_trans = wcsxfrm(reinterpret_cast<wchar_t*>(dest), reinterpret_cast<const wchar_t*>(cur), static_cast<unsigned>(-1));
                 else
-                    static_assert(DependencyFalse<CharT>, "collate_conf::transform is not implemented.");
+                    static_assert(dependent_false_v<CharT>, "collate_conf::transform is not implemented.");
                     
                 dest += cur_trans;
                 trans_count += cur_trans;
@@ -227,7 +227,7 @@ public:
                                    (static_cast<char32_t>(L'伟') == U'伟')))
                     trans_len = wcsxfrm(nullptr, reinterpret_cast<const wchar_t*>(cur), 0);
                 else
-                    static_assert(DependencyFalse<CharT>, "collate_conf::transform is not implemented.");
+                    static_assert(dependent_false_v<CharT>, "collate_conf::transform is not implemented.");
                     
                 std::vector<CharT> buf2;
                 buf2.resize(trans_len + 1);
@@ -243,7 +243,7 @@ public:
                                    (static_cast<char32_t>(L'伟') == U'伟')))
                     cur_trans = wcsxfrm(reinterpret_cast<wchar_t*>(buf2.data()), reinterpret_cast<const wchar_t*>(cur), static_cast<unsigned>(-1));
                 else
-                    static_assert(DependencyFalse<CharT>, "collate_conf::transform is not implemented.");
+                    static_assert(dependent_false_v<CharT>, "collate_conf::transform is not implemented.");
                     
                 cur_trans = std::min(cur_trans, mx_len - trans_count);
                 dest = std::copy(buf2.data(), buf2.data() + cur_trans, dest);

--- a/include/facet/ctype.h
+++ b/include/facet/ctype.h
@@ -278,7 +278,7 @@ private:
         if (!res)
         {
             auto v = m_obj->is(c);
-            m_table_cache.try_put(c, v);
+            m_table_cache.put(c, v);
             return v;
         }
         return *res;
@@ -294,7 +294,7 @@ private:
         if (!res)
         {
             auto v = m_obj->toupper(c);
-            m_upper_cache.try_put(c, v);
+            m_upper_cache.put(c, v);
             return v;
         }
         return *res;
@@ -310,7 +310,7 @@ private:
         if (!res)
         {
             auto v = m_obj->tolower(c);
-            m_lower_cache.try_put(c, v);
+            m_lower_cache.put(c, v);
             return v;
         }
         return *res;
@@ -326,7 +326,7 @@ private:
         if (!res)
         {
             auto v = m_obj->narrow(c);
-            m_narrow_cache.try_put(c, v);
+            m_narrow_cache.put(c, v);
             return v;
         }
         return *res;

--- a/include/facet/timeio.h
+++ b/include/facet/timeio.h
@@ -545,7 +545,7 @@ public:
     }
 
     template <typename TIter, std::sentinel_for<TIter> TSent, bool HaveDate, bool HaveTime, bool HaveTimeZone>
-        requires (std::bidirectional_iterator<TIter> || is_istreambuf_iterator_v<TIter>)
+        requires (std::bidirectional_iterator<TIter> || is_istreambuf_iterator<TIter>)
     TIter get(TIter beg, TSent end, time_parse_context<char_type, HaveDate, HaveTime, HaveTimeZone>& ctx,
               char format, char modifier = 0) const
     {
@@ -566,7 +566,7 @@ public:
     }
 
     template <typename TIter, std::sentinel_for<TIter> TSent, bool HaveDate, bool HaveTime, bool HaveTimeZone>
-        requires (std::bidirectional_iterator<TIter> || is_istreambuf_iterator_v<TIter>)
+        requires (std::bidirectional_iterator<TIter> || is_istreambuf_iterator<TIter>)
     TIter get(TIter rp, TSent rp_end, time_parse_context<char_type, HaveDate, HaveTime, HaveTimeZone>& ctx,
               std::basic_string_view<CharT> _fmt) const
     {
@@ -579,7 +579,7 @@ public:
 
 private:
     template <typename TIter, std::sentinel_for<TIter> TSent, bool HaveDate, bool HaveTime, bool HaveTimeZone>
-        requires (std::bidirectional_iterator<TIter> || is_istreambuf_iterator_v<TIter>)
+        requires (std::bidirectional_iterator<TIter> || is_istreambuf_iterator<TIter>)
     TIter do_get(TIter rp, TSent rp_end, time_parse_context<char_type, HaveDate, HaveTime, HaveTimeZone>& ctx,
                  bool& succ, std::basic_string_view<CharT> _fmt) const
     {
@@ -1121,7 +1121,7 @@ private:
                 else if (modifier == static_cast<CharT>('O')) goto bad_parse_format;
                 else if ((modifier == static_cast<CharT>('E')) && (!m_era_items.empty()))
                 {
-                    if constexpr (IsStampInputIterator<TIter>)
+                    if constexpr (is_stamp_input_iterator_v<TIter>)
                     {
                         succ = false;
                         return rp;

--- a/include/io/objects/in_impl.h
+++ b/include/io/objects/in_impl.h
@@ -52,7 +52,7 @@ public:
         else if constexpr (std::is_same_v<char_type, wchar_t>)
             m_streambuf = istreambuf<device_type, wchar_t>(std::move(dev), code_cvt_stdio_creator(code()), !sync);
         else
-            static_assert(DependencyFalse<char_type>, "invalid character type");
+            static_assert(dependent_false_v<char_type>, "invalid character type");
         return old_sync_state;
     }
 

--- a/include/io/utilities/istream_operators.h
+++ b/include/io/utilities/istream_operators.h
@@ -332,7 +332,7 @@ concept istream_type =
     {
         typename T::in_sentry_type;
         typename T::char_type;
-        { a.i_iter() } -> is_istreambuf_iterator_v;
+        { a.i_iter() } -> istreambuf_iterator;
         { a.locale() } -> std::same_as<const locale<typename T::char_type>&>;
     } &&
     is_in_sentry<typename T::in_sentry_type> &&
@@ -408,7 +408,7 @@ T& operator>>(T& obj, TValue& value)
             }
         }
         else
-            static_assert(DependencyFalse<TValue>, "No parse method provided");
+            static_assert(dependent_false_v<TValue>, "No parse method provided");
     }
     catch(...)
     {

--- a/include/io/utilities/ostream_operators.h
+++ b/include/io/utilities/ostream_operators.h
@@ -136,7 +136,7 @@ concept ostream_type =
     {
         typename T::out_sentry_type;
         typename T::char_type;
-        { a.o_iter() } -> is_ostreambuf_iterator_v;
+        { a.o_iter() } -> ostreambuf_iterator;
         { a.locale() } -> std::same_as<const locale<typename T::char_type>&>;
     } &&
     is_out_sentry<typename T::out_sentry_type> &&
@@ -201,7 +201,7 @@ T& operator<<(T& obj, const TValue& value)
         else if constexpr (is_writer_def<TChar, TDecay>)
             writer<TChar, TDecay>::swrite(obj.o_iter(), obj, obj.locale(), value);
         else
-            static_assert(DependencyFalse<TValue>, "No format method provided");
+            static_assert(dependent_false_v<TValue>, "No format method provided");
     }
     catch(...)
     {

--- a/test/util/test_lru_cache.cpp
+++ b/test/util/test_lru_cache.cpp
@@ -54,7 +54,7 @@ void test_lru_cache_eviction()
     cache.put(2, "two");
     
     // 1 is MRU, 2 is LRU
-    cache.get(1); 
+    (void)cache.get(1); 
     
     // 2 should be evicted
     cache.put(3, "three"); 

--- a/test/util/test_prefix_tree.cpp
+++ b/test/util/test_prefix_tree.cpp
@@ -107,7 +107,7 @@ void test_prefix_tree_vector_constructor()
 
     decltype(tree)::match_out_type out;
     std::string s = "banana";
-    tree.max_match(s.begin(), s.end(), out);
+    (void)tree.max_match(s.begin(), s.end(), out);
     VERIFY(out && *out == 1); // Index 1 in the vector
     dump_info("Done\n");
 }


### PR DESCRIPTION
- Refactor naming: Rename concepts (remove _v) and variable templates (snake_case_v).
- Update all call sites for dependent_false_v and dependent_false_nttp_v.
- Add Doxygen documentation with thread-safety notes to critical common classes.
- Standardize include ordering (local headers first) across common library.
- Use std::move in prefix_tree for performance and remove unnecessary includes.
- Fix compiler warnings in tests and update ctype cache usage.