### PR TITLE
Refactor cvt_reader and cvt_writer to manage buffers and use pointers to kernels

### DIFF
--- a/include/cvt/abs_cvt.h
+++ b/include/cvt/abs_cvt.h
@@ -4,36 +4,46 @@
 #include <bit>
 #include <cstring>
 #include <exception>
-#include <span>
 #include <vector>
-namespace IOv2 
+namespace IOv2
 {
     template <io_converter KernelType>
     class cvt_reader
     {
         using char_type = typename KernelType::internal_type;
     public:
-        cvt_reader(KernelType& kernel, std::span<char_type> buffer)
-            : m_refkernel(kernel)
-            , m_refbuffer(buffer)
-        {}
+        explicit cvt_reader(KernelType* kernel)
+            : m_kernel(kernel) {}
 
         cvt_reader(const cvt_reader&) = delete;
+        cvt_reader& operator=(const cvt_reader&) = delete;
         cvt_reader(cvt_reader&&) = default;
+        cvt_reader& operator=(cvt_reader&&) = default;
         ~cvt_reader() = default;
-    
+
+        void set_kernel(KernelType* kernel) { m_kernel = kernel; }
+
+        void reset(size_t buf_size)
+        {
+            m_buffer.resize(buf_size);
+            m_cur_pos = 0;
+            m_end_pos = 0;
+        }
+
         template <bool Saturate = false>
         auto get_buf(size_t to_max)
         {
+            if (m_kernel == nullptr)
+                throw cvt_error("cvt_reader::get_buf fail, kernel is null.");
             if (to_max == 0)
-                throw cvt_error("cvt_io::reader::get_buf fail, read size cannot be zero.");
-            if (to_max > m_refbuffer.size())
-                throw cvt_error("cvt_io::reader::get_buf fail, read size too large.");
+                throw cvt_error("cvt_reader::get_buf fail, read size cannot be zero.");
+            if (to_max > m_buffer.size())
+                throw cvt_error("cvt_reader::get_buf fail, read size too large.");
 
             const auto rollback_size = m_end_pos - m_cur_pos;
             if (to_max <= rollback_size)
             {
-                std::pair<const char_type*, size_t> res{m_refbuffer.data() + m_cur_pos, to_max};
+                std::pair<const char_type*, size_t> res{m_buffer.data() + m_cur_pos, to_max};
                 m_cur_pos += to_max;
                 if constexpr (!Saturate)
                     return res;
@@ -41,14 +51,14 @@ namespace IOv2
                     return res.first;
             }
 
-            if (to_max > m_refbuffer.size() - m_cur_pos)
+            if (to_max > m_buffer.size() - m_cur_pos)
             {
-                std::copy(m_refbuffer.data() + m_cur_pos, m_refbuffer.data() + m_end_pos, m_refbuffer.data());
+                std::copy(m_buffer.data() + m_cur_pos, m_buffer.data() + m_end_pos, m_buffer.data());
                 m_cur_pos = 0;
                 m_end_pos = rollback_size;
             }
             const size_t aim_size = to_max - rollback_size;
-            auto read_size = m_refkernel.get(m_refbuffer.data() + m_end_pos, aim_size);
+            auto read_size = m_kernel->get(m_buffer.data() + m_end_pos, aim_size);
             m_end_pos += read_size;
 
             if constexpr (Saturate)
@@ -56,7 +66,7 @@ namespace IOv2
                 while (read_size < aim_size)
                 {
                     const size_t new_aim_size = aim_size - read_size;
-                    const auto new_read_size = m_refkernel.get(m_refbuffer.data() + m_end_pos, new_aim_size);
+                    const auto new_read_size = m_kernel->get(m_buffer.data() + m_end_pos, new_aim_size);
                     if (new_read_size == 0)
                         throw cvt_error("get_buf<Saturate> fail: meet eos");
                     m_end_pos += new_read_size;
@@ -66,13 +76,13 @@ namespace IOv2
 
             if constexpr(!Saturate)
             {
-                std::pair<const char_type*, size_t> res{m_refbuffer.data() + m_cur_pos, rollback_size + read_size};
+                std::pair<const char_type*, size_t> res{m_buffer.data() + m_cur_pos, rollback_size + read_size};
                 m_cur_pos = m_end_pos;
                 return res;
             }
             else
             {
-                const char_type* res = m_refbuffer.data() + m_cur_pos;
+                const char_type* res = m_buffer.data() + m_cur_pos;
                 m_cur_pos = m_end_pos;
                 return res;
             }
@@ -81,15 +91,15 @@ namespace IOv2
         void rollback(size_t len)
         {
             if (len == 0)
-                throw cvt_error("cvt_io::reader::rollback fail, length cannot be zero.");
+                throw cvt_error("cvt_reader::rollback fail, length cannot be zero.");
             if (len > m_cur_pos)
-                throw cvt_error("cvt_io::reader::rollback fail, rollback length too large.");
+                throw cvt_error("cvt_reader::rollback fail, rollback length too large.");
             m_cur_pos -= len;
         }
 
     private:
-        KernelType& m_refkernel;
-        std::span<char_type> m_refbuffer;
+        KernelType* m_kernel;
+        std::vector<char_type> m_buffer;
         size_t m_cur_pos = 0;
         size_t m_end_pos = 0;
     };
@@ -99,87 +109,69 @@ namespace IOv2
     {
         using char_type = typename KernelType::internal_type;
     public:
-        cvt_writer(KernelType& kernel, std::span<char_type> buffer)
-            : m_refkernel(kernel)
-            , m_refbuffer(buffer)
-        {}
+        explicit cvt_writer(KernelType* kernel)
+            : m_kernel(kernel) {}
 
         cvt_writer(const cvt_writer&) = delete;
+        cvt_writer& operator=(const cvt_writer&) = delete;
         cvt_writer(cvt_writer&&) = default;
+        cvt_writer& operator=(cvt_writer&&) = default;
+        ~cvt_writer() = default;
 
-        ~cvt_writer()
+        void set_kernel(KernelType* kernel) { m_kernel = kernel; }
+
+        void reset(size_t buf_size)
         {
-            try
-            {
-                commit();
-            }
-            catch(...)
-            {}
+            m_buffer.resize(buf_size);
+            m_prev_len = 0;
         }
-    
+
         char_type* put_buf(size_t len)
         {
+            if (m_kernel == nullptr)
+                throw cvt_error("cvt_writer::put_buf fail, kernel is null.");
             if (len == 0)
-                throw cvt_error("cvt_io::writer::put_buf fail, write size cannot be zero.");
-            if (len > m_refbuffer.size())
-                throw cvt_error("cvt_io::writer::put_buf fail, write size too large.");
-        
-            size_t remain = m_refbuffer.size() - m_prev_len;
+                throw cvt_error("cvt_writer::put_buf fail, write size cannot be zero.");
+            if (len > m_buffer.size())
+                throw cvt_error("cvt_writer::put_buf fail, write size too large.");
+
+            size_t remain = m_buffer.size() - m_prev_len;
             if (remain < len)
             {
-                m_refkernel.put(m_refbuffer.data(), m_prev_len);
-                remain = m_refbuffer.size();
+                m_kernel->put(m_buffer.data(), m_prev_len);
+                remain = m_buffer.size();
                 m_prev_len = 0;
             }
-        
-            auto res = m_refbuffer.data() + m_prev_len;
+
+            auto res = m_buffer.data() + m_prev_len;
             m_prev_len += len;
             return res;
         }
-    
+
         void rollback(size_t len)
         {
             if (len == 0)
-                throw cvt_error("cvt_io::writer::rollback fail, length cannot be zero.");
+                throw cvt_error("cvt_writer::rollback fail, length cannot be zero.");
             if (len > m_prev_len)
-                throw cvt_error("cvt_io::writer::rollback fail, rollback length too large.");
+                throw cvt_error("cvt_writer::rollback fail, rollback length too large.");
             m_prev_len -= len;
         }
 
         void commit()
         {
+            if (m_kernel == nullptr)
+                throw cvt_error("cvt_writer::commit fail, kernel is null.");
             if (m_prev_len != 0)
             {
-                m_refkernel.put(m_refbuffer.data(), m_prev_len);
+                m_kernel->put(m_buffer.data(), m_prev_len);
                 m_prev_len = 0;
             }
         }
-    
-    private:
-        KernelType& m_refkernel;
-        std::span<char_type> m_refbuffer;
-        size_t m_prev_len = 0;
-    };
-
-    template <io_converter KernelType>
-    class cvt_io
-    {
-        using char_type = typename KernelType::internal_type;
-    public:
-        auto reader(KernelType& kernel, size_t buf_size)
-        {
-            m_buffer.resize(buf_size);
-            return cvt_reader(kernel, m_buffer);
-        }
-
-        auto writer(KernelType& kernel, size_t buf_size)
-        {
-            m_buffer.resize(buf_size);
-            return cvt_writer(kernel, m_buffer);
-        }
 
     private:
+        KernelType* m_kernel;
         std::vector<char_type> m_buffer;
+        size_t m_prev_len = 0;
     };
 
     template <typename CurrentType,
@@ -197,24 +189,48 @@ namespace IOv2
 
     private:
         // for bos: write s_bos_chunk external type at once. This will avoid allocating large memory, and use memory efficiently.
-        constexpr static size_t s_bos_chunk = 16;  
+        constexpr static size_t s_bos_chunk = 16;
 
     public:
         abs_cvt(KernelType kernel)
-            : m_kernel(std::move(kernel)) {}
-    
-        abs_cvt(const abs_cvt&) = default;
+            : m_kernel(std::move(kernel))
+            , m_reader(&m_kernel)
+            , m_writer(&m_kernel) {}
+
+        abs_cvt(const abs_cvt& val)
+            : m_kernel(val.m_kernel)
+            , m_io_status(val.m_io_status)
+            , m_is_bos_done(val.m_is_bos_done)
+            , m_reader(&m_kernel)
+            , m_writer(&m_kernel) {}
+
         abs_cvt(abs_cvt&& val)
             : m_kernel(std::move(val.m_kernel))
             , m_io_status(val.m_io_status)
             , m_is_bos_done(val.m_is_bos_done)
-            , m_cvt_io(std::move(val.m_cvt_io))
+            , m_reader(std::move(val.m_reader))
+            , m_writer(std::move(val.m_writer))
         {
+            m_reader.set_kernel(&m_kernel);
+            m_writer.set_kernel(&m_kernel);
+            val.m_reader.set_kernel(nullptr);
+            val.m_writer.set_kernel(nullptr);
             val.m_io_status = io_status::neutral;
             val.m_is_bos_done = false;
         }
 
-        abs_cvt& operator=(const abs_cvt&) = default;
+        abs_cvt& operator=(const abs_cvt& val)
+        {
+            if (this != &val)
+            {
+                m_kernel = val.m_kernel;
+                m_io_status = val.m_io_status;
+                m_is_bos_done = val.m_is_bos_done;
+                // m_reader and m_writer keep pointing to &m_kernel, no change needed
+            }
+            return *this;
+        }
+
         abs_cvt& operator=(abs_cvt&& val)
         {
             if (this != &val)
@@ -224,13 +240,18 @@ namespace IOv2
                 val.m_io_status = io_status::neutral;
                 m_is_bos_done = val.m_is_bos_done;
                 val.m_is_bos_done = false;
-                m_cvt_io = std::move(val.m_cvt_io);
+                m_reader = std::move(val.m_reader);
+                m_writer = std::move(val.m_writer);
+                m_reader.set_kernel(&m_kernel);
+                m_writer.set_kernel(&m_kernel);
+                val.m_reader.set_kernel(nullptr);
+                val.m_writer.set_kernel(nullptr);
             }
             return *this;
         }
 
         ~abs_cvt() = default;
-    
+
     // mandatory methods
     public:
         device_type& device() { return m_kernel.device(); }
@@ -240,14 +261,14 @@ namespace IOv2
             m_is_bos_done = false;
             return m_kernel.detach();
         }
-    
+
         device_type attach(device_type&& dev = device_type{})
         {
             m_io_status = io_status::neutral;
             m_is_bos_done = false;
             return m_kernel.attach(std::move(dev));
         }
-    
+
         void adjust(const cvt_behavior& b)
         {
             m_kernel.adjust(b);
@@ -257,7 +278,7 @@ namespace IOv2
         {
             m_kernel.retrieve(s);
         }
-        
+
         io_status bos()
         {
             if (m_io_status != io_status::neutral)
@@ -294,7 +315,7 @@ namespace IOv2
 
                 constexpr size_t ext_size = sizeof(external_type);
 
-                auto rd = this->reader(s_bos_chunk);
+                m_reader.reset(s_bos_chunk);
                 char* dest_bytes = reinterpret_cast<char*>(to);
                 const char* dest_bytes_end = reinterpret_cast<const char*>(to + to_max);
 
@@ -303,7 +324,7 @@ namespace IOv2
                 {
                     const size_t units_to_read_now = std::min((size_t)((dest_bytes_end - dest_bytes) / ext_size), s_bos_chunk);
 
-                    const auto* src_buf = rd.template get_buf<true>(units_to_read_now);
+                    const auto* src_buf = m_reader.template get_buf<true>(units_to_read_now);
                     std::memcpy(dest_bytes, src_buf, units_to_read_now * ext_size);
                     dest_bytes += units_to_read_now * ext_size;
                 }
@@ -312,7 +333,7 @@ namespace IOv2
                 const size_t final_remainder_bytes = dest_bytes_end - dest_bytes;
                 if (final_remainder_bytes > 0)
                 {
-                    const auto* src_buf = rd.template get_buf<true>(1);
+                    const auto* src_buf = m_reader.template get_buf<true>(1);
                     std::memcpy(dest_bytes, src_buf, final_remainder_bytes);
                     dest_bytes += final_remainder_bytes;
                 }
@@ -346,11 +367,11 @@ namespace IOv2
                 auto to_bytes = reinterpret_cast<const char*>(to);
                 auto to_bytes_end = reinterpret_cast<const char*>(to + to_size);
 
-                auto wt = this->writer(s_bos_chunk);
+                m_writer.reset(s_bos_chunk);
                 while (to_bytes + ext_size <= to_bytes_end)
                 {
                     auto dest_count = std::min<size_t>((to_bytes_end - to_bytes) / ext_size, s_bos_chunk);
-                    auto ptr = wt.put_buf(dest_count);
+                    auto ptr = m_writer.put_buf( dest_count);
                     std::memcpy(reinterpret_cast<char*>(ptr), to_bytes, dest_count * ext_size);
                     to_bytes += dest_count * ext_size;
                 }
@@ -361,12 +382,12 @@ namespace IOv2
                     // The modulo is logically redundant but helps the compiler's
                     // static analyzer prove the bound for memset size calculation.
                     size_t remaining = static_cast<size_t>(to_bytes_end - to_bytes) % ext_size;
-                    auto ptr = wt.put_buf(1);
+                    auto ptr = m_writer.put_buf( 1);
                     std::memcpy(reinterpret_cast<char*>(ptr), to_bytes, remaining);
                     std::memset(reinterpret_cast<char*>(ptr) + remaining, 0, ext_size - remaining);
                 }
 
-                wt.commit();
+                m_writer.commit();
             }
             else
             {
@@ -392,19 +413,19 @@ namespace IOv2
         {
             return m_kernel.tell();
         }
-        
+
         void seek(size_t pos)
             requires (default_positioning && cvt_cpt::support_positioning<KernelType>)
         {
             m_kernel.seek(pos);
         }
-        
+
         void rseek(size_t pos)
             requires (default_positioning && cvt_cpt::support_positioning<KernelType>)
         {
             m_kernel.rseek(pos);
         }
-        
+
         void switch_to_get()
             requires (default_io_switch && cvt_cpt::support_io_switch<KernelType>)
         {
@@ -420,14 +441,10 @@ namespace IOv2
         }
 
     protected:
-        auto reader(size_t buf_size) { return m_cvt_io.reader(m_kernel, buf_size); }
-        auto writer(size_t buf_size) { return m_cvt_io.writer(m_kernel, buf_size); }
-
-    protected:
         KernelType  m_kernel;
         io_status   m_io_status = io_status::neutral;
         bool        m_is_bos_done = false;
-    private:
-        cvt_io<KernelType> m_cvt_io;
+        cvt_reader<KernelType> m_reader;
+        cvt_writer<KernelType> m_writer;
     };
 }

--- a/include/cvt/code_cvt.h
+++ b/include/cvt/code_cvt.h
@@ -328,11 +328,11 @@ private:
     void put_main(const internal_type* to, size_t to_size)
         requires (cvt_cpt::support_put<KernelType>)
     {
-        auto wt = this->writer(s_max_buf_size);
+        this->m_writer.reset(s_max_buf_size);
         const size_t buf_len = m_cvt_kernel.epc();
         for (size_t i = 0; i < to_size; ++i)
         {
-            external_type* out_beg = wt.put_buf(buf_len);
+            external_type* out_beg = this->m_writer.put_buf(buf_len);
             external_type* out_next = out_beg;
 
             internal_type ch = *to++;
@@ -342,15 +342,15 @@ private:
 
             ++m_accu_len;
             if (out_next < out_beg + buf_len)
-                wt.rollback(out_beg + buf_len - out_next);
+                this->m_writer.rollback(out_beg + buf_len - out_next);
         }
-        wt.commit();
+        this->m_writer.commit();
     }
 
     size_t get_main(internal_type* to, size_t to_max)
         requires (cvt_cpt::support_get<KernelType>)
     {
-        auto rd = this->reader(s_max_buf_size);
+        this->m_reader.reset(s_max_buf_size);
         size_t total_size = 0;
 
         size_t prev_rollback = 0;
@@ -362,7 +362,7 @@ private:
             if (dest_size > s_max_buf_size) [[unlikely]]
                 throw cvt_error("code_cvt::get fail, input sequence too long.");
 
-            auto [ptr, cur_size] = rd.get_buf(dest_size);
+            auto [ptr, cur_size] = this->m_reader.get_buf(dest_size);
             if (cur_size == prev_rollback)
             {
                 if (cur_size == 0) return total_size;
@@ -382,7 +382,7 @@ private:
             else
             {
                 prev_rollback = ptr + cur_size - ext_cur;
-                rd.rollback(prev_rollback);
+                this->m_reader.rollback(prev_rollback);
             }
         }
         return total_size;

--- a/include/cvt/comp/zlib_cvt.h
+++ b/include/cvt/comp/zlib_cvt.h
@@ -195,10 +195,10 @@ public:
             auto ret = inflateInit(&m_strm);
             if (ret != Z_OK) throw cvt_error("zlib_cvt::bos fail: Cannot initialize zlib.");
 
-            auto rd = this->reader(2);
+            this->m_reader.reset(2);
             const external_type* ptr = nullptr;
             if constexpr (cvt_cpt::support_get<KernelType>)
-                ptr = rd.template get_buf<true>(2);
+                ptr = this->m_reader.template get_buf<true>(2);
             else throw cvt_error("zlib_cvt::bos fail: kernel does not support get.");
 
             m_strm.avail_in = 2;
@@ -225,8 +225,8 @@ public:
             auto ret = deflateInit(&m_strm, static_cast<int>(m_put_level));
             if (ret != Z_OK) throw cvt_error("zlib_cvt::bos fail: Cannot initialize zlib.");
 
-            auto wt = this->writer(3);
-            auto ptr = wt.put_buf(3);
+            this->m_writer.reset(3);
+            auto ptr = this->m_writer.put_buf(3);
 
             m_strm.avail_in = 0;
             m_strm.next_in = nullptr;
@@ -237,8 +237,8 @@ public:
 
             if (m_strm.avail_out != 1) throw cvt_error("zlib_cvt::bos fail: Invalid zlib header");
 
-            wt.rollback(1);
-            wt.commit();
+            this->m_writer.rollback(1);
+            this->m_writer.commit();
 
             m_strm.avail_out = 0;
             m_strm.next_out = nullptr;
@@ -257,7 +257,7 @@ private:
         // unpredictable expansion ratio - a few compressed bytes could expand
         // to overflow the output buffer. This keeps the code simple and correct.
         // The underlying converter already buffers, so this doesn't cause syscalls.
-        auto rd = this->reader(1);
+        this->m_reader.reset(1);
 
         constexpr size_t max_type_limit = std::numeric_limits<decltype(m_strm.avail_out)>::max();
         constexpr size_t max_chunk = max_type_limit - (max_type_limit % sizeof(internal_type));
@@ -273,7 +273,7 @@ private:
 
         while (m_strm.avail_out && ret != Z_STREAM_END)
         {
-            auto [ptr, len] = rd.get_buf(1);
+            auto [ptr, len] = this->m_reader.get_buf(1);
             if (len == 0) break;
             m_strm.next_in = reinterpret_cast<unsigned char*>(const_cast<char*>(ptr));
             m_strm.avail_in = 1;
@@ -301,7 +301,7 @@ private:
 
         auto to = reinterpret_cast<const unsigned char*>(_to);
 
-        auto wt = this->writer(CHUNK);
+        this->m_writer.reset(CHUNK);
         while (to_size > 0)
         {
             auto aim_output = (max_chunk / sizeof(internal_type) > to_size)
@@ -314,7 +314,7 @@ private:
                 m_strm.next_in = const_cast<unsigned char*>(to + write_size);
                 size_t cur_put_size = static_cast<size_t>(aim_output - write_size);
                 m_strm.avail_in = cur_put_size;
-                m_strm.next_out = reinterpret_cast<unsigned char*>(wt.put_buf(CHUNK));
+                m_strm.next_out = reinterpret_cast<unsigned char*>(this->m_writer.put_buf(CHUNK));
                 m_strm.avail_out = CHUNK;
 
                 auto ret = deflate(&m_strm, Z_NO_FLUSH);
@@ -322,12 +322,12 @@ private:
                 write_size += cur_put_size - m_strm.avail_in;
 
                 if (m_strm.avail_out)
-                    wt.rollback(m_strm.avail_out);
+                    this->m_writer.rollback(m_strm.avail_out);
             }
             to += aim_output;
             to_size -= aim_output / sizeof(internal_type);
         }
-        wt.commit();
+        this->m_writer.commit();
 
         m_strm.next_out = nullptr;
         m_strm.avail_out = 0;
@@ -346,21 +346,21 @@ public:
 
         if (m_sync_flush)
         {
-            auto wt = this->writer(CHUNK);
+            this->m_writer.reset(CHUNK);
             m_strm.next_in = nullptr;
             m_strm.avail_in = 0;
             while (true)
             {
-                m_strm.next_out = reinterpret_cast<unsigned char*>(wt.put_buf(CHUNK));
+                m_strm.next_out = reinterpret_cast<unsigned char*>(this->m_writer.put_buf(CHUNK));
                 m_strm.avail_out = CHUNK;
                 zerr("zlib_cvt::flush fail", deflate(&m_strm, Z_SYNC_FLUSH));
                 if (m_strm.avail_out)
                 {
-                    wt.rollback(m_strm.avail_out);
+                    this->m_writer.rollback(m_strm.avail_out);
                     break;
                 }
             }
-            wt.commit();
+            this->m_writer.commit();
             m_strm.next_out = nullptr;
             m_strm.avail_out = 0;
             m_strm.next_in = nullptr;
@@ -401,21 +401,21 @@ private:
         {
             if (BT::m_is_bos_done)
             {
-                auto wt = this->writer(CHUNK);
+                this->m_writer.reset(CHUNK);
                 m_strm.next_in = nullptr;
                 m_strm.avail_in = 0;
                 while (true)
                 {
-                    m_strm.next_out = reinterpret_cast<unsigned char*>(wt.put_buf(CHUNK));
+                    m_strm.next_out = reinterpret_cast<unsigned char*>(this->m_writer.put_buf(CHUNK));
                     m_strm.avail_out = CHUNK;
                     zerr("zlib_cvt::put_end fail", deflate(&m_strm, Z_FINISH));
                     if (m_strm.avail_out)
                     {
-                        wt.rollback(m_strm.avail_out);
+                        this->m_writer.rollback(m_strm.avail_out);
                         break;
                     }
                 }
-                wt.commit();
+                this->m_writer.commit();
                 deflateEnd(&m_strm);
             }
         }

--- a/include/cvt/crypt/chacha20_cvt.h
+++ b/include/cvt/crypt/chacha20_cvt.h
@@ -84,8 +84,8 @@ public:
         const size_t iv_len = m_cipher->default_iv_length();
         if (BT::m_io_status == io_status::input)
         {
-            auto rd = this->reader(iv_len);
-            auto ptr = rd.template get_buf<true>(iv_len);
+            this->m_reader.reset(iv_len);
+            auto ptr = this->m_reader.template get_buf<true>(iv_len);
 
             m_cipher->set_key(m_key);
             m_cipher->set_iv(reinterpret_cast<const uint8_t*>(ptr), iv_len);
@@ -93,13 +93,13 @@ public:
         else if (BT::m_io_status == io_status::output)
         {
             Botan::AutoSeeded_RNG rng;
-            auto wt = this->writer(iv_len);
-            auto ptr = wt.put_buf(iv_len);
+            this->m_writer.reset(iv_len);
+            auto ptr = this->m_writer.put_buf(iv_len);
             rng.randomize(reinterpret_cast<uint8_t*>(ptr), iv_len);
 
             m_cipher->set_key(m_key);
             m_cipher->set_iv(reinterpret_cast<const uint8_t*>(ptr), iv_len);
-            wt.commit();
+            this->m_writer.commit();
         }
         else
             throw cvt_error("chacha20_cvt::bos fail: neither in input nor output mode");
@@ -124,12 +124,12 @@ private:
 
         uint8_t* to = reinterpret_cast<uint8_t*>(_to);
 
-        auto rd = this->reader(block_size);
+        this->m_reader.reset(block_size);
         size_t res = 0;
         while (res != to_max)
         {
             size_t dest_size = std::min<size_t>(block_size, to_max - res);
-            auto [ptr, cur_len] = rd.get_buf(dest_size);
+            auto [ptr, cur_len] = this->m_reader.get_buf(dest_size);
             if (cur_len == 0) break;
             m_cipher->cipher(reinterpret_cast<const uint8_t*>(ptr), to, cur_len);
             to += cur_len;
@@ -140,7 +140,7 @@ private:
             throw cvt_error("chacha20_cvt::get fails: partial sequence");
         return res / sizeof(internal_type);
     }
-    
+
     void put_main(const internal_type* _to, size_t to_size)
         requires (cvt_cpt::support_put<KernelType>)
     {
@@ -149,7 +149,7 @@ private:
 
         const uint8_t* to = reinterpret_cast<const uint8_t*>(_to);
 
-        auto wt = this->writer(block_size);
+        this->m_writer.reset(block_size);
         while (to_size > 0)
         {
             size_t aim_output = (max_chunk / sizeof(internal_type) > to_size)
@@ -159,14 +159,14 @@ private:
             while (to_i != aim_output)
             {
                 size_t dest_size = std::min<size_t>(block_size, aim_output - to_i);
-                auto ptr = wt.put_buf(dest_size);
+                auto ptr = this->m_writer.put_buf(dest_size);
                 m_cipher->cipher(to + to_i, reinterpret_cast<uint8_t*>(ptr), dest_size);
                 to_i += dest_size;
             }
             to += aim_output;
             to_size -= aim_output / sizeof(internal_type);
         }
-        wt.commit();
+        this->m_writer.commit();
     }
 private:
     std::unique_ptr<Botan::StreamCipher> m_cipher;

--- a/include/cvt/crypt/vigenere_cvt.h
+++ b/include/cvt/crypt/vigenere_cvt.h
@@ -77,11 +77,11 @@ private:
         requires (cvt_cpt::support_get<KernelType>)
     {
         size_t total_count = 0;
-        auto rd = this->reader(s_buf_len);
+        this->m_reader.reset(s_buf_len);
         while (total_count != to_max)
         {
             const size_t dest_size = std::min(s_buf_len, to_max - total_count);
-            auto [ptr, cur_size] = rd.get_buf(dest_size);
+            auto [ptr, cur_size] = this->m_reader.get_buf(dest_size);
             if (cur_size == 0)
                 return total_count;
 
@@ -94,17 +94,17 @@ private:
         }
         return total_count;
     }
-    
+
     void put_main(const internal_type* to, size_t to_size)
         requires (cvt_cpt::support_put<KernelType>)
     {
-        auto wt = this->writer(s_buf_len);
+        this->m_writer.reset(s_buf_len);
 
         size_t total_count = 0;
         while (total_count != to_size)
         {
             const size_t dest_size = std::min(s_buf_len, to_size - total_count);
-            auto ptr = wt.put_buf(dest_size);
+            auto ptr = this->m_writer.put_buf(dest_size);
 
             for (size_t i = 0; i < dest_size; ++i)
             {
@@ -113,7 +113,7 @@ private:
             }
             total_count += dest_size;
         }
-        wt.commit();
+        this->m_writer.commit();
     }
 
 public:

--- a/include/cvt/root_cvt.h
+++ b/include/cvt/root_cvt.h
@@ -26,10 +26,10 @@ template <io_device DeviceType, bool HasInBuffer>
 class root_cvt
 {
     template <io_converter KernelType>
-    friend class root_cvt_reader;
+    friend class cvt_reader;
 
     template <io_converter KernelType>
-    friend class root_cvt_writer;
+    friend class cvt_writer;
 
 public:
     constexpr static size_t s_buffer_length = 2048;
@@ -585,26 +585,37 @@ class no_rb_root_cvt : public root_cvt<DeviceType, false>
 template <io_device DeviceType>
 no_rb_root_cvt(DeviceType) -> no_rb_root_cvt<DeviceType>;
 
-template <io_converter KernelType>
-class root_cvt_reader;
-
+// cvt_reader specialization for root_cvt with buffer: directly use root_cvt's internal buffer
 template <io_converter KernelType>
     requires (std::is_base_of_v<root_cvt<typename KernelType::device_type, true>, KernelType> &&
               !is_mem_device<typename KernelType::device_type>)
-class root_cvt_reader<KernelType>
+class cvt_reader<KernelType>
 {
     using device_type = typename KernelType::device_type;
     using char_type = typename KernelType::internal_type;
 
 public:
-    root_cvt_reader(KernelType& kernel, size_t buf_size)
-        : m_kernel(kernel)
-        , m_buf_size(buf_size)
-    {}
+    explicit cvt_reader(KernelType* kernel)
+        : m_kernel(kernel) {}
+
+    cvt_reader(const cvt_reader&) = delete;
+    cvt_reader& operator=(const cvt_reader&) = delete;
+    cvt_reader(cvt_reader&&) = default;
+    cvt_reader& operator=(cvt_reader&&) = default;
+    ~cvt_reader() = default;
+
+    void set_kernel(KernelType* kernel) { m_kernel = kernel; }
+
+    void reset(size_t buf_size)
+    {
+        m_buf_size = buf_size;
+    }
 
     template <bool Saturate = false>
     auto get_buf(size_t to_max)
     {
+        if (m_kernel == nullptr)
+            throw cvt_error("cvt_reader::get_buf fail, kernel is null.");
         if (to_max == 0)
             throw cvt_error("cvt_reader::get_buf fail, read size cannot be zero.");
         if (to_max > m_buf_size)
@@ -612,48 +623,48 @@ public:
 
         if constexpr (dev_cpt::support_put<device_type>)
         {
-            if (m_kernel.m_io_status != io_status::input)
-                m_kernel.switch_to_get();
+            if (m_kernel->m_io_status != io_status::input)
+                m_kernel->switch_to_get();
         }
-        if (m_kernel.m_io_status != io_status::input)
+        if (m_kernel->m_io_status != io_status::input)
             throw cvt_error("cvt_reader::get_buf fail, invalid io status");
 
-        const size_t remain = m_kernel.m_buf_end - m_kernel.m_buf_cur;
+        const size_t remain = m_kernel->m_buf_end - m_kernel->m_buf_cur;
         // need to read, then read at most as it can
         if (remain < to_max)
         {
             if (remain != 0)
-                m_kernel.m_buf_end = std::copy(m_kernel.m_buf_cur, m_kernel.m_buf_end, m_kernel.m_buffer.data());
+                m_kernel->m_buf_end = std::copy(m_kernel->m_buf_cur, m_kernel->m_buf_end, m_kernel->m_buffer.data());
             else
-                m_kernel.m_buf_end = m_kernel.m_buffer.data();
+                m_kernel->m_buf_end = m_kernel->m_buffer.data();
 
-            m_kernel.m_buf_cur = m_kernel.m_buffer.data();
-            m_kernel.m_buf_end += m_kernel.m_device.dget(m_kernel.m_buf_end, KernelType::s_buffer_length - remain);
+            m_kernel->m_buf_cur = m_kernel->m_buffer.data();
+            m_kernel->m_buf_end += m_kernel->m_device.dget(m_kernel->m_buf_end, KernelType::s_buffer_length - remain);
         }
 
         if constexpr (Saturate)
         {
-            const auto aim_ptr = to_max + m_kernel.m_buf_cur;
-            while (m_kernel.m_buf_end < aim_ptr)
+            const auto aim_ptr = to_max + m_kernel->m_buf_cur;
+            while (m_kernel->m_buf_end < aim_ptr)
             {
-                auto new_size = m_kernel.m_device.dget(m_kernel.m_buf_end, aim_ptr - m_kernel.m_buf_end);
+                auto new_size = m_kernel->m_device.dget(m_kernel->m_buf_end, aim_ptr - m_kernel->m_buf_end);
                 if (new_size == 0)
                     throw cvt_error("get_buf<Saturate> fail: meet eos");
-                m_kernel.m_buf_end += new_size;
+                m_kernel->m_buf_end += new_size;
             }
         }
 
         if constexpr (!Saturate)
         {
-            auto res_len = std::min<size_t>(m_kernel.m_buf_end - m_kernel.m_buf_cur, to_max);
-            std::pair<const char_type*, size_t> res{m_kernel.m_buf_cur, res_len};
-            m_kernel.m_buf_cur += res_len;
+            auto res_len = std::min<size_t>(m_kernel->m_buf_end - m_kernel->m_buf_cur, to_max);
+            std::pair<const char_type*, size_t> res{m_kernel->m_buf_cur, res_len};
+            m_kernel->m_buf_cur += res_len;
             return res;
         }
         else
         {
-            const char_type* res = m_kernel.m_buf_cur;
-            m_kernel.m_buf_cur += to_max;
+            const char_type* res = m_kernel->m_buf_cur;
+            m_kernel->m_buf_cur += to_max;
             return res;
         }
     }
@@ -662,184 +673,175 @@ public:
     {
         if (len == 0)
             throw cvt_error("cvt_reader::rollback fail, length cannot be zero.");
-        if ((m_kernel.m_buf_cur == nullptr) || (len > static_cast<size_t>(m_kernel.m_buf_cur - m_kernel.m_buffer.data())))
+        if ((m_kernel == nullptr) || (m_kernel->m_buf_cur == nullptr) || (len > static_cast<size_t>(m_kernel->m_buf_cur - m_kernel->m_buffer.data())))
             throw cvt_error("cvt_reader::rollback fail, rollback length too large.");
-        m_kernel.m_buf_cur -= len;
+        m_kernel->m_buf_cur -= len;
     }
 
 private:
-    KernelType& m_kernel;
-    const size_t m_buf_size;
+    KernelType* m_kernel;
+    size_t m_buf_size = 0;
 };
 
-template <io_converter KernelType>
-class root_cvt_writer;
-
+// cvt_writer specialization for root_cvt: directly use root_cvt's internal buffer
 template <io_converter KernelType>
     requires (std::is_base_of_v<root_cvt<typename KernelType::device_type, KernelType::s_has_buffer>, KernelType> &&
               !is_mem_device<typename KernelType::device_type>)
-class root_cvt_writer<KernelType>
+class cvt_writer<KernelType>
 {
     using device_type = typename KernelType::device_type;
     using char_type = typename KernelType::internal_type;
 
 public:
-    root_cvt_writer(KernelType& kernel, size_t buf_size)
-        : m_kernel(kernel)
-        , m_buf_size(buf_size)
+    explicit cvt_writer(KernelType* kernel)
+        : m_kernel(kernel) {}
+
+    cvt_writer(const cvt_writer&) = delete;
+    cvt_writer& operator=(const cvt_writer&) = delete;
+    cvt_writer(cvt_writer&&) = default;
+    cvt_writer& operator=(cvt_writer&&) = default;
+    ~cvt_writer() = default;
+
+    void set_kernel(KernelType* kernel) { m_kernel = kernel; }
+
+    void reset(size_t buf_size)
     {
+        m_buf_size = buf_size;
         if (m_buf_size > KernelType::s_buffer_length)
-            throw cvt_error("root_cvt_writer: buf_size exceeds buffer capacity");
+            throw cvt_error("cvt_writer::reset fail, buf_size exceeds buffer capacity");
     }
 
     char_type* put_buf(size_t len)
     {
+        if (m_kernel == nullptr)
+            throw cvt_error("cvt_writer::put_buf fail, kernel is null.");
         if (len == 0)
-            throw cvt_error("root_cvt_writer::put_buf fail, write size cannot be zero.");
+            throw cvt_error("cvt_writer::put_buf fail, write size cannot be zero.");
         if (len > m_buf_size)
-            throw cvt_error("root_cvt_writer::put_buf fail, write size too large.");
+            throw cvt_error("cvt_writer::put_buf fail, write size too large.");
 
         if constexpr (dev_cpt::support_get<device_type>)
         {
-            if (m_kernel.m_io_status != io_status::output)
-                m_kernel.switch_to_put();
+            if (m_kernel->m_io_status != io_status::output)
+                m_kernel->switch_to_put();
         }
-        if (m_kernel.m_io_status != io_status::output)
-            throw cvt_error("root_cvt_writer::put_buf fail, invalid io status");
+        if (m_kernel->m_io_status != io_status::output)
+            throw cvt_error("cvt_writer::put_buf fail, invalid io status");
 
-        const size_t buf_used = m_kernel.m_buf_cur - m_kernel.m_buffer.data();
+        const size_t buf_used = m_kernel->m_buf_cur - m_kernel->m_buffer.data();
         const size_t remain = KernelType::s_buffer_length - buf_used;
         if (len < remain)
         {
-            auto res = m_kernel.m_buf_cur;
-            m_kernel.m_buf_cur += len;
+            auto res = m_kernel->m_buf_cur;
+            m_kernel->m_buf_cur += len;
             return res;
         }
-        
-        m_kernel.m_device.dput(m_kernel.m_buffer.data(), buf_used);
-        m_kernel.m_buf_cur = m_kernel.m_buffer.data() + len;
-        return m_kernel.m_buffer.data();
+
+        m_kernel->m_device.dput(m_kernel->m_buffer.data(), buf_used);
+        m_kernel->m_buf_cur = m_kernel->m_buffer.data() + len;
+        return m_kernel->m_buffer.data();
     }
 
     void rollback(size_t len)
     {
         if (len == 0)
-            throw cvt_error("root_cvt_writer::rollback fail, length cannot be zero.");
-        if ((m_kernel.m_buf_cur == nullptr) || (len > static_cast<size_t>(m_kernel.m_buf_cur - m_kernel.m_buffer.data())))
-            throw cvt_error("root_cvt_writer::rollback fail, rollback length too large.");
-        m_kernel.m_buf_cur -= len;
+            throw cvt_error("cvt_writer::rollback fail, length cannot be zero.");
+        if ((m_kernel == nullptr) || (m_kernel->m_buf_cur == nullptr) || (len > static_cast<size_t>(m_kernel->m_buf_cur - m_kernel->m_buffer.data())))
+            throw cvt_error("cvt_writer::rollback fail, rollback length too large.");
+        m_kernel->m_buf_cur -= len;
     }
 
     void commit() {}
 
 private:
-    KernelType& m_kernel;
-    const size_t m_buf_size;
+    KernelType* m_kernel;
+    size_t m_buf_size = 0;
 };
 
-template <io_converter KernelType>
-class cvt_io;
-
-template <io_converter KernelType>
-    requires (std::is_base_of_v<root_cvt<typename KernelType::device_type, KernelType::s_has_buffer>, KernelType> &&
-              !is_mem_device<typename KernelType::device_type>)
-class cvt_io<KernelType>
-{
-    using char_type = typename KernelType::internal_type;
-
-public:
-    auto reader(KernelType& kernel, size_t buf_size)
-    {
-        if constexpr (KernelType::s_has_buffer)
-        {
-            if (buf_size > KernelType::s_buffer_length)
-                throw cvt_error("cvt_io::reader construction fail: buffer too large");
-            return root_cvt_reader<KernelType>(kernel, buf_size);
-        }
-        else
-        {
-            buffer.resize(buf_size);
-            return cvt_reader(kernel, buffer);
-        }
-    }
-
-    auto writer(KernelType& kernel, size_t buf_size)
-    {
-        if (buf_size > KernelType::s_buffer_length)
-            throw cvt_error("cvt_io::writer construction fail: buffer too large");
-        return root_cvt_writer<KernelType>(kernel, buf_size);
-    }
-
-private:
-    // Buffer is reused across reader() calls to avoid repeated heap allocation.
-    // Consequently, the returned cvt_reader holds a reference to this buffer —
-    // callers must ensure this cvt_io instance outlives any cvt_reader it produces,
-    // and must not call reader() again while a previous cvt_reader is still in use.
-    std::vector<char_type> buffer;
-};
-
+// cvt_reader specialization for mem_device: directly access device buffer
 template <io_converter KernelType>
     requires ((std::is_base_of_v<root_cvt<typename KernelType::device_type, true>, KernelType> ||
                std::is_base_of_v<root_cvt<typename KernelType::device_type, false>, KernelType>) &&
               is_mem_device<typename KernelType::device_type>)
-class cvt_io<KernelType>
+class cvt_reader<KernelType>
 {
-    class direct_reader
-    {
-        using device_type = typename KernelType::device_type;
-    public:
-        direct_reader(device_type& device)
-            : m_device(device)
-        {}
-
-        template <bool Saturate = false>
-        auto get_buf(size_t to_max)
-        {
-            return m_device.template get_buf<Saturate>(to_max);
-        }
-
-        void rollback(size_t len)
-        {
-            m_device.get_rollback(len);
-        }
-
-    private:
-        device_type& m_device;
-    };
-
-    class direct_writer
-    {
-        using device_type = typename KernelType::device_type;
-    public:
-        direct_writer(device_type& device)
-            : m_device(device)
-        {}
-
-        auto put_buf(size_t len)
-        {
-            return m_device.put_buf(len);
-        }
-
-        void rollback(size_t len)
-        {
-            m_device.put_rollback(len);
-        }
-
-        void commit() {}
-
-    private:
-        device_type& m_device;
-    };
+    using device_type = typename KernelType::device_type;
+    using char_type = typename KernelType::internal_type;
 
 public:
-    auto reader(KernelType& kernel, size_t)
+    explicit cvt_reader(KernelType* kernel)
+        : m_kernel(kernel) {}
+
+    cvt_reader(const cvt_reader&) = delete;
+    cvt_reader& operator=(const cvt_reader&) = delete;
+    cvt_reader(cvt_reader&&) = default;
+    cvt_reader& operator=(cvt_reader&&) = default;
+    ~cvt_reader() = default;
+
+    void set_kernel(KernelType* kernel) { m_kernel = kernel; }
+
+    void reset(size_t) {}
+
+    template <bool Saturate = false>
+    auto get_buf(size_t to_max)
     {
-        return direct_reader(kernel.device());
+        if (m_kernel == nullptr)
+            throw cvt_error("cvt_reader::get_buf fail, kernel is null.");
+        return m_kernel->device().template get_buf<Saturate>(to_max);
     }
 
-    auto writer(KernelType& kernel, size_t)
+    void rollback(size_t len)
     {
-        return direct_writer(kernel.device());
+        if (m_kernel == nullptr)
+            throw cvt_error("cvt_reader::rollback fail, kernel is null.");
+        m_kernel->device().get_rollback(len);
     }
+
+private:
+    KernelType* m_kernel;
+};
+
+// cvt_writer specialization for mem_device: directly access device buffer
+template <io_converter KernelType>
+    requires ((std::is_base_of_v<root_cvt<typename KernelType::device_type, true>, KernelType> ||
+               std::is_base_of_v<root_cvt<typename KernelType::device_type, false>, KernelType>) &&
+              is_mem_device<typename KernelType::device_type>)
+class cvt_writer<KernelType>
+{
+    using device_type = typename KernelType::device_type;
+    using char_type = typename KernelType::internal_type;
+
+public:
+    explicit cvt_writer(KernelType* kernel)
+        : m_kernel(kernel) {}
+
+    cvt_writer(const cvt_writer&) = delete;
+    cvt_writer& operator=(const cvt_writer&) = delete;
+    cvt_writer(cvt_writer&&) = default;
+    cvt_writer& operator=(cvt_writer&&) = default;
+    ~cvt_writer() = default;
+
+    void set_kernel(KernelType* kernel) { m_kernel = kernel; }
+
+    void reset(size_t) {}
+
+    char_type* put_buf(size_t len)
+    {
+        if (m_kernel == nullptr)
+            throw cvt_error("cvt_writer::put_buf fail, kernel is null.");
+        return m_kernel->device().put_buf(len);
+    }
+
+    void rollback(size_t len)
+    {
+        if (m_kernel == nullptr)
+            throw cvt_error("cvt_writer::rollback fail, kernel is null.");
+        m_kernel->device().put_rollback(len);
+    }
+
+    void commit() {}
+
+private:
+    KernelType* m_kernel;
 };
 }

--- a/test/cvt/cvt_io/test_root_cvt_io.cpp
+++ b/test/cvt/cvt_io/test_root_cvt_io.cpp
@@ -16,8 +16,8 @@ void test_root_cvt_mem_input_1()
     {
         obj.bos(); obj.main_cont_beg();
 
-        cvt_io<T> io;
-        auto reader = io.reader(obj, 1024);
+        cvt_reader<T> reader(&obj);
+        reader.reset(1024);
 
         auto [ptr, len] = reader.get_buf(3);
         VERIFY(len == 3);
@@ -51,8 +51,8 @@ void test_root_cvt_mem_input_2()
     {
         obj.bos(); obj.main_cont_beg();
 
-        cvt_io<T> io;
-        auto reader = io.reader(obj, 5);
+        cvt_reader<T> reader(&obj);
+        reader.reset(5);
 
         auto [ptr, len] = reader.get_buf(5);
         VERIFY(len == 5);
@@ -93,8 +93,8 @@ void test_root_cvt_mem_input_3()
 
         std::string res;
         {
-            cvt_io<T> io;
-            auto reader = io.reader(obj, 7);
+            cvt_reader<T> reader(&obj);
+            reader.reset(7);
 
             size_t cur = 0;
             size_t get_len = 1;
@@ -130,8 +130,8 @@ void test_root_cvt_mem_output_1()
         obj.bos(); obj.main_cont_beg();
 
         {
-            cvt_io<T> io;
-            auto writer = io.writer(obj, 1024);
+            cvt_writer<T> writer(&obj);
+            writer.reset(1024);
 
             auto ptr = writer.put_buf(3);
             std::string str = "123";
@@ -169,8 +169,8 @@ void test_root_cvt_mem_output_2()
         obj.bos(); obj.main_cont_beg();
 
         {
-            cvt_io<T> io;
-            auto writer = io.writer(obj, 1024);
+            cvt_writer<T> writer(&obj);
+            writer.reset(1024);
 
             auto ptr = writer.put_buf(5);
             std::string str = "123";
@@ -216,8 +216,8 @@ void test_root_cvt_mem_output_3()
             ref += 'a' + (i % 26);
 
         {
-            cvt_io<T> io;
-            auto writer = io.writer(obj, 10);
+            cvt_writer<T> writer(&obj);
+            writer.reset(10);
 
             size_t cur = 0;
             size_t get_len = 1;
@@ -260,8 +260,8 @@ void test_root_cvt_mem_saturate_input_1()
 
         std::string res;
         {
-            cvt_io<T> io;
-            auto reader = io.reader(obj, 7);
+            cvt_reader<T> reader(&obj);
+            reader.reset(7);
 
             size_t cur = 0;
             size_t get_len = 1;


### PR DESCRIPTION


- Replaced reference-based kernel access with pointer-based access in cvt_reader and cvt_writer.
- Moved buffer management into cvt_reader and cvt_writer or specialized them to use root_cvt's internal buffer.
- Removed cvt_io class in favor of direct use of reader/writer.
- Updated all converters (abs, code, zlib, chacha20, vigenere, root) to use the new reader/writer interface.
- Updated relevant tests.