### PR TITLE
feat(device,cvt): add direct I/O support for mem_device

### DIFF
--- a/include/cvt/root_cvt.h
+++ b/include/cvt/root_cvt.h
@@ -1,15 +1,16 @@
 #pragma once
+#include <common/defs.h>
+#include <common/metafunctions.h>
+#include <cvt/abs_cvt.h>
+#include <cvt/cvt_concepts.h>
+#include <device/device_concepts.h>
+#include <device/mem_device.h>
+
 #include <cassert>
 #include <stdexcept>
 #include <type_traits>
 #include <utility>
 #include <vector>
-#include <common/defs.h>
-#include <common/metafunctions.h>
-#include <cvt/cvt_concepts.h>
-#include <cvt/abs_cvt.h>
-#include <device/device_concepts.h>
-#include <device/mem_device.h>
 
 namespace IOv2
 {
@@ -526,6 +527,7 @@ public:
     {
         m_io_status = io_status::output;
     }
+
 private:
     device_type                 m_device;
     size_t                      m_bos_len;
@@ -734,5 +736,70 @@ public:
 
 private:
     std::vector<char_type> buffer;
+};
+
+template <io_converter KernelType>
+    requires ((std::is_base_of_v<root_cvt<typename KernelType::device_type, true>, KernelType> ||
+               std::is_base_of_v<root_cvt<typename KernelType::device_type, false>, KernelType>) &&
+              is_mem_device<typename KernelType::device_type>)
+class cvt_io<KernelType>
+{
+    class direct_reader
+    {
+        using device_type = typename KernelType::device_type;
+    public:
+        direct_reader(device_type& device)
+            : m_device(device)
+        {}
+
+        template <bool Saturate = false>
+        auto get_buf(size_t to_max)
+        {
+            return m_device.template get_buf<Saturate>(to_max);
+        }
+
+        void rollback(size_t len)
+        {
+            m_device.get_rollback(len);
+        }
+
+    private:
+        device_type& m_device;
+    };
+
+    class direct_writer
+    {
+        using device_type = typename KernelType::device_type;
+    public:
+        direct_writer(device_type& device)
+            : m_device(device)
+        {}
+
+        auto put_buf(size_t len)
+        {
+            return m_device.put_buf(len);
+        }
+
+        void rollback(size_t len)
+        {
+            return m_device.put_rollback(len);
+        }
+
+        void commit() {}
+
+    private:
+        device_type& m_device;
+    };
+
+public:
+    auto reader(KernelType& kernel, size_t)
+    {
+        return direct_reader(kernel.device());
+    }
+
+    auto writer(KernelType& kernel, size_t)
+    {
+        return direct_writer(kernel.device());
+    }
 };
 }

--- a/include/device/mem_device.h
+++ b/include/device/mem_device.h
@@ -377,7 +377,10 @@ public:
         if (needed > m_str.size())
         {
             if (needed > m_str.capacity())
-                m_str.reserve(grow(m_str.capacity(), needed));
+            {
+                const size_t cap = m_str.capacity();
+                m_str.reserve(std::max(needed, cap + cap / 2));
+            }
             m_str.resize(needed);
         }
         CharT* res = m_str.data() + m_next_pos;
@@ -406,29 +409,6 @@ public:
             throw device_error("mem_device::put_rollback fail, rollback length too large");
         m_next_pos -= len;
         m_str.resize(std::max(m_next_pos, m_ori_size));
-    }
-
-private:
-    /**
-     * @lang{ZH}
-     * @brief 计算缓冲区增长后的新容量。
-     * @param current 当前容量。
-     * @param required 所需的最小容量。
-     * @return 增长后的新容量。
-     * @endif
-     *
-     * @lang{EN}
-     * @brief Calculates the new capacity for buffer growth.
-     * @param current The current capacity.
-     * @param required The minimum required capacity.
-     * @return The calculated new capacity.
-     * @endif
-     */
-    static size_t grow(size_t current, size_t required)
-    {
-        const size_t new_cap = current + current / 2;
-        if (new_cap < required) return required;
-        return new_cap;
     }
 
 private:

--- a/include/device/mem_device.h
+++ b/include/device/mem_device.h
@@ -14,6 +14,7 @@
  */
 #pragma once
 #include <common/defs.h>
+#include <device/device_concepts.h>
 
 #include <algorithm>
 #include <cassert>
@@ -295,9 +296,145 @@ public:
      */
     void dflush() {}
 
+    /**
+     * @lang{ZH}
+     * @brief 获取输入缓冲区中的一段连续内存。
+     * @tparam Saturate 如果为 true，则要求必须读取到请求的长度，否则抛出异常。
+     * @param to_max 请求获取的最大长度。
+     * @return 如果 Saturate 为 true，返回指向数据的指针；否则返回 std::pair，包含数据指针和实际获取的长度。
+     * @throw device_error 如果 Saturate 为 true 且剩余数据不足。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Retrieves a contiguous block of memory from the input buffer.
+     * @tparam Saturate If true, requires the exact requested length; otherwise, throws an exception.
+     * @param to_max The maximum requested length.
+     * @return If Saturate is true, returns a pointer to the data; otherwise, returns a std::pair containing the data pointer and actual length.
+     * @throw device_error If Saturate is true and there is insufficient data remaining.
+     * @endif
+     */
+    template <bool Saturate = false>
+    auto get_buf(size_t to_max)
+    {
+        assert(m_str.size() >= m_next_pos);
+        const size_t remain = m_str.size() - m_next_pos;
+        if constexpr (Saturate)
+        {
+            if (to_max > remain)
+                throw device_error("mem_device::get_but fail: not enough input");
+            auto res = const_cast<const CharT*>(m_str.c_str() + m_next_pos);
+            m_next_pos += to_max;
+            return res;
+        }
+        else
+        {
+            const size_t res_len = std::min(to_max, remain);
+            auto res = std::pair<const CharT*, size_t>{m_str.c_str() + m_next_pos, res_len};
+            m_next_pos += res_len;
+            return res;
+        }
+    }
+
+    /**
+     * @lang{ZH}
+     * @brief 回退输入流的读取位置。
+     * @param len 要回退的长度。
+     * @throw device_error 如果回退长度为零或超过当前已读取的位置。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Rolls back the read position of the input stream.
+     * @param len The length to roll back.
+     * @throw device_error If the rollback length is zero or exceeds the current read position.
+     * @endif
+     */
+    void get_rollback(size_t len)
+    {
+        if (len == 0)
+            throw device_error("mem_device::get_rollback fail, length cannot be zero");
+        if (m_next_pos < len)
+            throw device_error("mem_device::get_rollback fail, rollback length too large");
+        m_next_pos -= len;
+    }
+
+    /**
+     * @lang{ZH}
+     * @brief 获取输出缓冲区中的一段可写入的连续内存。
+     * @param len 要请求的可写入长度。
+     * @return 指向可写入区域起始位置的指针。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Retrieves a contiguous block of writable memory from the output buffer.
+     * @param len The requested length to write.
+     * @return A pointer to the start of the writable area.
+     * @endif
+     */
+    CharT* put_buf(size_t len)
+    {
+        m_ori_size = m_str.size();
+        const size_t needed = m_next_pos + len;
+        if (needed > m_str.size())
+        {
+            if (needed > m_str.capacity())
+                m_str.reserve(grow(m_str.capacity(), needed));
+            m_str.resize(needed);
+        }
+        CharT* res = m_str.data() + m_next_pos;
+        m_next_pos = needed;
+        return res;
+    }
+
+    /**
+     * @lang{ZH}
+     * @brief 回退输出流的写入位置，并根据需要调整底层缓冲区大小。
+     * @param len 要回退的长度。
+     * @throw device_error 如果回退长度为零或超过当前写入的位置。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Rolls back the write position of the output stream and adjusts the internal buffer size if necessary.
+     * @param len The length to roll back.
+     * @throw device_error If the rollback length is zero or exceeds the current write position.
+     * @endif
+     */
+    void put_rollback(size_t len)
+    {
+        if (len == 0)
+            throw device_error("mem_device::put_rollback fail, length cannot be zero");
+        if (m_next_pos < len)
+            throw device_error("mem_device::put_rollback fail, rollback length too large");
+        m_next_pos -= len;
+        m_str.resize(std::max(m_next_pos, m_ori_size));
+    }
+
+private:
+    /**
+     * @lang{ZH}
+     * @brief 计算缓冲区增长后的新容量。
+     * @param current 当前容量。
+     * @param required 所需的最小容量。
+     * @return 增长后的新容量。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Calculates the new capacity for buffer growth.
+     * @param current The current capacity.
+     * @param required The minimum required capacity.
+     * @return The calculated new capacity.
+     * @endif
+     */
+    static size_t grow(size_t current, size_t required)
+    {
+        const size_t new_cap = current + current / 2;
+        if (new_cap < required) return required;
+        return new_cap;
+    }
+
 private:
     std::basic_string<CharT, Traits, Allocator> m_str;
     size_t m_next_pos = 0;
+    size_t m_ori_size = 0;
 };
 
 /// @cond

--- a/include/device/std_device.h
+++ b/include/device/std_device.h
@@ -164,7 +164,7 @@ public:
         if (s == nullptr)
             throw device_error("std_device::dget fail: null buffer");
 
-        constexpr size_t max_read = static_cast<size_t>(std::numeric_limits<ssize_t>::max());
+        constexpr auto max_read = static_cast<size_t>(std::numeric_limits<ssize_t>::max());
         ssize_t ret = 0;
         while (true)
         {


### PR DESCRIPTION
- Implement get_buf/put_buf and rollback mechanisms in mem_device for direct memory access.
- Add specialized cvt_io for mem_device in root_cvt.h to bypass intermediate buffering.
- Fix a critical bad_alloc bug in mem_device::put_buf caused by incorrect position tracking.
- Add bilingual Doxygen documentation for the new API.