### PR TITLE
fix(device): address code review issues in file_device and std_device

### DIFF
--- a/include/device/file_device.h
+++ b/include/device/file_device.h
@@ -156,7 +156,7 @@ public:
         const char* mode = fopen_mode(flags);
         m_file.reset(std::fopen(file_name.c_str(), mode));
         if (!m_file)
-            throw device_error("cannot open file \"" + file_name + "\": " + std::strerror(errno));
+            throw device_error("cannot open file \"" + file_name + "\" (errno=" + std::to_string(errno) + ")");
 
         if (fseek_64(m_file.get(), 0, SEEK_END) != 0)
             throw device_error("cannot get file length for \"" + file_name + "\"");
@@ -445,9 +445,9 @@ public:
         if (std::fwrite(ch, sizeof(CharType), n, m_file.get()) != n)
             throw device_error("file_device::dput fail: partial success.");
 
-        auto cur_pos = dtell();
-        if (cur_pos > m_file_len)
-            m_file_len = cur_pos;
+        auto res = ftell_64(m_file.get());
+        if (res >= 0 && static_cast<size_t>(res) > m_file_len)
+            m_file_len = static_cast<size_t>(res);
     }
 
     /**

--- a/include/device/std_device.h
+++ b/include/device/std_device.h
@@ -31,6 +31,10 @@ namespace IOv2
  * 来创建一个 I/O 设备。它为标准输入提供了非阻塞读取和 EOF 处理，
  * 并为标准输出/错误提供了写入和刷新功能。
  *
+ * @warning 对于 stdin，此类使用底层的 POSIX `read()`，它会绕过 stdio 缓冲。
+ * 请勿在 stdin 上将 `std_input_device` 与 C stdio 函数（`scanf`, `fgets`, `getchar` 等）
+ * 混合使用，因为由于缓冲不一致，这可能会导致数据丢失或意外行为。
+ *
  * @tparam ID 文件描述符。必须是 `STDIN_FILENO`、`STDOUT_FILENO` 或 `STDERR_FILENO` 之一。
  * @endif
  *
@@ -40,6 +44,11 @@ namespace IOv2
  * This class template uses a file descriptor (`STDIN_FILENO`, `STDOUT_FILENO`, `STDERR_FILENO`)
  * to create an I/O device. It provides non-blocking reads and EOF handling for standard input,
  * and write/flush capabilities for standard output/error.
+ *
+ * @warning For stdin, this class uses low-level POSIX read() which bypasses
+ * stdio buffering. Do NOT mix usage of std_input_device with C stdio functions
+ * (scanf, fgets, getchar, etc.) on stdin, as this may cause data loss or
+ * unexpected behavior due to buffering inconsistencies.
  *
  * @tparam ID The file descriptor. Must be one of `STDIN_FILENO`, `STDOUT_FILENO`, or `STDERR_FILENO`.
  * @endif


### PR DESCRIPTION
- Replace thread-unsafe strerror with to_string(errno) in file_device
- Improve exception safety in file_device::dput by using ftell_64 directly
- Add documentation warning about mixing std_device with C stdio