### PR TITLE
refactor(device): standardize error messages, fix docs, and add missing includes

### DIFF
--- a/include/device/file_device.h
+++ b/include/device/file_device.h
@@ -350,7 +350,7 @@ public:
 
         auto res = ftell_64(m_file.get());
         if (!std::in_range<size_t>(res))
-            throw device_error("file_device::dtell fail: got invalid position.");
+            throw device_error("file_device::dtell fail: got invalid position");
         return static_cast<size_t>(res);
     }
 
@@ -412,7 +412,7 @@ public:
      * @endif
      *
      * @lang{EN}
-     * @brief Moves the read/write pointer forward from the end of the file.
+     * @brief Moves the read/write pointer backward from the end of the file.
      * @param offset The offset from the end of the file.
      * @throw device_error If the file is not open or seeking fails.
      * @endif
@@ -453,7 +453,7 @@ public:
         if (ch == nullptr)
             throw device_error("file_device::dput fail: null buffer");
         if (!is_open())
-            throw device_error("file_device::dput fail: file closed.");
+            throw device_error("file_device::dput fail: file is closed");
         size_t written = std::fwrite(ch, sizeof(CharType), n, m_file.get());
 
         auto res = ftell_64(m_file.get());
@@ -468,7 +468,7 @@ public:
             throw device_error("file_device::dput fail: cannot determine file position");
 
         if (written != n)
-            throw device_error("file_device::dput fail: partial success.");
+            throw device_error("file_device::dput fail: partial write");
     }
 
     /**
@@ -491,7 +491,7 @@ public:
     {
         if (!is_open()) return;
         if (std::fflush(m_file.get()) == EOF)
-            throw device_error("file_device::dflush fail: fflush fail.");
+            throw device_error("file_device::dflush fail: fflush error");
     }
 
 private:

--- a/include/device/mem_device.h
+++ b/include/device/mem_device.h
@@ -15,6 +15,7 @@
 #pragma once
 #include <common/defs.h>
 
+#include <algorithm>
 #include <cassert>
 #include <cstring>
 #include <memory>
@@ -204,7 +205,7 @@ public:
     void dseek(size_t v)
     {
         if (v > m_str.size())
-            throw device_error("mem_device::seek fail: out of boundary");
+            throw device_error("mem_device::dseek fail: out of bounds");
         m_next_pos = v;
     }
 
@@ -224,7 +225,7 @@ public:
     void drseek(size_t offset)
     {
         if (offset > m_str.size())
-            throw device_error("mem_device::rseek fail: out of boundary");
+            throw device_error("mem_device::drseek fail: out of bounds");
         m_next_pos = m_str.size() - offset;
     }
 

--- a/include/device/std_device.h
+++ b/include/device/std_device.h
@@ -13,6 +13,7 @@
 #pragma once
 #include <common/defs.h>
 
+#include <algorithm>
 #include <cerrno>
 #include <cstdio>
 #include <limits>
@@ -209,7 +210,7 @@ public:
         if (!put_res)
         {
             std::clearerr(ID == STDOUT_FILENO ? stdout : stderr);
-            throw device_error("std_device::dput fail: partial success.");
+            throw device_error("std_device::dput fail: partial write");
         }
     }
 
@@ -236,7 +237,7 @@ public:
         if (!flush_res)
         {
             std::clearerr(ID == STDOUT_FILENO ? stdout : stderr);
-            throw device_error("std_device::dflush fail: fflush failed.");
+            throw device_error("std_device::dflush fail: fflush error");
         }
     }
 


### PR DESCRIPTION


- Unified error message format (removed trailing periods).
- Fixed function names in mem_device error messages.
- Corrected drseek documentation in file_device.
- Added missing <algorithm> includes in mem_device and std_device.