### PR TITLE
feat(device): improve safety and robustness in file, memory, and std devices

### DIFF
--- a/include/device/file_device.h
+++ b/include/device/file_device.h
@@ -313,9 +313,9 @@ public:
     size_t dget(CharType* s, size_t n)
         requires (IsIn)
     {
+        if (n == 0) return 0;
         if (s == nullptr && n > 0)
             throw device_error("file_device::dget fail: null buffer");
-        if (n == 0) return 0;
 
         if (!is_open()) return 0;
         size_t count = std::fread(s, sizeof(CharType), n, m_file.get());
@@ -438,11 +438,11 @@ public:
     void dput(const CharType* ch, size_t n)
         requires (IsOut)
     {
+        if (n == 0) return;
         if (ch == nullptr && n > 0)
             throw device_error("file_device::dput fail: null buffer");
         if (!is_open())
             throw device_error("file_device::dput fail: file closed.");
-        if (n == 0) return;
         size_t written = std::fwrite(ch, sizeof(CharType), n, m_file.get());
 
         auto res = ftell_64(m_file.get());

--- a/include/device/file_device.h
+++ b/include/device/file_device.h
@@ -24,6 +24,7 @@
 #include <limits>
 #include <memory>
 #include <string>
+#include <utility>
 
 namespace IOv2
 {
@@ -164,7 +165,7 @@ public:
         int64_t len = ftell_64(m_file.get());
         if (len < 0)
             throw device_error("cannot get file length for \"" + file_name + "\"");
-        else if (static_cast<uint64_t>(len) > std::numeric_limits<size_t>::max())
+        else if (!std::in_range<size_t>(len))
             throw device_error("file too large for this platform");
 
         if (fseek_64(m_file.get(), 0, SEEK_SET) != 0)
@@ -442,12 +443,19 @@ public:
         if (!is_open())
             throw device_error("file_device::dput fail: file closed.");
         if (n == 0) return;
-        if (std::fwrite(ch, sizeof(CharType), n, m_file.get()) != n)
-            throw device_error("file_device::dput fail: partial success.");
+        size_t written = std::fwrite(ch, sizeof(CharType), n, m_file.get());
 
         auto res = ftell_64(m_file.get());
-        if (res >= 0 && static_cast<size_t>(res) > m_file_len)
-            m_file_len = static_cast<size_t>(res);
+        if (res >= 0)
+        {
+            if (!std::in_range<size_t>(res))
+                throw device_error("file_device::dput fail: file size overflow");
+            if (static_cast<size_t>(res) > m_file_len)
+                m_file_len = static_cast<size_t>(res);
+        }
+
+        if (written != n)
+            throw device_error("file_device::dput fail: partial success.");
     }
 
     /**
@@ -550,6 +558,22 @@ private:
 
 private:
     std::unique_ptr<FILE, file_deleter> m_file;
+
+    // Cached file length, in CharType units.
+    //
+    // Type is `size_t` (not `uint64_t`) because the public API — `dsize()`,
+    // `dseek(size_t)`, `drseek(size_t)` — is `size_t`-typed; using `size_t`
+    // here keeps the value lossless across the boundary on every platform
+    // (including 32-bit, where a `uint64_t` field could hold values that
+    // `dsize()` cannot return without truncation).
+    //
+    // Invariant: `m_file_len <= INT64_MAX`. All writes to this field source
+    // from a non-negative `int64_t` (the result of `ftell_64()`), narrowed
+    // through `std::in_range<size_t>` in the constructor and `dput()`.
+    // This invariant is what makes `-static_cast<int64_t>(offset)` in
+    // `drseek()` safe: any `offset <= m_file_len` fits in `int64_t`'s
+    // positive range, so the negation cannot overflow. Do not introduce
+    // setters or alternate sources that bypass the `int64_t`-derived path.
     size_t m_file_len = 0;
 };
 

--- a/include/device/mem_device.h
+++ b/include/device/mem_device.h
@@ -16,6 +16,8 @@
 #include <common/defs.h>
 #include <device/device_concepts.h>
 
+#include <cstring>
+#include <functional>
 #include <iterator>
 #include <memory>
 #include <string>
@@ -129,7 +131,7 @@ public:
         if (n == 0) return 0;
 
         std::size_t res = std::min(m_str.size() - m_next_pos, n);
-        std::copy(m_str.data() + m_next_pos, m_str.data() + m_next_pos + res, s);
+        std::memmove(s, m_str.data() + m_next_pos, res * sizeof(char_type));
         m_next_pos += res;
         return res;
     }
@@ -211,18 +213,33 @@ public:
      * @brief 向当前位置写入数据。
      *
      * 如果写入操作超出当前字符串大小，字符串会自动增长。
+     *
+     * @warning `ch` 不能指向设备的内部缓冲区（即 `str()` 返回的存储区域）。
+     * 在需要扩容的写入路径上，扩容可能使指向内部缓冲区的指针失效，因此一旦
+     * 检测到 `[ch, ch + n)` 与内部缓冲区重叠，就会抛出 `device_error`。
+     * 如果调用者需要从设备自身的数据进行写入，请先复制到独立缓冲区。
+     *
      * @param ch 要写入的数据。
      * @param n 要写入的字符数。
-     * @throw device_error 如果大小溢出。
+     * @throw device_error 当 `ch` 为 `nullptr` 且 `n > 0`、大小溢出，
+     * 或在扩容路径上 `ch` 与内部缓冲区别名时抛出。
      * @endif
      *
      * @lang{EN}
      * @brief Writes data at the current position.
      *
      * The string grows automatically if the write operation exceeds the current string size.
+     *
+     * @warning `ch` must not point into the device's internal buffer (the storage
+     * exposed via `str()`). On the grow path, growth may invalidate pointers into
+     * the internal buffer, so if `[ch, ch + n)` is detected to overlap the internal
+     * buffer the function throws `device_error`. Callers that need to write from
+     * the device's own data must copy it into an independent buffer first.
+     *
      * @param ch The data to write.
      * @param n The number of characters to write.
-     * @throw device_error If the size overflows.
+     * @throw device_error When `ch` is `nullptr` and `n > 0`, when the size overflows,
+     * or when `ch` aliases the internal buffer on the grow path.
      * @endif
      */
     void dput(const char_type* ch, size_t n)
@@ -235,12 +252,22 @@ public:
 
         if (m_next_pos + n > m_str.size())
         {
+            // Reserve below may reallocate m_str's storage and invalidate any
+            // pointer that lives inside it. Reject aliased input up-front rather
+            // than risk a use-after-free. std::less is used because comparing
+            // unrelated pointers with raw `<` is unspecified.
+            const std::less<const char_type*> ptr_less;
+            const char_type* buf_beg = m_str.data();
+            const char_type* buf_end = buf_beg + m_str.capacity();
+            if (ptr_less(ch, buf_end) && ptr_less(buf_beg, ch + n))
+                throw device_error("mem_device::dput fail: ch aliases internal buffer");
+
             m_str.erase(m_str.begin() + m_next_pos, m_str.end());
             m_str.reserve(m_next_pos + n);
-            std::copy(ch, ch + n, std::back_inserter(m_str));
+            m_str.append(ch, n);
         }
         else
-            std::copy(ch, ch + n, m_str.data() + m_next_pos);
+            std::memmove(m_str.data() + m_next_pos, ch, n * sizeof(char_type));
         m_next_pos += n;
     }
 

--- a/include/device/mem_device.h
+++ b/include/device/mem_device.h
@@ -126,9 +126,9 @@ public:
      */
     size_t dget(char_type* s, size_t n)
     {
+        if (n == 0) return 0;
         if (s == nullptr && n > 0)
             throw device_error("mem_device::dget fail: null buffer");
-        if (n == 0) return 0;
 
         std::size_t res = std::min(m_str.size() - m_next_pos, n);
         std::memmove(s, m_str.data() + m_next_pos, res * sizeof(char_type));
@@ -244,6 +244,7 @@ public:
      */
     void dput(const char_type* ch, size_t n)
     {
+        if (n == 0) return;
         if (ch == nullptr && n > 0)
             throw device_error("mem_device::dput fail: null buffer");
 

--- a/include/device/std_device.h
+++ b/include/device/std_device.h
@@ -129,9 +129,9 @@ public:
     size_t dget(char* s, size_t n)
         requires (ID == STDIN_FILENO)
     {
+        if (n == 0 || m_eof_hit) return 0;
         if (s == nullptr && n > 0)
             throw device_error("std_device::dget fail: null buffer");
-        if (n == 0 || m_eof_hit) return 0;
 
         constexpr size_t max_read = static_cast<size_t>(std::numeric_limits<ssize_t>::max());
         ssize_t ret = 0;
@@ -183,9 +183,9 @@ public:
     void dput(const char* ch, size_t n)
         requires ((ID == STDOUT_FILENO) || (ID == STDERR_FILENO))
     {
+        if (n == 0) return;
         if (ch == nullptr && n > 0)
             throw device_error("std_device::dput fail: null buffer");
-        if (n == 0) return;
 
         bool put_res = false;
         if constexpr (ID == STDOUT_FILENO)

--- a/include/device/std_device.h
+++ b/include/device/std_device.h
@@ -151,11 +151,9 @@ public:
                 }
                 if (pfd.revents & (POLLERR | POLLNVAL))
                     throw device_error("std_device::dget fail: poll revents error");
-                if (pfd.revents & POLLHUP)
-                {
-                    m_eof_hit = true;
-                    return 0;
-                }
+                // POLLHUP is intentionally not treated as EOF: the peer may have
+                // closed while bytes remain buffered. Re-issue read(); it returns 0
+                // only when both the buffer is drained and the peer is gone.
                 continue;
             }
             throw device_error("std_device::dget fail: read error");

--- a/test/device/file_device/test_file_io_char.cpp
+++ b/test/device/file_device/test_file_io_char.cpp
@@ -586,6 +586,41 @@ void test_file_device_char_seek_8()
     dump_info("Done\n");
 }
 
+void test_file_device_char_edge_cases()
+{
+    using namespace IOv2;
+
+    dump_info("Test file_device<char> edge cases...");
+
+    const char name[] = "edge_cases.txt";
+    file_guard g(name);
+
+    {
+        basic_file_device<true, true, char> fb(name, file_open_flag::trunc);
+        
+        // Test dput(nullptr, 0)
+        fb.dput(nullptr, 0);
+        VERIFY(fb.dsize() == 0);
+
+        // Test dget(nullptr, 0)
+        char ch;
+        VERIFY(fb.dget(nullptr, 0) == 0);
+        
+        // Test dget(nullptr, 1) should throw
+        try {
+            fb.dget(nullptr, 1);
+            throw std::runtime_error("file_device::dget(nullptr, 1) should throw");
+        } catch (const device_error&) {}
+
+        fb.dput("abc", 3);
+        fb.dseek(0);
+        VERIFY(fb.dget(nullptr, 0) == 0);
+        VERIFY(fb.dget(&ch, 1) == 1 && ch == 'a');
+    }
+
+    dump_info("Done\n");
+}
+
 void test_file_device_char_error_1()
 {
     using namespace IOv2;

--- a/test/device/mem_device/test_mem_io_char.cpp
+++ b/test/device/mem_device/test_mem_io_char.cpp
@@ -308,6 +308,14 @@ void test_mem_device_char_out_2()
         obj.dput(nullptr, 0);
         if (obj.str() != "") throw std::runtime_error("mem_device<char> output put() fail");
         if (obj.dtell() != 0) throw std::runtime_error("mem_device<char> output tell fail");
+
+        // Test dget edge cases
+        if (obj.dget(nullptr, 0) != 0) throw std::runtime_error("mem_device<char> dget(nullptr, 0) fail");
+        
+        try {
+            obj.dget(nullptr, 1);
+            throw std::runtime_error("mem_device<char> dget(nullptr, 1) should throw");
+        } catch (const IOv2::device_error&) {}
     }
     
     {

--- a/test/device/std_device/test_std_device.cpp
+++ b/test/device/std_device/test_std_device.cpp
@@ -4,6 +4,7 @@
 
 #include <common/dump_info.h>
 #include <common/stdio_guard.h>
+#include <common/verify.h>
 
 void test_std_device_gen_1()
 {
@@ -124,6 +125,36 @@ void test_std_device_output_2()
         obj.dflush();
         obj.dput("bcdef", 5);
         if (g.contents() != "abcdef") throw std::runtime_error("std_device::put fails");
+    }
+
+    dump_info("Done\n");
+}
+void test_std_device_edge_cases()
+{
+    using namespace IOv2;
+
+    dump_info("Test std_device edge cases...");
+
+    {
+        std_output_device obj;
+        // Test dput(nullptr, 0)
+        obj.dput(nullptr, 0);
+    }
+
+    {
+        std_input_device obj;
+        // Test dget(nullptr, 0)
+        char ch;
+        iguard g("abc");
+        VERIFY(obj.dget(nullptr, 0) == 0);
+        
+        // Test dget(nullptr, 1) should throw
+        try {
+            obj.dget(nullptr, 1);
+            throw std::runtime_error("std_device::dget(nullptr, 1) should throw");
+        } catch (const device_error&) {}
+
+        VERIFY(obj.dget(&ch, 1) == 1 && ch == 'a');
     }
 
     dump_info("Done\n");

--- a/test/device/test_device.cpp
+++ b/test/device/test_device.cpp
@@ -55,6 +55,7 @@ void test_std_device_gen_1();
 void test_std_device_input_1();
 void test_std_device_output_1();
 void test_std_device_output_2();
+void test_std_device_edge_cases();
 
 void test_file_device_char_gen_1();
 void test_file_device_char_close_1();
@@ -72,6 +73,7 @@ void test_file_device_char_seek_5();
 void test_file_device_char_seek_6();
 void test_file_device_char_seek_7();
 void test_file_device_char_seek_8();
+void test_file_device_char_edge_cases();
 void test_file_device_char_error_1();
 
 void test_file_device_char8_t_gen_1();
@@ -149,6 +151,7 @@ int main()
         test_std_device_input_1();
         test_std_device_output_1();
         test_std_device_output_2();
+        test_std_device_edge_cases();
 
         test_file_device_char_gen_1();
         test_file_device_char_close_1();
@@ -166,6 +169,7 @@ int main()
         test_file_device_char_seek_6();
         test_file_device_char_seek_7();
         test_file_device_char_seek_8();
+        test_file_device_char_edge_cases();
         test_file_device_char_error_1();
 
         test_file_device_char8_t_gen_1();


### PR DESCRIPTION


- file_device: use std::in_range for safe size checks and update m_file_len before error checking.
- mem_device: use std::memmove for safe overlapping copies and add aliasing detection in dput.
- std_device: remove POLLHUP-as-EOF logic to allow draining kernel buffers.
- Added detailed documentation on field invariants and memory aliasing constraints.