### PR TITLE
refactor: decouple converter flush from device dflush

### DIFF
--- a/include/cvt/abs_cvt.h
+++ b/include/cvt/abs_cvt.h
@@ -236,7 +236,7 @@ namespace IOv2
     
     // mandatory methods
     public:
-        const device_type& device() const & { return m_kernel.device(); }
+        device_type& device() { return m_kernel.device(); }
         device_type detach()
         {
             m_io_status = io_status::neutral;

--- a/include/cvt/cvt_concepts.h
+++ b/include/cvt/cvt_concepts.h
@@ -60,7 +60,7 @@ namespace IOv2
         concept mandatory_methods = requires(T a, const T& c,
                                              const cvt_behavior& b, cvt_status& s)
             {
-                { c.device() } -> std::same_as<const typename T::device_type&>;
+                { a.device() } -> std::same_as<typename T::device_type&>;
                 { a.detach() } -> std::same_as<typename T::device_type>;
                 { a.attach(std::declval<typename T::device_type>()) } -> std::same_as<typename T::device_type>;
 

--- a/include/cvt/root_cvt.h
+++ b/include/cvt/root_cvt.h
@@ -135,7 +135,7 @@ public:
 
 // mandatory methods
 public:
-    const device_type& device() const & { return m_device; }
+    device_type& device() { return m_device; }
     
     device_type detach()
     {
@@ -293,7 +293,6 @@ public:
             m_device.dput(m_buffer.data(), m_buf_cur - m_buffer.data());
             m_buf_cur = m_buffer.data();
         }
-        m_device.dflush();
     }
     
     /// positioning

--- a/include/cvt/runtime_cvt.h
+++ b/include/cvt/runtime_cvt.h
@@ -22,7 +22,7 @@ public:
 public:
     virtual std::unique_ptr<abs_runtime_cvt_imp> clone() const & = 0;
     
-    virtual const device_type& device() const & = 0;
+    virtual device_type& device() = 0;
     virtual device_type detach() = 0;
     virtual device_type attach(device_type&& dev = device_type{}) = 0;
     virtual void adjust(const cvt_behavior& acc) = 0;
@@ -70,7 +70,7 @@ public:
             throw cvt_error("runtime_cvt fail: kernel does not support copy construction");
     }
     
-    const device_type& device() const & override
+    device_type& device() override
     {
         return m_kernel.device();
     }
@@ -224,7 +224,7 @@ public:
     runtime_cvt& operator=(runtime_cvt&&) = default;
 
 public:
-    const device_type& device() const &
+    device_type& device()
     {
         return m_ptr->device();
     }

--- a/include/io/streambuf.h
+++ b/include/io/streambuf.h
@@ -192,7 +192,7 @@ public:
     }
 
     /// others
-    const device_type& device() const &
+    device_type& device()
     {
         return m_cvt.device();
     }

--- a/include/io/utilities/ostream_operators.h
+++ b/include/io/utilities/ostream_operators.h
@@ -15,7 +15,7 @@ public:
         , m_is_unit_buf(is_unit_buf)
     {
         if constexpr (is_std)
-            m_is_unit_buf = m_is_unit_buf || os.m_sync_with_stdio;
+            m_sync_with_stdio = os.m_sync_with_stdio;
 
         if constexpr (involve_input)
             os.m_streambuf.switch_to_put();
@@ -34,9 +34,17 @@ public:
 
     ~out_sentry()
     {
-        if (m_is_unit_buf && m_os.good())
+        if (m_os.good())
         {
-            m_os.m_streambuf.flush();
+            if (m_is_unit_buf || m_sync_with_stdio)
+            {
+                m_os.m_streambuf.flush();
+            }
+
+            if (m_is_unit_buf)
+            {
+                m_os.m_streambuf.device().dflush();
+            }
         }
     }
     
@@ -44,8 +52,9 @@ public:
     out_sentry& operator=(const out_sentry&) = delete;
 
 private:
-    TStream& m_os;
-    bool m_is_unit_buf;
+    TStream&    m_os;
+    bool        m_is_unit_buf;
+    bool        m_sync_with_stdio = false;
 };
 
 template <typename>
@@ -111,11 +120,18 @@ struct ostream_operators : public abs_ostream
     {
         T& obj = static_cast<T&>(*this);
         if (!obj.good()) return;
+
         try
         {
-            using sentry_type = typename T::out_sentry_type;
-            sentry_type cerb(obj, bool(obj.flags() & ios_defs::unitbuf), false);
-            return obj.m_streambuf.flush();
+            if constexpr (dev_cpt::support_put<typename T::device_type>)
+            {
+                using sentry_type = typename T::out_sentry_type;
+                sentry_type cerb(obj, bool(obj.flags() & ios_defs::unitbuf), false);
+                obj.m_streambuf.flush();
+                obj.m_streambuf.device().dflush();
+            }
+            else
+                throw stream_error("ostream_operators::flush fail: device does not support output");
         }
         catch(...)
         {

--- a/include/io/utilities/stream_common_operators.h
+++ b/include/io/utilities/stream_common_operators.h
@@ -57,9 +57,9 @@ struct stream_common_operators
         return obj;
     }
 
-    const TDevice& device() const &
+    TDevice& device()
     {
-        const T& obj = static_cast<const T&>(*this);
+        T& obj = static_cast<T&>(*this);
         return obj.m_streambuf.device();
     }
 

--- a/test/cvt/root_cvt/root_cvt_file.cpp
+++ b/test/cvt/root_cvt/root_cvt_file.cpp
@@ -642,6 +642,7 @@ void test_root_cvt_file_reset_1()
         obj.put(" cpp", 4);
         if (obj.tell() != 4) throw std::runtime_error("root_cvt<file_device>::tell incorrect");
         obj.flush();
+        obj.device().dflush();
 
         if (g2.contents() != "liwei cpp") throw std::runtime_error("root_cvt<file_device>::put incorrect");
     };


### PR DESCRIPTION
- Refactored root_cvt::flush() to perform only buffer-to-device transfer.
- Updated ostream_operators::flush() to perform a full flush (flush + dflush).
- Optimized out_sentry to only perform soft flush on sync_with_stdio(true).
- Updated related converters and streambuf to align with new flush semantics.