### PR TITLE
docs(device): add Doxygen comments for device headers

### DIFF
--- a/include/device/device_concepts.h
+++ b/include/device/device_concepts.h
@@ -1,3 +1,16 @@
+/**
+ * @file device_concepts.h
+ * @lang{ZH}
+ * 定义了 I/O 设备所需满足的 C++ 概念（Concepts）。
+ * 这些概念用于在编译期检查设备类型是否提供了预期的接口，例如定位、读取或写入。
+ * @endif
+ *
+ * @lang{EN}
+ * Defines the C++ concepts that I/O devices must satisfy.
+ * These concepts are used at compile-time to verify whether a device type provides
+ * the expected interface, such as for positioning, reading, or writing.
+ * @endif
+ */
 #pragma once
 #include <concepts>
 #include <cstddef>
@@ -5,8 +18,33 @@
 
 namespace IOv2
 {
+    /**
+     * @lang{ZH}
+     * 包含设备概念底层实现的命名空间。
+     * @endif
+     *
+     * @lang{EN}
+     * Namespace containing the underlying implementation of device concepts.
+     * @endif
+     */
     namespace dev_cpt
     {
+        /**
+         * @lang{ZH}
+         * @brief 设备支持定位操作的概念。
+         *
+         * 要求设备提供获取当前位置、获取总大小、从头定位和从尾定位的接口。
+         * @tparam T 要检查的设备类型。
+         * @endif
+         *
+         * @lang{EN}
+         * @brief Concept for devices that support positioning operations.
+         *
+         * Requires the device to provide interfaces for getting the current position,
+         * getting the total size, seeking from the beginning, and seeking from the end.
+         * @tparam T The device type to check.
+         * @endif
+         */
         template <typename T>
         concept support_positioning = requires(T a, const T& c)
             {
@@ -15,14 +53,46 @@ namespace IOv2
                 { a.dseek(std::declval<size_t>()) } -> std::same_as<void>;
                 { a.drseek(std::declval<size_t>()) } -> std::same_as<void>;
             };
-        
+
+        /**
+         * @lang{ZH}
+         * @brief 设备支持写入操作的概念。
+         *
+         * 要求设备提供写入数据（dput）和刷新缓冲区（dflush）的接口。
+         * @tparam T 要检查的设备类型。
+         * @endif
+         *
+         * @lang{EN}
+         * @brief Concept for devices that support write operations.
+         *
+         * Requires the device to provide interfaces for writing data (dput) and
+         * flushing the buffer (dflush).
+         * @tparam T The device type to check.
+         * @endif
+         */
         template <typename T>
         concept support_put = requires(T a)
             {
                 { a.dput(std::declval<const typename T::char_type*>(), std::declval<size_t>()) } -> std::same_as<void>;
                 { a.dflush() } -> std::same_as<void>;
             };
-        
+
+        /**
+         * @lang{ZH}
+         * @brief 设备支持读取操作的概念。
+         *
+         * 要求设备提供读取数据（dget）和检查文件末尾（deof）的接口。
+         * @tparam T 要检查的设备类型。
+         * @endif
+         *
+         * @lang{EN}
+         * @brief Concept for devices that support read operations.
+         *
+         * Requires the device to provide interfaces for reading data (dget) and
+         * checking for the end of the file (deof).
+         * @tparam T The device type to check.
+         * @endif
+         */
         template <typename T>
         concept support_get = requires(T a, const T& c)
             {
@@ -31,6 +101,23 @@ namespace IOv2
             };
     }
 
+    /**
+     * @lang{ZH}
+     * @brief I/O 设备的统一概念。
+     *
+     * 一个类型如果能被称为 I/O 设备，它必须定义 `char_type` 类型，
+     * 并且至少支持读取（support_get）或写入（support_put）操作之一。
+     * @tparam T 要检查的设备类型。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Unified concept for an I/O device.
+     *
+     * For a type to be considered an I/O device, it must define the `char_type` type
+     * and support at least one of read (support_get) or write (support_put) operations.
+     * @tparam T The device type to check.
+     * @endif
+     */
     template <typename T>
     concept io_device =
         requires{ typename T::char_type; } &&

--- a/include/device/file_device.h
+++ b/include/device/file_device.h
@@ -1,3 +1,15 @@
+/**
+ * @file file_device.h
+ * @lang{ZH}
+ * 定义了 `basic_file_device` 类，这是一个 I/O 设备，它封装了 C 标准库的 `FILE` 操作。
+ * 这个设备提供了对文件进行读、写和定位的功能。
+ * @endif
+ *
+ * @lang{EN}
+ * Defines the `basic_file_device` class, an I/O device that wraps the C standard library `FILE` operations.
+ * This device provides functionality for reading, writing, and seeking within files.
+ * @endif
+ */
 #pragma once
 #include <common/defs.h>
 #include <common/metafunctions.h>
@@ -15,14 +27,30 @@
 
 namespace IOv2
 {
+/**
+ * @lang{ZH}
+ * @brief `fopen` 的文件打开模式标志。
+ *
+ * 这个枚举类提供了一组标志，用于以类型安全的方式指定文件打开模式，
+ * 例如二进制模式、截断模式等。
+ * @endif
+ *
+ * @lang{EN}
+ * @brief File opening mode flags for `fopen`.
+ *
+ * This enum class provides a set of flags to specify file opening modes
+ * in a type-safe manner, such as binary mode, truncation, etc.
+ * @endif
+ */
 enum class file_open_flag : std::uint8_t
 {
-    none        = 0,
-    binary      = (std::uint8_t)1 << 0,
-    trunc       = (std::uint8_t)1 << 1,
-    noreplace   = (std::uint8_t)1 << 2
+    none        = 0,                            ///< @lang{ZH} 无特殊标志。 @endif @lang{EN} No special flags. @endif
+    binary      = (std::uint8_t)1 << 0,         ///< @lang{ZH} 以二进制模式打开文件。 @endif @lang{EN} Open the file in binary mode. @endif
+    trunc       = (std::uint8_t)1 << 1,         ///< @lang{ZH} 如果文件已存在，则截断它。 @endif @lang{EN} Truncate the file if it already exists. @endif
+    noreplace   = (std::uint8_t)1 << 2          ///< @lang{ZH} 如果文件已存在，则打开失败。 @endif @lang{EN} Fail to open if the file already exists. @endif
 };
 
+/// @cond
 constexpr file_open_flag operator | (file_open_flag v1, file_open_flag v2)
 {
     return (file_open_flag)((std::uint8_t) v1 | (std::uint8_t)v2);
@@ -37,18 +65,55 @@ constexpr file_open_flag operator ~ (file_open_flag v1)
 {
     return (file_open_flag)(~((std::uint8_t) v1));
 }
+/// @endcond
 
 template <bool IsIn, bool IsOut, typename CharType>
 class basic_file_device;
 
+/**
+ * @lang{ZH}
+ * @brief 基于 C `FILE*` 的文件设备模板。
+ *
+ * 封装了 C 标准 I/O 库，提供了一个 RAII 风格的接口来管理文件。
+ * 它可以通过模板参数配置为只读、只写或读写模式。
+ *
+ * @tparam IsIn 指定设备是否支持输入（读取）。
+ * @tparam IsOut 指定设备是否支持输出（写入）。
+ * @tparam CharType 字符类型，当前支持 `char` 和 `char8_t`。
+ * @endif
+ *
+ * @lang{EN}
+ * @brief A file device template based on the C `FILE*`.
+ *
+ * This class wraps the C standard I/O library, providing an RAII-style interface for managing files.
+ * It can be configured as read-only, write-only, or read-write via template parameters.
+ *
+ * @tparam IsIn Specifies if the device supports input (reading).
+ * @tparam IsOut Specifies if the device supports output (writing).
+ * @tparam CharType The character type, currently supports `char` and `char8_t`.
+ * @endif
+ */
 template <bool IsIn, bool IsOut, typename CharType>
     requires ((IsIn || IsOut) && (std::is_same_v<CharType, char> || std::is_same_v<CharType, char8_t>))
 class basic_file_device<IsIn, IsOut, CharType>
 {
 public:
     using char_type = CharType;
-    
+
 private:
+    /**
+     * @lang{ZH}
+     * @brief 用于 `std::unique_ptr` 的 `FILE` 删除器。
+     *
+     * 当 `unique_ptr` 销毁时，这个删除器会调用 `std::fclose` 来确保文件被关闭。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief A `FILE` deleter for `std::unique_ptr`.
+     *
+     * This deleter calls `std::fclose` to ensure the file is closed when the `unique_ptr` is destroyed.
+     * @endif
+     */
     struct file_deleter
     {
         void operator()(FILE* fp) const noexcept
@@ -58,8 +123,34 @@ private:
     };
 
 public:
+    /**
+     * @lang{ZH}
+     * @brief 默认构造函数，创建一个关闭状态的文件设备。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Default constructor, creates a file device in a closed state.
+     * @endif
+     */
     basic_file_device() = default;
 
+    /**
+     * @lang{ZH}
+     * @brief 构造函数，打开一个文件并准备 I/O 操作。
+     *
+     * @param file_name 要打开的文件的路径。
+     * @param flags 文件打开标志。
+     * @throw device_error 如果文件打开、查询大小或定位失败。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Constructor that opens a file and prepares it for I/O operations.
+     *
+     * @param file_name The path to the file to open.
+     * @param flags File opening flags.
+     * @throw device_error If opening the file, querying its size, or seeking fails.
+     * @endif
+     */
     explicit basic_file_device(const std::string& file_name, file_open_flag flags = file_open_flag::none)
     {
         const char* mode = fopen_mode(flags);
@@ -69,7 +160,7 @@ public:
 
         if (fseek_64(m_file.get(), 0, SEEK_END) != 0)
             throw device_error("cannot get file length for \"" + file_name + "\"");
-        
+
         int64_t len = ftell_64(m_file.get());
         if (len < 0)
             throw device_error("cannot get file length for \"" + file_name + "\"");
@@ -78,10 +169,30 @@ public:
 
         if (fseek_64(m_file.get(), 0, SEEK_SET) != 0)
             throw device_error("cannot reset the file for \"" + file_name + "\"");
-              
+
         m_file_len = static_cast<size_t>(len);
     }
 
+    /**
+     * @lang{ZH}
+     * @brief 尝试打开一个文件，并以 `std::expected` 返回结果。
+     *
+     * 这是一个不会抛出异常的工厂函数。如果成功，返回文件设备；如果失败，返回错误信息。
+     * @param file_name 要打开的文件的路径。
+     * @param flags 文件打开标志。
+     * @return 包含 `basic_file_device` 或错误字符串的 `std::expected` 对象。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Tries to open a file and returns the result as a `std::expected`.
+     *
+     * This is a factory function that does not throw exceptions. It returns a file device on success
+     * or an error message on failure.
+     * @param file_name The path to the file to open.
+     * @param flags File opening flags.
+     * @return A `std::expected` object containing either a `basic_file_device` or an error string.
+     * @endif
+     */
     static std::expected<basic_file_device, std::string> try_open(const std::string& file_name, file_open_flag flags = file_open_flag::none) noexcept
     {
         try {
@@ -92,16 +203,30 @@ public:
             return std::unexpected("unknown error occurred during try_open");
         }
     }
-    
+
     basic_file_device(const basic_file_device&) = delete;
     basic_file_device& operator=(const basic_file_device&) = delete;
-    
     basic_file_device(basic_file_device&&) noexcept = default;
     basic_file_device& operator=(basic_file_device&&) noexcept = default;
-    
     ~basic_file_device() = default;
 
 public:
+    /**
+     * @lang{ZH}
+     * @brief 检查是否已到达文件末尾。
+     *
+     * 通过比较当前位置和文件大小来判断。如果文件未打开或发生错误，也返回 `true`。
+     * @return 如果到达文件末尾，则为 `true`，否则为 `false`。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Checks if the end of the file has been reached.
+     *
+     * Determined by comparing the current position with the file size. Returns `true`
+     * if the file is not open or an error occurs.
+     * @return `true` if the end of the file is reached, otherwise `false`.
+     * @endif
+     */
     [[nodiscard]] bool deof() const
     {
         if (!is_open())
@@ -116,11 +241,37 @@ public:
         }
     }
 
+    /**
+     * @lang{ZH}
+     * @brief 检查文件是否已成功打开。
+     * @return 如果文件已打开，则为 `true`，否则为 `false`。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Checks if the file is successfully opened.
+     * @return `true` if the file is open, otherwise `false`.
+     * @endif
+     */
     [[nodiscard]] bool is_open() const
     {
         return m_file != nullptr;
     }
-    
+
+    /**
+     * @lang{ZH}
+     * @brief 关闭文件。
+     *
+     * 对于输出设备，它会先尝试刷新缓冲区。然后释放文件句柄。
+     * 如果刷新失败，它会重抛异常。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Closes the file.
+     *
+     * For output devices, it first attempts to flush the buffer. Then, it releases the file handle.
+     * If flushing fails, it re-throws the exception.
+     * @endif
+     */
     void close()
     {
         if (is_open())
@@ -139,8 +290,25 @@ public:
             if (ptr) std::rethrow_exception(ptr);
         }
     }
-    
+
 public:
+    /**
+     * @lang{ZH}
+     * @brief 从设备读取数据。
+     * @param s 指向存储读取数据的缓冲区的指针。
+     * @param n 要读取的字符数。
+     * @return 实际读取的字符数。
+     * @throw device_error 如果缓冲区为空或发生读取错误。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Reads data from the device.
+     * @param s Pointer to the buffer where the read data will be stored.
+     * @param n The number of characters to read.
+     * @return The number of characters actually read.
+     * @throw device_error If the buffer is null or a read error occurs.
+     * @endif
+     */
     size_t dget(CharType* s, size_t n)
         requires (IsIn)
     {
@@ -155,22 +323,59 @@ public:
         return count;
     }
 
+    /**
+     * @lang{ZH}
+     * @brief 获取当前读/写指针的位置。
+     * @return 从文件开头算起的字节偏移量。
+     * @throw device_error 如果文件未打开或获取位置失败。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Gets the current position of the read/write pointer.
+     * @return The byte offset from the beginning of the file.
+     * @throw device_error If the file is not open or getting the position fails.
+     * @endif
+     */
     [[nodiscard]] size_t dtell() const
     {
         if (!is_open())
             throw device_error("file_device::dtell fail: file is closed");
-        
+
         auto res = ftell_64(m_file.get());
         if (res < 0)
             throw device_error("file_device::dtell fail: got invalid position.");
         return static_cast<size_t>(res);
     }
 
+    /**
+     * @lang{ZH}
+     * @brief 获取文件的总大小。
+     * @return 文件的字节大小。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Gets the total size of the file.
+     * @return The size of the file in bytes.
+     * @endif
+     */
     [[nodiscard]] size_t dsize() const
     {
         return m_file_len;
     }
-    
+
+    /**
+     * @lang{ZH}
+     * @brief 将读/写指针移动到指定位置。
+     * @param v 从文件开头算起的绝对位置。
+     * @throw device_error 如果文件未打开或定位失败。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Moves the read/write pointer to a specified position.
+     * @param v The absolute position from the beginning of the file.
+     * @throw device_error If the file is not open or seeking fails.
+     * @endif
+     */
     void dseek(size_t v)
     {
         if (!is_open())
@@ -188,6 +393,19 @@ public:
             throw device_error("file_device::dseek fail: fseek invalid response");
     }
 
+    /**
+     * @lang{ZH}
+     * @brief 将读/写指针从文件末尾向前移动。
+     * @param offset 从文件末尾向前的偏移量。
+     * @throw device_error 如果文件未打开或定位失败。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Moves the read/write pointer forward from the end of the file.
+     * @param offset The offset from the end of the file.
+     * @throw device_error If the file is not open or seeking fails.
+     * @endif
+     */
     void drseek(size_t offset)
     {
         if (!is_open())
@@ -200,7 +418,22 @@ public:
         if (fseek_64(m_file.get(), l_off, SEEK_END) != 0)
             throw device_error("file_device::drseek fail: fseek invalid response");
     }
-    
+
+    /**
+     * @lang{ZH}
+     * @brief 将数据写入设备。
+     * @param ch 指向要写入数据的缓冲区的指针。
+     * @param n 要写入的字符数。
+     * @throw device_error 如果文件未打开或写入失败。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Writes data to the device.
+     * @param ch Pointer to the buffer containing the data to be written.
+     * @param n The number of characters to write.
+     * @throw device_error If the file is not open or writing fails.
+     * @endif
+     */
     void dput(const CharType* ch, size_t n)
         requires (IsOut)
     {
@@ -211,12 +444,27 @@ public:
         if (n == 0) return;
         if (std::fwrite(ch, sizeof(CharType), n, m_file.get()) != n)
             throw device_error("file_device::dput fail: partial success.");
-        
+
         auto cur_pos = dtell();
         if (cur_pos > m_file_len)
             m_file_len = cur_pos;
     }
-    
+
+    /**
+     * @lang{ZH}
+     * @brief 刷新写入缓冲区。
+     *
+     * 强制将 C 标准库 `FILE` 的内部缓冲区内容写入操作系统。
+     * @throw device_error 如果刷新失败。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Flushes the write buffer.
+     *
+     * Forces the contents of the C standard library `FILE`'s internal buffer to be written to the operating system.
+     * @throw device_error If flushing fails.
+     * @endif
+     */
     void dflush()
         requires (IsOut)
     {
@@ -229,9 +477,9 @@ private:
     static const char* fopen_mode(file_open_flag flags)
     {
         using enum file_open_flag;
-        
+
         file_open_flag checkres = flags & (trunc | binary | noreplace);
-        
+
         if constexpr (IsIn && IsOut)
         {
             if (checkres == none)
@@ -280,7 +528,7 @@ private:
             static_assert(dependent_false_nttp_v<IsIn, IsOut>, "file device cannot open with neither in nor out mode");
         }
     }
-    
+
 private:
     static int fseek_64(FILE* stream, int64_t offset, int origin)
     {
@@ -305,12 +553,45 @@ private:
     size_t m_file_len = 0;
 };
 
+/**
+ * @lang{ZH}
+ * @brief 只读文件设备的类型别名。
+ * @tparam CharType 字符类型。
+ * @endif
+ *
+ * @lang{EN}
+ * @brief Type alias for a read-only file device.
+ * @tparam CharType The character type.
+ * @endif
+ */
 template <typename CharType>
 using ifile_device = basic_file_device<true, false, CharType>;
 
+/**
+ * @lang{ZH}
+ * @brief 只写文件设备的类型别名。
+ * @tparam CharType 字符类型。
+ * @endif
+ *
+ * @lang{EN}
+ * @brief Type alias for a write-only file device.
+ * @tparam CharType The character type.
+ * @endif
+ */
 template <typename CharType>
 using ofile_device = basic_file_device<false, true, CharType>;
 
+/**
+ * @lang{ZH}
+ * @brief 读写文件设备的类型别名。
+ * @tparam CharType 字符类型。
+ * @endif
+ *
+ * @lang{EN}
+ * @brief Type alias for a read-write file device.
+ * @tparam CharType The character type.
+ * @endif
+ */
 template <typename CharType>
 using file_device = basic_file_device<true, true, CharType>;
 }

--- a/include/device/mem_device.h
+++ b/include/device/mem_device.h
@@ -1,3 +1,17 @@
+/**
+ * @file mem_device.h
+ * @lang{ZH}
+ * 定义了 `mem_device` 类，这是一个基于内存的 I/O 设备。
+ * 它使用 `std::basic_string` 作为底层存储，提供了在内存字符串上进行
+ * 读、写和定位操作的接口。
+ * @endif
+ *
+ * @lang{EN}
+ * Defines the `mem_device` class, a memory-based I/O device.
+ * It uses `std::basic_string` as its underlying storage, providing an interface
+ * for reading, writing, and seeking on an in-memory string.
+ * @endif
+ */
 #pragma once
 #include <common/defs.h>
 #include <device/device_concepts.h>
@@ -9,6 +23,30 @@
 
 namespace IOv2
 {
+/**
+ * @lang{ZH}
+ * @brief 一个在内存中进行 I/O 操作的设备。
+ *
+ * `mem_device` 将 `std::basic_string` 封装成一个满足 `io_device` 概念的设备。
+ * 它支持对内部字符串缓冲区的读、写和寻址操作，是实现 `stringstream` 功能的基础。
+ *
+ * @tparam CharT 字符类型。
+ * @tparam Traits 字符类型的特性，默认为 `std::char_traits<CharT>`。
+ * @tparam Allocator 内存分配器，默认为 `std::allocator<CharT>`。
+ * @endif
+ *
+ * @lang{EN}
+ * @brief A device that performs I/O operations in memory.
+ *
+ * `mem_device` wraps a `std::basic_string` into a device that satisfies the `io_device` concept.
+ * It supports reading, writing, and seeking within its internal string buffer, forming the
+ * basis for implementing features like `stringstream`.
+ *
+ * @tparam CharT The character type.
+ * @tparam Traits The character traits, defaulting to `std::char_traits<CharT>`.
+ * @tparam Allocator The memory allocator, defaulting to `std::allocator<CharT>`.
+ * @endif
+ */
 template <class CharT,
           class Traits = std::char_traits<CharT>,
           class Allocator = std::allocator<CharT>>
@@ -16,8 +54,19 @@ class mem_device
 {
 public:
     using char_type = CharT;
-    
+
 public:
+    /**
+     * @lang{ZH}
+     * @brief 构造函数，可以从一个现有的 `basic_string` 初始化设备。
+     * @param info 用于初始化内部缓冲区的字符串。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Constructor, optionally initializes the device from an existing `basic_string`.
+     * @param info The string used to initialize the internal buffer.
+     * @endif
+     */
     mem_device(std::basic_string<CharT, Traits, Allocator> info = std::basic_string<CharT, Traits, Allocator>{})
         : m_str(std::move(info))
     {}
@@ -28,14 +77,51 @@ public:
     mem_device& operator=(mem_device&&) = default;
     ~mem_device() = default;
 
+    /**
+     * @lang{ZH}
+     * @brief 获取对内部字符串的常量引用。
+     * @return 内部 `std::basic_string` 的常量引用。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Gets a constant reference to the internal string.
+     * @return A constant reference to the internal `std::basic_string`.
+     * @endif
+     */
     [[nodiscard]] const std::basic_string<CharT, Traits, Allocator>& str() const { return m_str; }
 
 public:
+    /**
+     * @lang{ZH}
+     * @brief 检查是否已到达内存缓冲区的末尾。
+     * @return 如果当前位置大于或等于缓冲区大小，则为 `true`。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Checks if the end of the memory buffer has been reached.
+     * @return `true` if the current position is at or beyond the end of the buffer.
+     * @endif
+     */
     [[nodiscard]] bool deof() const
     {
         return (m_next_pos >= m_str.size());
     }
 
+    /**
+     * @lang{ZH}
+     * @brief 从当前位置读取数据。
+     * @param s 存储读取数据的缓冲区。
+     * @param n 要读取的字符数。
+     * @return 实际读取的字符数。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Reads data from the current position.
+     * @param s The buffer to store the read data.
+     * @param n The number of characters to read.
+     * @return The number of characters actually read.
+     * @endif
+     */
     size_t dget(char_type* s, size_t n)
     {
         if (s == nullptr && n > 0)
@@ -47,17 +133,52 @@ public:
         m_next_pos += res;
         return res;
     }
-    
+
+    /**
+     * @lang{ZH}
+     * @brief 获取当前读/写位置。
+     * @return 当前在缓冲区中的位置。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Gets the current read/write position.
+     * @return The current position within the buffer.
+     * @endif
+     */
     [[nodiscard]] size_t dtell() const
     {
         return m_next_pos;
     }
 
+    /**
+     * @lang{ZH}
+     * @brief 获取内部缓冲区的总大小。
+     * @return 字符串的大小。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Gets the total size of the internal buffer.
+     * @return The size of the string.
+     * @endif
+     */
     [[nodiscard]] size_t dsize() const
     {
         return m_str.size();
     }
-    
+
+    /**
+     * @lang{ZH}
+     * @brief 将读/写位置移动到绝对位置。
+     * @param v 要移动到的新位置。
+     * @throw device_error 如果位置超出范围。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Moves the read/write pointer to an absolute position.
+     * @param v The new position to move to.
+     * @throw device_error If the position is out of bounds.
+     * @endif
+     */
     void dseek(size_t v)
     {
         if (v > m_str.size())
@@ -65,13 +186,45 @@ public:
         m_next_pos = v;
     }
 
+    /**
+     * @lang{ZH}
+     * @brief 将读/写位置从末尾反向移动。
+     * @param offset 从末尾算起的偏移量。
+     * @throw device_error 如果位置超出范围。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Moves the read/write pointer backwards from the end.
+     * @param offset The offset from the end.
+     * @throw device_error If the position is out of bounds.
+     * @endif
+     */
     void drseek(size_t offset)
     {
         if (offset > m_str.size())
             throw device_error("mem_device::rseek fail: out of boundary");
         m_next_pos = m_str.size() - offset;
     }
-    
+
+    /**
+     * @lang{ZH}
+     * @brief 向当前位置写入数据。
+     *
+     * 如果写入操作超出当前字符串大小，字符串会自动增长。
+     * @param ch 要写入的数据。
+     * @param n 要写入的字符数。
+     * @throw device_error 如果大小溢出。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Writes data at the current position.
+     *
+     * The string grows automatically if the write operation exceeds the current string size.
+     * @param ch The data to write.
+     * @param n The number of characters to write.
+     * @throw device_error If the size overflows.
+     * @endif
+     */
     void dput(const char_type* ch, size_t n)
     {
         if (ch == nullptr && n > 0)
@@ -90,7 +243,16 @@ public:
             std::copy(ch, ch + n, m_str.data() + m_next_pos);
         m_next_pos += n;
     }
-    
+
+    /**
+     * @lang{ZH}
+     * @brief 刷新设备。对于内存设备，此操作为空。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Flushes the device. This is a no-op for a memory device.
+     * @endif
+     */
     void dflush() {}
 
 private:
@@ -98,6 +260,8 @@ private:
     size_t m_next_pos = 0;
 };
 
+/// @cond
 template <typename TChar>
 mem_device(const TChar*) -> mem_device<TChar>;
+/// @endcond
 }

--- a/include/device/std_device.h
+++ b/include/device/std_device.h
@@ -1,3 +1,15 @@
+/**
+ * @file std_device.h
+ * @lang{ZH}
+ * 定义了 `std_device` 类，用于封装标准 I/O 流（stdin, stdout, stderr）。
+ * 此设备提供了与标准输入、输出和错误流交互的统一接口。
+ * @endif
+ *
+ * @lang{EN}
+ * Defines the `std_device` class for wrapping standard I/O streams (stdin, stdout, stderr).
+ * This device provides a unified interface for interacting with standard input, output, and error streams.
+ * @endif
+ */
 #pragma once
 #include <common/defs.h>
 #include <device/device_concepts.h>
@@ -11,6 +23,27 @@
 
 namespace IOv2
 {
+/**
+ * @lang{ZH}
+ * @brief 封装标准 I/O 文件描述符的设备。
+ *
+ * 这个类模板通过文件描述符（`STDIN_FILENO`, `STDOUT_FILENO`, `STDERR_FILENO`）
+ * 来创建一个 I/O 设备。它为标准输入提供了非阻塞读取和 EOF 处理，
+ * 并为标准输出/错误提供了写入和刷新功能。
+ *
+ * @tparam ID 文件描述符。必须是 `STDIN_FILENO`、`STDOUT_FILENO` 或 `STDERR_FILENO` 之一。
+ * @endif
+ *
+ * @lang{EN}
+ * @brief A device that encapsulates standard I/O file descriptors.
+ *
+ * This class template uses a file descriptor (`STDIN_FILENO`, `STDOUT_FILENO`, `STDERR_FILENO`)
+ * to create an I/O device. It provides non-blocking reads and EOF handling for standard input,
+ * and write/flush capabilities for standard output/error.
+ *
+ * @tparam ID The file descriptor. Must be one of `STDIN_FILENO`, `STDOUT_FILENO`, or `STDERR_FILENO`.
+ * @endif
+ */
 template <int ID>
     requires ((ID == STDIN_FILENO) || (ID == STDOUT_FILENO) || (ID == STDERR_FILENO))
 class std_device
@@ -24,6 +57,15 @@ public:
     std_device(std_device&&) noexcept = default;
     std_device& operator=(std_device&&) noexcept = default;
 
+    /**
+     * @lang{ZH}
+     * @brief 析构函数，在销毁时刷新标准输出或标准错误流。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Destructor that flushes standard output or standard error upon destruction.
+     * @endif
+     */
     ~std_device()
     {
         if constexpr ((ID == STDOUT_FILENO) || (ID == STDERR_FILENO))
@@ -36,12 +78,45 @@ public:
         }
     }
 
+    /**
+     * @lang{ZH}
+     * @brief 检查标准输入流是否已到达文件末尾（EOF）。
+     * @return 如果已触发 EOF，则为 `true`。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Checks if the standard input stream has reached the end-of-file (EOF).
+     * @return `true` if EOF has been triggered.
+     * @endif
+     */
     [[nodiscard]] bool deof() const
         requires (ID == STDIN_FILENO)
     {
         return m_eof_hit;
     }
 
+    /**
+     * @lang{ZH}
+     * @brief 从标准输入读取数据。
+     *
+     * 这是一个阻塞式读取操作，使用 `poll` 来等待数据可用，并能正确处理 `EINTR` 中断。
+     * @param s 存储数据的缓冲区。
+     * @param n 要读取的字节数。
+     * @return 实际读取的字节数。如果到达 EOF，则返回 0。
+     * @throw device_error 如果发生读取或轮询错误。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Reads data from standard input.
+     *
+     * This is a blocking read operation that uses `poll` to wait for data to become available
+     * and correctly handles `EINTR` interrupts.
+     * @param s The buffer to store the data.
+     * @param n The number of bytes to read.
+     * @return The number of bytes actually read. Returns 0 if EOF is reached.
+     * @throw device_error If a read or poll error occurs.
+     * @endif
+     */
     size_t dget(char* s, size_t n)
         requires (ID == STDIN_FILENO)
     {
@@ -83,6 +158,21 @@ public:
         return static_cast<size_t>(ret);
     }
 
+    /**
+     * @lang{ZH}
+     * @brief 将数据写入标准输出或标准错误。
+     * @param ch 要写入的数据。
+     * @param n 要写入的字节数。
+     * @throw device_error 如果写入失败。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Writes data to standard output or standard error.
+     * @param ch The data to write.
+     * @param n The number of bytes to write.
+     * @throw device_error If the write fails.
+     * @endif
+     */
     void dput(const char* ch, size_t n)
         requires ((ID == STDOUT_FILENO) || (ID == STDERR_FILENO))
     {
@@ -99,7 +189,18 @@ public:
         if (!put_res)
             throw device_error("std_device::dput fail: partial success.");
     }
-    
+
+    /**
+     * @lang{ZH}
+     * @brief 刷新标准输出或标准错误流。
+     * @throw device_error 如果刷新失败。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Flushes the standard output or standard error stream.
+     * @throw device_error If flushing fails.
+     * @endif
+     */
     void dflush()
         requires ((ID == STDOUT_FILENO) || (ID == STDERR_FILENO))
     {
@@ -116,4 +217,27 @@ public:
 private:
     bool m_eof_hit = false;
 };
+
+/**
+ * @lang{ZH}
+ * @brief 标准输入设备的类型别名。
+ * @endif
+ *
+ * @lang{EN}
+ * @brief Type alias for the standard input device.
+ * @endif
+ */
+using std_input_device = std_device<STDIN_FILENO>;
+
+/**
+ * @lang{ZH}
+ * @brief 标准输出设备的类型别名。
+ * @endif
+ *
+ * @lang{EN}
+ * @brief Type alias for the standard output device.
+ * @endif
+ */
+using std_output_device = std_device<STDOUT_FILENO>;
+
 }


### PR DESCRIPTION
Add bilingual (EN/ZH) Doxygen comments to all header files in the 'include/device' directory.

This enables the generation of comprehensive documentation for the core device abstractions:
- device_concepts.h
- file_device.h
- mem_device.h
- std_device.h