### PR TITLE
refactor(device): integrate clang-tidy fixes and transition to std::unique_ptr

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
 
     - name: Run clang-tidy
       run: |
-        clang-tidy-19 $(find include/common -name '*.h') \
+        clang-tidy-19 $(find include/common include/device -name '*.h') \
           --checks='bugprone-*,performance-*,modernize-*,cppcoreguidelines-*,-modernize-use-trailing-return-type,-cppcoreguidelines-avoid-magic-numbers,-cppcoreguidelines-pro-bounds-pointer-arithmetic,-cppcoreguidelines-pro-bounds-constant-array-index,-cppcoreguidelines-avoid-non-const-global-variables,-clang-diagnostic-pragma-once-outside-header' \
           --warnings-as-errors='bugprone-*' \
           -- -std=c++23 -x c++ -I include -I /usr/include -I /usr/include/botan-2

--- a/include/common/clocale_wrapper.h
+++ b/include/common/clocale_wrapper.h
@@ -40,7 +40,7 @@ struct clocale_wrapper
     template <typename CharT> friend class ctype_conf;
 
     explicit clocale_wrapper(const char* name)
-        : c_locale(name ? newlocale(LC_ALL_MASK, name, 0) : nullptr)
+        : c_locale(name ? newlocale(LC_ALL_MASK, name, nullptr) : nullptr)
     {
         if (!name)
             throw cvt_error("clocale_wrapper: name cannot be null");

--- a/include/device/file_device.h
+++ b/include/device/file_device.h
@@ -10,31 +10,32 @@
 #include <exception>
 #include <expected>
 #include <limits>
+#include <memory>
 #include <string>
 
 namespace IOv2
 {
-enum class file_open_flag : unsigned
+enum class file_open_flag : std::uint8_t
 {
     none        = 0,
-    binary      = (unsigned)1 << 0,
-    trunc       = (unsigned)1 << 1,
-    noreplace   = (unsigned)1 << 2
+    binary      = (std::uint8_t)1 << 0,
+    trunc       = (std::uint8_t)1 << 1,
+    noreplace   = (std::uint8_t)1 << 2
 };
 
 constexpr file_open_flag operator | (file_open_flag v1, file_open_flag v2)
 {
-    return (file_open_flag)((unsigned) v1 | (unsigned)v2);
+    return (file_open_flag)((std::uint8_t) v1 | (std::uint8_t)v2);
 }
 
 constexpr file_open_flag operator & (file_open_flag v1, file_open_flag v2)
 {
-    return (file_open_flag)((unsigned) v1 & (unsigned)v2);
+    return (file_open_flag)((std::uint8_t) v1 & (std::uint8_t)v2);
 }
 
 constexpr file_open_flag operator ~ (file_open_flag v1)
 {
-    return (file_open_flag)(~((unsigned) v1));
+    return (file_open_flag)(~((std::uint8_t) v1));
 }
 
 template <bool IsIn, bool IsOut, typename CharType>
@@ -47,39 +48,37 @@ class basic_file_device<IsIn, IsOut, CharType>
 public:
     using char_type = CharType;
     
+private:
+    struct file_deleter
+    {
+        void operator()(FILE* fp) const noexcept
+        {
+            if (fp) std::fclose(fp); // NOLINT(cppcoreguidelines-owning-memory)
+        }
+    };
+
 public:
     basic_file_device() = default;
 
     explicit basic_file_device(const std::string& file_name, file_open_flag flags = file_open_flag::none)
     {
         const char* mode = fopen_mode(flags);
-        FILE* fp = std::fopen(file_name.c_str(), mode);
-        if (!fp)
+        m_file.reset(std::fopen(file_name.c_str(), mode));
+        if (!m_file)
             throw device_error("cannot open file \"" + file_name + "\": " + std::strerror(errno));
 
-        if (fseek_64(fp, 0, SEEK_END) != 0)
-        {
-            std::fclose(fp);
+        if (fseek_64(m_file.get(), 0, SEEK_END) != 0)
             throw device_error("cannot get file length for \"" + file_name + "\"");
-        }
-        int64_t len = ftell_64(fp);
+        
+        int64_t len = ftell_64(m_file.get());
         if (len < 0)
-        {
-            std::fclose(fp);
             throw device_error("cannot get file length for \"" + file_name + "\"");
-        }
         else if (static_cast<uint64_t>(len) > std::numeric_limits<size_t>::max())
-        {
-            std::fclose(fp);
             throw device_error("file too large for this platform");
-        }
 
-        if (fseek_64(fp, 0, SEEK_SET) != 0)
-        {
-            std::fclose(fp);
+        if (fseek_64(m_file.get(), 0, SEEK_SET) != 0)
             throw device_error("cannot reset the file for \"" + file_name + "\"");
-        }        
-        m_file = fp;
+              
         m_file_len = static_cast<size_t>(len);
     }
 
@@ -97,37 +96,13 @@ public:
     basic_file_device(const basic_file_device&) = delete;
     basic_file_device& operator=(const basic_file_device&) = delete;
     
-    basic_file_device(basic_file_device&& obj)
-        : m_file(obj.m_file)
-        , m_file_len(obj.m_file_len)
-    {
-        obj.m_file = nullptr;
-        obj.m_file_len = 0;
-    }
+    basic_file_device(basic_file_device&&) noexcept = default;
+    basic_file_device& operator=(basic_file_device&&) noexcept = default;
     
-    basic_file_device& operator=(basic_file_device&& obj)
-    {
-        if (this != &obj)
-        {
-            close();
-            m_file = obj.m_file;
-            m_file_len = obj.m_file_len;
-
-            obj.m_file = nullptr;
-            obj.m_file_len = 0;
-        }
-        return *this;
-    }
-    
-    ~basic_file_device()
-    {
-        try {
-            close();
-        } catch (...) {}
-    }
+    ~basic_file_device() = default;
 
 public:
-    bool deof() const
+    [[nodiscard]] bool deof() const
     {
         if (!is_open())
             return true;
@@ -141,7 +116,7 @@ public:
         }
     }
 
-    bool is_open() const
+    [[nodiscard]] bool is_open() const
     {
         return m_file != nullptr;
     }
@@ -159,8 +134,7 @@ public:
                     ptr = std::current_exception();
                 }
             }
-            std::fclose(m_file);
-            m_file = nullptr;
+            m_file.reset();
             m_file_len = 0;
             if (ptr) std::rethrow_exception(ptr);
         }
@@ -175,24 +149,24 @@ public:
         if (n == 0) return 0;
 
         if (!is_open()) return 0;
-        size_t count = fread(s, sizeof(CharType), n, m_file);
-        if (count < n && ferror(m_file))
+        size_t count = std::fread(s, sizeof(CharType), n, m_file.get());
+        if (count < n && std::ferror(m_file.get()))
             throw device_error("file_device::dget fail: read error");
         return count;
     }
 
-    size_t dtell() const
+    [[nodiscard]] size_t dtell() const
     {
         if (!is_open())
             throw device_error("file_device::dtell fail: file is closed");
         
-        auto res = ftell_64(m_file);
+        auto res = ftell_64(m_file.get());
         if (res < 0)
             throw device_error("file_device::dtell fail: got invalid position.");
         return static_cast<size_t>(res);
     }
 
-    size_t dsize() const
+    [[nodiscard]] size_t dsize() const
     {
         return m_file_len;
     }
@@ -210,7 +184,7 @@ public:
         if (v > std::numeric_limits<int64_t>::max())
             throw device_error("file_device::dseek fail: position exceeds maximum seekable range");
 
-        if (fseek_64(m_file, static_cast<int64_t>(v), SEEK_SET) != 0)
+        if (fseek_64(m_file.get(), static_cast<int64_t>(v), SEEK_SET) != 0)
             throw device_error("file_device::dseek fail: fseek invalid response");
     }
 
@@ -223,7 +197,7 @@ public:
             throw device_error("file_device::drseek fail: invalid parameter");
         const int64_t l_off = -static_cast<int64_t>(offset);
 
-        if (fseek_64(m_file, l_off, SEEK_END) != 0)
+        if (fseek_64(m_file.get(), l_off, SEEK_END) != 0)
             throw device_error("file_device::drseek fail: fseek invalid response");
     }
     
@@ -235,7 +209,7 @@ public:
         if (!is_open())
             throw device_error("file_device::dput fail: file closed.");
         if (n == 0) return;
-        if (std::fwrite(ch, sizeof(CharType), n, m_file) != n)
+        if (std::fwrite(ch, sizeof(CharType), n, m_file.get()) != n)
             throw device_error("file_device::dput fail: partial success.");
         
         auto cur_pos = dtell();
@@ -247,7 +221,7 @@ public:
         requires (IsOut)
     {
         if (!is_open()) return;
-        if (fflush(m_file) == EOF)
+        if (std::fflush(m_file.get()) == EOF)
             throw device_error("file_device::dflush fail: fflush fail.");
     }
 
@@ -327,7 +301,7 @@ private:
     }
 
 private:
-    FILE*  m_file = nullptr;
+    std::unique_ptr<FILE, file_deleter> m_file;
     size_t m_file_len = 0;
 };
 

--- a/include/device/mem_device.h
+++ b/include/device/mem_device.h
@@ -20,18 +20,18 @@ public:
 public:
     mem_device(std::basic_string<CharT, Traits, Allocator> info = std::basic_string<CharT, Traits, Allocator>{})
         : m_str(std::move(info))
-        , m_next_pos(0)
     {}
 
     mem_device(const mem_device&) = default;
     mem_device(mem_device&&) = default;
     mem_device& operator=(const mem_device&) = default;
     mem_device& operator=(mem_device&&) = default;
+    ~mem_device() = default;
 
-    const std::basic_string<CharT, Traits, Allocator>& str() const { return m_str; }
+    [[nodiscard]] const std::basic_string<CharT, Traits, Allocator>& str() const { return m_str; }
 
 public:
-    bool deof() const
+    [[nodiscard]] bool deof() const
     {
         return (m_next_pos >= m_str.size());
     }
@@ -48,12 +48,12 @@ public:
         return res;
     }
     
-    size_t dtell() const
+    [[nodiscard]] size_t dtell() const
     {
         return m_next_pos;
     }
 
-    size_t dsize() const
+    [[nodiscard]] size_t dsize() const
     {
         return m_str.size();
     }
@@ -99,5 +99,5 @@ private:
 };
 
 template <typename TChar>
-mem_device(const TChar []) -> mem_device<TChar>;
+mem_device(const TChar*) -> mem_device<TChar>;
 }

--- a/include/device/std_device.h
+++ b/include/device/std_device.h
@@ -20,8 +20,8 @@ public:
     std_device() = default;
     std_device(const std_device&) = delete;
     std_device& operator=(const std_device&) = delete;
-    std_device(std_device&&) = default;
-    std_device& operator=(std_device&&) = default;
+    std_device(std_device&&) noexcept = default;
+    std_device& operator=(std_device&&) noexcept = default;
 
     ~std_device()
     {
@@ -29,11 +29,13 @@ public:
         {
             try {
                 dflush();
-            } catch (...) {}
+            } catch (...) { // NOLINT(bugprone-empty-catch)
+                // Ignore exceptions in destructor to prevent std::terminate
+            }
         }
     }
 
-    bool deof() const
+    [[nodiscard]] bool deof() const
         requires (ID == STDIN_FILENO)
     {
         return m_eof_hit;
@@ -46,7 +48,7 @@ public:
             throw device_error("std_device::dget fail: null buffer");
         if (n == 0 || m_eof_hit) return 0;
 
-        ssize_t ret;
+        ssize_t ret = 0;
         while (true)
         {
             ret = read(ID, s, n);


### PR DESCRIPTION
- Refactored basic_file_device to use std::unique_ptr for FILE* management.
- Simplified resource handling and move semantics in file_device.h.
- Applied clang-tidy recommendations across include/device:
  - Added [[nodiscard]] and noexcept where applicable.
  - Initialized variables and fixed enum base types.
  - Handled empty catch blocks with NOLINT and comments.
- Updated ci.yml to include include/device in the clang-tidy pipeline.