### PR TITLE
feat(device): implement manual move semantics for mem_device

### DIFF
--- a/include/device/mem_device.h
+++ b/include/device/mem_device.h
@@ -80,9 +80,25 @@ public:
     {}
 
     mem_device(const mem_device&) = default;
-    mem_device(mem_device&&) = default;
     mem_device& operator=(const mem_device&) = default;
-    mem_device& operator=(mem_device&&) = default;
+    mem_device(mem_device&& other) noexcept
+        : m_str(std::move(other.m_str))
+        , m_next_pos(other.m_next_pos)
+    {
+        other.m_next_pos = 0;
+    }
+
+    mem_device& operator=(mem_device&& other) noexcept
+    {
+        if (this != &other)
+        {
+            m_str = std::move(other.m_str);
+            m_next_pos = other.m_next_pos;
+            other.m_next_pos = 0;
+        }
+        return *this;
+    }
+
     ~mem_device() = default;
 
     /**


### PR DESCRIPTION
Explicitly reset m_next_pos to 0 in move constructor and move assignment to ensure consistent state after move.