### PR TITLE
fix(device): improve safety checks and refine documentation for device classes

### DIFF
--- a/include/device/file_device.h
+++ b/include/device/file_device.h
@@ -424,8 +424,9 @@ public:
         if (!is_open())
             throw device_error("file_device::drseek fail: file is closed");
 
-        if (offset > m_file_len)
+        if ((offset > m_file_len) || (offset > static_cast<size_t>(std::numeric_limits<int64_t>::max())))
             throw device_error("file_device::drseek fail: invalid parameter");
+
         const int64_t l_off = -static_cast<int64_t>(offset);
 
         if (fseek_64(m_file.get(), l_off, SEEK_END) != 0)

--- a/include/device/file_device.h
+++ b/include/device/file_device.h
@@ -452,7 +452,7 @@ public:
         requires (IsOut)
     {
         if (n == 0) return;
-        if (ch == nullptr && n > 0)
+        if (ch == nullptr)
             throw device_error("file_device::dput fail: null buffer");
         if (!is_open())
             throw device_error("file_device::dput fail: file closed.");

--- a/include/device/mem_device.h
+++ b/include/device/mem_device.h
@@ -239,7 +239,7 @@ public:
     void dput(const char_type* ch, size_t n)
     {
         if (n == 0) return;
-        if (ch == nullptr && n > 0)
+        if (ch == nullptr)
             throw device_error("mem_device::dput fail: null buffer");
 
         if (n > m_str.max_size() - m_next_pos)

--- a/include/device/mem_device.h
+++ b/include/device/mem_device.h
@@ -221,15 +221,9 @@ public:
      *
      * 如果写入操作超出当前字符串大小，字符串会自动增长。
      *
-     * @warning `ch` 不能指向设备的内部缓冲区（即 `str()` 返回的存储区域）。
-     * 在需要扩容的写入路径上，扩容可能使指向内部缓冲区的指针失效，因此一旦
-     * 检测到 `[ch, ch + n)` 与内部缓冲区重叠，就会抛出 `device_error`。
-     * 如果调用者需要从设备自身的数据进行写入，请先复制到独立缓冲区。
-     *
      * @param ch 要写入的数据。
      * @param n 要写入的字符数。
-     * @throw device_error 当 `ch` 为 `nullptr` 且 `n > 0`、大小溢出，
-     * 或在扩容路径上 `ch` 与内部缓冲区别名时抛出。
+     * @throw device_error 当 `ch` 为 `nullptr` 且 `n > 0` 或大小溢出时抛出。
      * @endif
      *
      * @lang{EN}
@@ -239,8 +233,7 @@ public:
      *
      * @param ch The data to write.
      * @param n The number of characters to write.
-     * @throw device_error When `ch` is `nullptr` and `n > 0`, when the size overflows,
-     * or when `ch` aliases the internal buffer on the grow path.
+     * @throw device_error When `ch` is `nullptr` and `n > 0`, or when the size overflows.
      * @endif
      */
     void dput(const char_type* ch, size_t n)

--- a/include/device/std_device.h
+++ b/include/device/std_device.h
@@ -140,7 +140,7 @@ public:
         requires (ID == STDIN_FILENO)
     {
         if (n == 0 || m_eof_hit) return 0;
-        if (s == nullptr && n > 0)
+        if (s == nullptr)
             throw device_error("std_device::dget fail: null buffer");
 
         constexpr size_t max_read = static_cast<size_t>(std::numeric_limits<ssize_t>::max());

--- a/include/device/std_device.h
+++ b/include/device/std_device.h
@@ -119,6 +119,8 @@ public:
      * @param n 要读取的字节数。
      * @return 实际读取的字节数。如果到达 EOF，则返回 0。
      * @throw device_error 如果发生读取或轮询错误。
+     * @note 遇到 EOF 时立即返回 0，符合 POSIX read() 语义。
+     *       后续调用也会继续返回 0
      * @endif
      *
      * @lang{EN}
@@ -130,6 +132,8 @@ public:
      * @param n The number of bytes to read.
      * @return The number of bytes actually read. Returns 0 if EOF is reached.
      * @throw device_error If a read or poll error occurs.
+     * @note Returns 0 immediately upon EOF, conforming to POSIX read() semantics.
+     *       Subsequent calls will continue to return 0.
      * @endif
      */
     size_t dget(char* s, size_t n)
@@ -155,14 +159,16 @@ public:
                     if (errno == EINTR) continue;
                     throw device_error("std_device::dget fail: poll error");
                 }
-                if (pfd.revents & (POLLERR | POLLNVAL))
+                else if (pfd.revents & (POLLERR | POLLNVAL))
                     throw device_error("std_device::dget fail: poll revents error");
-                if (pfd.revents & POLLIN) continue;
-                if (pfd.revents & POLLHUP)
+                else if (pfd.revents & POLLIN) continue;
+                else if (pfd.revents & POLLHUP)
                 {
                     m_eof_hit = true;
                     return 0;
                 }
+                else
+                    throw device_error("std_device::dget fail: unexpected poll revents");
             }
             else
                 throw device_error("std_device::dget fail: read error");


### PR DESCRIPTION


- file_device.h: Add range check for offset in drseek to prevent overflow.
- mem_device.h: Remove outdated aliasing warnings and align documentation.
- std_device.h: Refactor poll logic in dget, fix typos, and document EOF behavior.