### PR TITLE
Refactor: replace cvt_reader/cvt_writer pointer members with reference-based locals

### DIFF
--- a/include/cvt/abs_cvt.h
+++ b/include/cvt/abs_cvt.h
@@ -12,16 +12,15 @@ namespace IOv2
     {
         using char_type = typename KernelType::internal_type;
     public:
-        explicit cvt_reader(KernelType* kernel)
-            : m_kernel(kernel) {}
+        explicit cvt_reader(KernelType& kernel, std::vector<char_type>& buffer)
+            : m_kernel(kernel)
+            , m_buffer(buffer) {}
 
         cvt_reader(const cvt_reader&) = delete;
         cvt_reader& operator=(const cvt_reader&) = delete;
-        cvt_reader(cvt_reader&&) = default;
-        cvt_reader& operator=(cvt_reader&&) = default;
+        cvt_reader(cvt_reader&&) = delete;
+        cvt_reader& operator=(cvt_reader&&) = delete;
         ~cvt_reader() = default;
-
-        void set_kernel(KernelType* kernel) { m_kernel = kernel; }
 
         void reset(size_t buf_size)
         {
@@ -46,8 +45,6 @@ namespace IOv2
         template <bool Saturate = false>
         auto get_buf(size_t to_max)
         {
-            if (m_kernel == nullptr)
-                throw cvt_error("cvt_reader::get_buf fail, kernel is null.");
             if (to_max == 0)
                 throw cvt_error("cvt_reader::get_buf fail, read size cannot be zero.");
             if (to_max > m_buffer.size())
@@ -71,7 +68,7 @@ namespace IOv2
                 m_end_pos = rollback_size;
             }
             const size_t aim_size = to_max - rollback_size;
-            auto read_size = m_kernel->get(m_buffer.data() + m_end_pos, aim_size);
+            auto read_size = m_kernel.get(m_buffer.data() + m_end_pos, aim_size);
             m_end_pos += read_size;
 
             if constexpr (Saturate)
@@ -79,7 +76,7 @@ namespace IOv2
                 while (read_size < aim_size)
                 {
                     const size_t new_aim_size = aim_size - read_size;
-                    const auto new_read_size = m_kernel->get(m_buffer.data() + m_end_pos, new_aim_size);
+                    const auto new_read_size = m_kernel.get(m_buffer.data() + m_end_pos, new_aim_size);
                     if (new_read_size == 0)
                         throw cvt_error("get_buf<Saturate> fail: meet eos");
                     m_end_pos += new_read_size;
@@ -111,8 +108,8 @@ namespace IOv2
         }
 
     private:
-        KernelType* m_kernel;
-        std::vector<char_type> m_buffer;
+        KernelType& m_kernel;
+        std::vector<char_type>& m_buffer;
         size_t m_cur_pos = 0;
         size_t m_end_pos = 0;
     };
@@ -122,16 +119,15 @@ namespace IOv2
     {
         using char_type = typename KernelType::internal_type;
     public:
-        explicit cvt_writer(KernelType* kernel)
-            : m_kernel(kernel) {}
+        explicit cvt_writer(KernelType& kernel, std::vector<char_type>& buffer)
+            : m_kernel(kernel)
+            , m_buffer(buffer) {}
 
         cvt_writer(const cvt_writer&) = delete;
         cvt_writer& operator=(const cvt_writer&) = delete;
-        cvt_writer(cvt_writer&&) = default;
-        cvt_writer& operator=(cvt_writer&&) = default;
+        cvt_writer(cvt_writer&&) = delete;
+        cvt_writer& operator=(cvt_writer&&) = delete;
         ~cvt_writer() = default;
-
-        void set_kernel(KernelType* kernel) { m_kernel = kernel; }
 
         void reset(size_t buf_size)
         {
@@ -141,8 +137,6 @@ namespace IOv2
 
         char_type* put_buf(size_t len)
         {
-            if (m_kernel == nullptr)
-                throw cvt_error("cvt_writer::put_buf fail, kernel is null.");
             if (len == 0)
                 throw cvt_error("cvt_writer::put_buf fail, write size cannot be zero.");
             if (len > m_buffer.size())
@@ -151,7 +145,7 @@ namespace IOv2
             size_t remain = m_buffer.size() - m_prev_len;
             if (remain < len)
             {
-                m_kernel->put(m_buffer.data(), m_prev_len);
+                m_kernel.put(m_buffer.data(), m_prev_len);
                 remain = m_buffer.size();
                 m_prev_len = 0;
             }
@@ -172,18 +166,16 @@ namespace IOv2
 
         void commit()
         {
-            if (m_kernel == nullptr)
-                throw cvt_error("cvt_writer::commit fail, kernel is null.");
             if (m_prev_len != 0)
             {
-                m_kernel->put(m_buffer.data(), m_prev_len);
+                m_kernel.put(m_buffer.data(), m_prev_len);
                 m_prev_len = 0;
             }
         }
 
     private:
-        KernelType* m_kernel;
-        std::vector<char_type> m_buffer;
+        KernelType& m_kernel;
+        std::vector<char_type>& m_buffer;
         size_t m_prev_len = 0;
     };
 
@@ -206,28 +198,18 @@ namespace IOv2
 
     public:
         abs_cvt(KernelType kernel)
-            : m_kernel(std::move(kernel))
-            , m_reader(&m_kernel)
-            , m_writer(&m_kernel) {}
+            : m_kernel(std::move(kernel)) {}
 
         abs_cvt(const abs_cvt& val)
             : m_kernel(val.m_kernel)
             , m_io_status(val.m_io_status)
-            , m_is_bos_done(val.m_is_bos_done)
-            , m_reader(&m_kernel)
-            , m_writer(&m_kernel) {}
+            , m_is_bos_done(val.m_is_bos_done) {}
 
         abs_cvt(abs_cvt&& val)
             : m_kernel(std::move(val.m_kernel))
             , m_io_status(val.m_io_status)
             , m_is_bos_done(val.m_is_bos_done)
-            , m_reader(std::move(val.m_reader))
-            , m_writer(std::move(val.m_writer))
         {
-            m_reader.set_kernel(&m_kernel);
-            m_writer.set_kernel(&m_kernel);
-            val.m_reader.set_kernel(nullptr);
-            val.m_writer.set_kernel(nullptr);
             val.m_io_status = io_status::neutral;
             val.m_is_bos_done = false;
         }
@@ -253,12 +235,6 @@ namespace IOv2
                 val.m_io_status = io_status::neutral;
                 m_is_bos_done = val.m_is_bos_done;
                 val.m_is_bos_done = false;
-                m_reader = std::move(val.m_reader);
-                m_writer = std::move(val.m_writer);
-                m_reader.set_kernel(&m_kernel);
-                m_writer.set_kernel(&m_kernel);
-                val.m_reader.set_kernel(nullptr);
-                val.m_writer.set_kernel(nullptr);
             }
             return *this;
         }
@@ -318,17 +294,19 @@ namespace IOv2
     // optional methods
     public:
         size_t get(internal_type* to, size_t to_max)
-            requires requires(CurrentType& t, internal_type* data, size_t len) {
-                { t.get_main(data, len) } -> std::same_as<size_t>;
+            requires requires(CurrentType& t, cvt_reader<KernelType>& r, internal_type* data, size_t len) {
+                { t.get_main(r, data, len) } -> std::same_as<size_t>;
             }
         {
+            cvt_reader<KernelType> reader(m_kernel, m_tmp_io_buffer);
+
             if (!m_is_bos_done)
             {
                 if (to_max == 0) return 0;
 
                 constexpr size_t ext_size = sizeof(external_type);
 
-                m_reader.reset(s_bos_chunk);
+                reader.reset(s_bos_chunk);
                 char* dest_bytes = reinterpret_cast<char*>(to);
                 const char* dest_bytes_end = reinterpret_cast<const char*>(to + to_max);
 
@@ -337,7 +315,7 @@ namespace IOv2
                 {
                     const size_t units_to_read_now = std::min((size_t)((dest_bytes_end - dest_bytes) / ext_size), s_bos_chunk);
 
-                    const auto* src_buf = m_reader.template get_buf<true>(units_to_read_now);
+                    const auto* src_buf = reader.template get_buf<true>(units_to_read_now);
                     std::memcpy(dest_bytes, src_buf, units_to_read_now * ext_size);
                     dest_bytes += units_to_read_now * ext_size;
                 }
@@ -346,7 +324,7 @@ namespace IOv2
                 const size_t final_remainder_bytes = dest_bytes_end - dest_bytes;
                 if (final_remainder_bytes > 0)
                 {
-                    const auto* src_buf = m_reader.template get_buf<true>(1);
+                    const auto* src_buf = reader.template get_buf<true>(1);
                     std::memcpy(dest_bytes, src_buf, final_remainder_bytes);
                     dest_bytes += final_remainder_bytes;
                 }
@@ -362,15 +340,16 @@ namespace IOv2
                     else
                         throw cvt_error("abs_cvt::get fail: cannot switch to input mode");
                 }
-                return static_cast<CurrentType*>(this)->get_main(to, to_max);
+                return static_cast<CurrentType*>(this)->get_main(reader, to, to_max);
             }
         }
 
         void put(const internal_type* to, size_t to_size)
-            requires requires(CurrentType& t, const internal_type* data, size_t len) {
-                { t.put_main(data, len) } -> std::same_as<void>;
+            requires requires(CurrentType& t, cvt_writer<KernelType>& w, const internal_type* data, size_t len) {
+                { t.put_main(w, data, len) } -> std::same_as<void>;
             }
         {
+            cvt_writer<KernelType> writer(m_kernel, m_tmp_io_buffer);
             if (!m_is_bos_done)
             {
                 if (to_size == 0) return;
@@ -380,11 +359,11 @@ namespace IOv2
                 auto to_bytes = reinterpret_cast<const char*>(to);
                 auto to_bytes_end = reinterpret_cast<const char*>(to + to_size);
 
-                m_writer.reset(s_bos_chunk);
+                writer.reset(s_bos_chunk);
                 while (to_bytes + ext_size <= to_bytes_end)
                 {
                     auto dest_count = std::min<size_t>((to_bytes_end - to_bytes) / ext_size, s_bos_chunk);
-                    auto ptr = m_writer.put_buf( dest_count);
+                    auto ptr = writer.put_buf( dest_count);
                     std::memcpy(reinterpret_cast<char*>(ptr), to_bytes, dest_count * ext_size);
                     to_bytes += dest_count * ext_size;
                 }
@@ -395,12 +374,12 @@ namespace IOv2
                     // The modulo is logically redundant but helps the compiler's
                     // static analyzer prove the bound for memset size calculation.
                     size_t remaining = static_cast<size_t>(to_bytes_end - to_bytes) % ext_size;
-                    auto ptr = m_writer.put_buf( 1);
+                    auto ptr = writer.put_buf(1);
                     std::memcpy(reinterpret_cast<char*>(ptr), to_bytes, remaining);
                     std::memset(reinterpret_cast<char*>(ptr) + remaining, 0, ext_size - remaining);
                 }
 
-                m_writer.commit();
+                writer.commit();
             }
             else
             {
@@ -411,7 +390,7 @@ namespace IOv2
                     else
                         throw cvt_error("abs_cvt::put fail: cannot switch to output mode");
                 }
-                static_cast<CurrentType*>(this)->put_main(to, to_size);
+                static_cast<CurrentType*>(this)->put_main(writer, to, to_size);
             }
         }
 
@@ -457,7 +436,6 @@ namespace IOv2
         KernelType  m_kernel;
         io_status   m_io_status = io_status::neutral;
         bool        m_is_bos_done = false;
-        cvt_reader<KernelType> m_reader;
-        cvt_writer<KernelType> m_writer;
+        std::vector<external_type> m_tmp_io_buffer;
     };
 }

--- a/include/cvt/code_cvt.h
+++ b/include/cvt/code_cvt.h
@@ -325,14 +325,14 @@ public:
 
 // optional methods
 private:
-    void put_main(const internal_type* to, size_t to_size)
+    void put_main(cvt_writer<KernelType>& writer, const internal_type* to, size_t to_size)
         requires (cvt_cpt::support_put<KernelType>)
     {
-        this->m_writer.reset(s_max_buf_size);
+        writer.reset(s_max_buf_size);
         const size_t buf_len = m_cvt_kernel.epc();
         for (size_t i = 0; i < to_size; ++i)
         {
-            external_type* out_beg = this->m_writer.put_buf(buf_len);
+            external_type* out_beg = writer.put_buf(buf_len);
             external_type* out_next = out_beg;
 
             internal_type ch = *to++;
@@ -342,15 +342,15 @@ private:
 
             ++m_accu_len;
             if (out_next < out_beg + buf_len)
-                this->m_writer.rollback(out_beg + buf_len - out_next);
+                writer.rollback(out_beg + buf_len - out_next);
         }
-        this->m_writer.commit();
+        writer.commit();
     }
 
-    size_t get_main(internal_type* to, size_t to_max)
+    size_t get_main(cvt_reader<KernelType>& reader, internal_type* to, size_t to_max)
         requires (cvt_cpt::support_get<KernelType>)
     {
-        this->m_reader.reset(s_max_buf_size);
+        reader.reset(s_max_buf_size);
         size_t total_size = 0;
 
         size_t prev_rollback = 0;
@@ -362,7 +362,7 @@ private:
             if (dest_size > s_max_buf_size) [[unlikely]]
                 throw cvt_error("code_cvt::get fail, input sequence too long.");
 
-            auto [ptr, cur_size] = this->m_reader.get_buf(dest_size);
+            auto [ptr, cur_size] = reader.get_buf(dest_size);
             if (cur_size == prev_rollback)
             {
                 if (cur_size == 0) return total_size;
@@ -382,7 +382,7 @@ private:
             else
             {
                 prev_rollback = ptr + cur_size - ext_cur;
-                this->m_reader.rollback(prev_rollback);
+                reader.rollback(prev_rollback);
             }
         }
         return total_size;

--- a/include/cvt/comp/zlib_cvt.h
+++ b/include/cvt/comp/zlib_cvt.h
@@ -195,10 +195,11 @@ public:
             auto ret = inflateInit(&m_strm);
             if (ret != Z_OK) throw cvt_error("zlib_cvt::bos fail: Cannot initialize zlib.");
 
-            this->m_reader.reset(2);
+            cvt_reader<KernelType> bos_reader(this->m_kernel, this->m_tmp_io_buffer);
+            bos_reader.reset(2);
             const external_type* ptr = nullptr;
             if constexpr (cvt_cpt::support_get<KernelType>)
-                ptr = this->m_reader.template get_buf<true>(2);
+                ptr = bos_reader.template get_buf<true>(2);
             else throw cvt_error("zlib_cvt::bos fail: kernel does not support get.");
 
             m_strm.avail_in = 2;
@@ -225,8 +226,9 @@ public:
             auto ret = deflateInit(&m_strm, static_cast<int>(m_put_level));
             if (ret != Z_OK) throw cvt_error("zlib_cvt::bos fail: Cannot initialize zlib.");
 
-            this->m_writer.reset(3);
-            auto ptr = this->m_writer.put_buf(3);
+            cvt_writer<KernelType> bos_writer(this->m_kernel, this->m_tmp_io_buffer);
+            bos_writer.reset(3);
+            auto ptr = bos_writer.put_buf(3);
 
             m_strm.avail_in = 0;
             m_strm.next_in = nullptr;
@@ -237,8 +239,8 @@ public:
 
             if (m_strm.avail_out != 1) throw cvt_error("zlib_cvt::bos fail: Invalid zlib header");
 
-            this->m_writer.rollback(1);
-            this->m_writer.commit();
+            bos_writer.rollback(1);
+            bos_writer.commit();
 
             m_strm.avail_out = 0;
             m_strm.next_out = nullptr;
@@ -250,14 +252,14 @@ public:
 
 // optional methods
 private:
-    size_t get_main(internal_type* to, size_t to_max)
+    size_t get_main(cvt_reader<KernelType>& reader, internal_type* to, size_t to_max)
         requires (cvt_cpt::support_get<KernelType>)
     {
         // Note: We read one byte at a time intentionally. Decompression has
         // unpredictable expansion ratio - a few compressed bytes could expand
         // to overflow the output buffer. This keeps the code simple and correct.
         // The underlying converter already buffers, so this doesn't cause syscalls.
-        this->m_reader.reset(1);
+        reader.reset(1);
 
         constexpr size_t max_type_limit = std::numeric_limits<decltype(m_strm.avail_out)>::max();
         constexpr size_t max_chunk = max_type_limit - (max_type_limit % sizeof(internal_type));
@@ -273,7 +275,7 @@ private:
 
         while (m_strm.avail_out && ret != Z_STREAM_END)
         {
-            auto [ptr, len] = this->m_reader.get_buf(1);
+            auto [ptr, len] = reader.get_buf(1);
             if (len == 0) break;
             m_strm.next_in = reinterpret_cast<unsigned char*>(const_cast<char*>(ptr));
             m_strm.avail_in = 1;
@@ -293,7 +295,7 @@ private:
         return res / sizeof(internal_type);
     }
 
-    void put_main(const internal_type* _to, size_t to_size)
+    void put_main(cvt_writer<KernelType>& writer, const internal_type* _to, size_t to_size)
         requires (cvt_cpt::support_put<KernelType>)
     {
         constexpr size_t max_type_limit = std::numeric_limits<decltype(m_strm.avail_out)>::max();
@@ -301,7 +303,7 @@ private:
 
         auto to = reinterpret_cast<const unsigned char*>(_to);
 
-        this->m_writer.reset(CHUNK);
+        writer.reset(CHUNK);
         while (to_size > 0)
         {
             auto aim_output = (max_chunk / sizeof(internal_type) > to_size)
@@ -314,7 +316,7 @@ private:
                 m_strm.next_in = const_cast<unsigned char*>(to + write_size);
                 size_t cur_put_size = static_cast<size_t>(aim_output - write_size);
                 m_strm.avail_in = cur_put_size;
-                m_strm.next_out = reinterpret_cast<unsigned char*>(this->m_writer.put_buf(CHUNK));
+                m_strm.next_out = reinterpret_cast<unsigned char*>(writer.put_buf(CHUNK));
                 m_strm.avail_out = CHUNK;
 
                 auto ret = deflate(&m_strm, Z_NO_FLUSH);
@@ -322,12 +324,12 @@ private:
                 write_size += cur_put_size - m_strm.avail_in;
 
                 if (m_strm.avail_out)
-                    this->m_writer.rollback(m_strm.avail_out);
+                    writer.rollback(m_strm.avail_out);
             }
             to += aim_output;
             to_size -= aim_output / sizeof(internal_type);
         }
-        this->m_writer.commit();
+        writer.commit();
 
         m_strm.next_out = nullptr;
         m_strm.avail_out = 0;
@@ -346,21 +348,22 @@ public:
 
         if (m_sync_flush)
         {
-            this->m_writer.reset(CHUNK);
+            cvt_writer<KernelType> writer(this->m_kernel, this->m_tmp_io_buffer);
+            writer.reset(CHUNK);
             m_strm.next_in = nullptr;
             m_strm.avail_in = 0;
             while (true)
             {
-                m_strm.next_out = reinterpret_cast<unsigned char*>(this->m_writer.put_buf(CHUNK));
+                m_strm.next_out = reinterpret_cast<unsigned char*>(writer.put_buf(CHUNK));
                 m_strm.avail_out = CHUNK;
                 zerr("zlib_cvt::flush fail", deflate(&m_strm, Z_SYNC_FLUSH));
                 if (m_strm.avail_out)
                 {
-                    this->m_writer.rollback(m_strm.avail_out);
+                    writer.rollback(m_strm.avail_out);
                     break;
                 }
             }
-            this->m_writer.commit();
+            writer.commit();
             m_strm.next_out = nullptr;
             m_strm.avail_out = 0;
             m_strm.next_in = nullptr;
@@ -401,21 +404,22 @@ private:
         {
             if (BT::m_is_bos_done)
             {
-                this->m_writer.reset(CHUNK);
+                cvt_writer<KernelType> writer(this->m_kernel, this->m_tmp_io_buffer);
+                writer.reset(CHUNK);
                 m_strm.next_in = nullptr;
                 m_strm.avail_in = 0;
                 while (true)
                 {
-                    m_strm.next_out = reinterpret_cast<unsigned char*>(this->m_writer.put_buf(CHUNK));
+                    m_strm.next_out = reinterpret_cast<unsigned char*>(writer.put_buf(CHUNK));
                     m_strm.avail_out = CHUNK;
                     zerr("zlib_cvt::put_end fail", deflate(&m_strm, Z_FINISH));
                     if (m_strm.avail_out)
                     {
-                        this->m_writer.rollback(m_strm.avail_out);
+                        writer.rollback(m_strm.avail_out);
                         break;
                     }
                 }
-                this->m_writer.commit();
+                writer.commit();
                 deflateEnd(&m_strm);
             }
         }

--- a/include/cvt/crypt/chacha20_cvt.h
+++ b/include/cvt/crypt/chacha20_cvt.h
@@ -84,8 +84,9 @@ public:
         const size_t iv_len = m_cipher->default_iv_length();
         if (BT::m_io_status == io_status::input)
         {
-            this->m_reader.reset(iv_len);
-            auto ptr = this->m_reader.template get_buf<true>(iv_len);
+            cvt_reader<KernelType> reader(this->m_kernel, this->m_tmp_io_buffer);
+            reader.reset(iv_len);
+            auto ptr = reader.template get_buf<true>(iv_len);
 
             m_cipher->set_key(m_key);
             m_cipher->set_iv(reinterpret_cast<const uint8_t*>(ptr), iv_len);
@@ -93,13 +94,14 @@ public:
         else if (BT::m_io_status == io_status::output)
         {
             Botan::AutoSeeded_RNG rng;
-            this->m_writer.reset(iv_len);
-            auto ptr = this->m_writer.put_buf(iv_len);
+            cvt_writer<KernelType> writer(this->m_kernel, this->m_tmp_io_buffer);
+            writer.reset(iv_len);
+            auto ptr = writer.put_buf(iv_len);
             rng.randomize(reinterpret_cast<uint8_t*>(ptr), iv_len);
 
             m_cipher->set_key(m_key);
             m_cipher->set_iv(reinterpret_cast<const uint8_t*>(ptr), iv_len);
-            this->m_writer.commit();
+            writer.commit();
         }
         else
             throw cvt_error("chacha20_cvt::bos fail: neither in input nor output mode");
@@ -113,7 +115,7 @@ public:
 
 // optional methods
 private:
-    size_t get_main(internal_type* _to, size_t to_max)
+    size_t get_main(cvt_reader<KernelType>& reader, internal_type* _to, size_t to_max)
         requires (cvt_cpt::support_get<KernelType>)
     {
         constexpr size_t max_type_limit = std::numeric_limits<size_t>::max();
@@ -124,12 +126,12 @@ private:
 
         uint8_t* to = reinterpret_cast<uint8_t*>(_to);
 
-        this->m_reader.reset(block_size);
+        reader.reset(block_size);
         size_t res = 0;
         while (res != to_max)
         {
             size_t dest_size = std::min<size_t>(block_size, to_max - res);
-            auto [ptr, cur_len] = this->m_reader.get_buf(dest_size);
+            auto [ptr, cur_len] = reader.get_buf(dest_size);
             if (cur_len == 0) break;
             m_cipher->cipher(reinterpret_cast<const uint8_t*>(ptr), to, cur_len);
             to += cur_len;
@@ -141,7 +143,7 @@ private:
         return res / sizeof(internal_type);
     }
 
-    void put_main(const internal_type* _to, size_t to_size)
+    void put_main(cvt_writer<KernelType>& writer, const internal_type* _to, size_t to_size)
         requires (cvt_cpt::support_put<KernelType>)
     {
         constexpr size_t max_type_limit = std::numeric_limits<size_t>::max();
@@ -149,7 +151,7 @@ private:
 
         const uint8_t* to = reinterpret_cast<const uint8_t*>(_to);
 
-        this->m_writer.reset(block_size);
+        writer.reset(block_size);
         while (to_size > 0)
         {
             size_t aim_output = (max_chunk / sizeof(internal_type) > to_size)
@@ -159,14 +161,14 @@ private:
             while (to_i != aim_output)
             {
                 size_t dest_size = std::min<size_t>(block_size, aim_output - to_i);
-                auto ptr = this->m_writer.put_buf(dest_size);
+                auto ptr = writer.put_buf(dest_size);
                 m_cipher->cipher(to + to_i, reinterpret_cast<uint8_t*>(ptr), dest_size);
                 to_i += dest_size;
             }
             to += aim_output;
             to_size -= aim_output / sizeof(internal_type);
         }
-        this->m_writer.commit();
+        writer.commit();
     }
 private:
     std::unique_ptr<Botan::StreamCipher> m_cipher;

--- a/include/cvt/crypt/hash_cvt.h
+++ b/include/cvt/crypt/hash_cvt.h
@@ -163,7 +163,7 @@ public:
     
 // optional methods
 private:
-    void put_main(const internal_type* to, size_t to_size)
+    void put_main(cvt_writer<KernelType>& /*writer*/, const internal_type* to, size_t to_size)
     {
         m_has_main_cont = true;
         m_hash->update((const uint8_t*)to, to_size * sizeof(internal_type));

--- a/include/cvt/crypt/vigenere_cvt.h
+++ b/include/cvt/crypt/vigenere_cvt.h
@@ -73,15 +73,15 @@ public:
 
 // optional methods
 private:
-    size_t get_main(internal_type* to, size_t to_max)
+    size_t get_main(cvt_reader<KernelType>& reader, internal_type* to, size_t to_max)
         requires (cvt_cpt::support_get<KernelType>)
     {
         size_t total_count = 0;
-        this->m_reader.reset(s_buf_len);
+        reader.reset(s_buf_len);
         while (total_count != to_max)
         {
             const size_t dest_size = std::min(s_buf_len, to_max - total_count);
-            auto [ptr, cur_size] = this->m_reader.get_buf(dest_size);
+            auto [ptr, cur_size] = reader.get_buf(dest_size);
             if (cur_size == 0)
                 return total_count;
 
@@ -95,16 +95,16 @@ private:
         return total_count;
     }
 
-    void put_main(const internal_type* to, size_t to_size)
+    void put_main(cvt_writer<KernelType>& writer, const internal_type* to, size_t to_size)
         requires (cvt_cpt::support_put<KernelType>)
     {
-        this->m_writer.reset(s_buf_len);
+        writer.reset(s_buf_len);
 
         size_t total_count = 0;
         while (total_count != to_size)
         {
             const size_t dest_size = std::min(s_buf_len, to_size - total_count);
-            auto ptr = this->m_writer.put_buf(dest_size);
+            auto ptr = writer.put_buf(dest_size);
 
             for (size_t i = 0; i < dest_size; ++i)
             {
@@ -113,7 +113,7 @@ private:
             }
             total_count += dest_size;
         }
-        this->m_writer.commit();
+        writer.commit();
     }
 
 public:

--- a/include/cvt/root_cvt.h
+++ b/include/cvt/root_cvt.h
@@ -626,16 +626,14 @@ class cvt_reader<KernelType>
     using char_type = typename KernelType::internal_type;
 
 public:
-    explicit cvt_reader(KernelType* kernel)
+    explicit cvt_reader(KernelType& kernel, std::vector<char_type>&)
         : m_kernel(kernel) {}
 
     cvt_reader(const cvt_reader&) = delete;
     cvt_reader& operator=(const cvt_reader&) = delete;
-    cvt_reader(cvt_reader&&) = default;
-    cvt_reader& operator=(cvt_reader&&) = default;
+    cvt_reader(cvt_reader&&) = delete;
+    cvt_reader& operator=(cvt_reader&&) = delete;
     ~cvt_reader() = default;
-
-    void set_kernel(KernelType* kernel) { m_kernel = kernel; }
 
     void reset(size_t) {}
 
@@ -655,8 +653,6 @@ public:
     template <bool Saturate = false>
     auto get_buf(size_t to_max)
     {
-        if (m_kernel == nullptr)
-            throw cvt_error("cvt_reader::get_buf fail, kernel is null.");
         if (to_max == 0)
             throw cvt_error("cvt_reader::get_buf fail, read size cannot be zero.");
         if (to_max > KernelType::s_buffer_length)
@@ -664,48 +660,48 @@ public:
 
         if constexpr (dev_cpt::support_put<device_type>)
         {
-            if (m_kernel->m_io_status != io_status::input)
-                m_kernel->switch_to_get();
+            if (m_kernel.m_io_status != io_status::input)
+                m_kernel.switch_to_get();
         }
-        if (m_kernel->m_io_status != io_status::input)
+        if (m_kernel.m_io_status != io_status::input)
             throw cvt_error("cvt_reader::get_buf fail, invalid io status");
 
-        const size_t remain = m_kernel->m_buf_end - m_kernel->m_buf_cur;
+        const size_t remain = m_kernel.m_buf_end - m_kernel.m_buf_cur;
         // need to read, then read at most as it can
         if (remain < to_max)
         {
             if (remain != 0)
-                m_kernel->m_buf_end = std::copy(m_kernel->m_buf_cur, m_kernel->m_buf_end, m_kernel->m_buffer.data());
+                m_kernel.m_buf_end = std::copy(m_kernel.m_buf_cur, m_kernel.m_buf_end, m_kernel.m_buffer.data());
             else
-                m_kernel->m_buf_end = m_kernel->m_buffer.data();
+                m_kernel.m_buf_end = m_kernel.m_buffer.data();
 
-            m_kernel->m_buf_cur = m_kernel->m_buffer.data();
-            m_kernel->m_buf_end += m_kernel->m_device.dget(m_kernel->m_buf_end, KernelType::s_buffer_length - remain);
+            m_kernel.m_buf_cur = m_kernel.m_buffer.data();
+            m_kernel.m_buf_end += m_kernel.m_device.dget(m_kernel.m_buf_end, KernelType::s_buffer_length - remain);
         }
 
         if constexpr (Saturate)
         {
-            const auto aim_ptr = to_max + m_kernel->m_buf_cur;
-            while (m_kernel->m_buf_end < aim_ptr)
+            const auto aim_ptr = to_max + m_kernel.m_buf_cur;
+            while (m_kernel.m_buf_end < aim_ptr)
             {
-                auto new_size = m_kernel->m_device.dget(m_kernel->m_buf_end, aim_ptr - m_kernel->m_buf_end);
+                auto new_size = m_kernel.m_device.dget(m_kernel.m_buf_end, aim_ptr - m_kernel.m_buf_end);
                 if (new_size == 0)
                     throw cvt_error("get_buf<Saturate> fail: meet eos");
-                m_kernel->m_buf_end += new_size;
+                m_kernel.m_buf_end += new_size;
             }
         }
 
         if constexpr (!Saturate)
         {
-            auto res_len = std::min<size_t>(m_kernel->m_buf_end - m_kernel->m_buf_cur, to_max);
-            std::pair<const char_type*, size_t> res{m_kernel->m_buf_cur, res_len};
-            m_kernel->m_buf_cur += res_len;
+            auto res_len = std::min<size_t>(m_kernel.m_buf_end - m_kernel.m_buf_cur, to_max);
+            std::pair<const char_type*, size_t> res{m_kernel.m_buf_cur, res_len};
+            m_kernel.m_buf_cur += res_len;
             return res;
         }
         else
         {
-            const char_type* res = m_kernel->m_buf_cur;
-            m_kernel->m_buf_cur += to_max;
+            const char_type* res = m_kernel.m_buf_cur;
+            m_kernel.m_buf_cur += to_max;
             return res;
         }
     }
@@ -714,13 +710,13 @@ public:
     {
         if (len == 0)
             throw cvt_error("cvt_reader::rollback fail, length cannot be zero.");
-        if ((m_kernel == nullptr) || (m_kernel->m_buf_cur == nullptr) || (len > static_cast<size_t>(m_kernel->m_buf_cur - m_kernel->m_buffer.data())))
+        if ((m_kernel.m_buf_cur == nullptr) || (len > static_cast<size_t>(m_kernel.m_buf_cur - m_kernel.m_buffer.data())))
             throw cvt_error("cvt_reader::rollback fail, rollback length too large.");
-        m_kernel->m_buf_cur -= len;
+        m_kernel.m_buf_cur -= len;
     }
 
 private:
-    KernelType* m_kernel;
+    KernelType& m_kernel;
 };
 
 // cvt_writer specialization for root_cvt: directly use root_cvt's internal buffer
@@ -733,16 +729,14 @@ class cvt_writer<KernelType>
     using char_type = typename KernelType::internal_type;
 
 public:
-    explicit cvt_writer(KernelType* kernel)
+    explicit cvt_writer(KernelType& kernel, std::vector<char_type>&)
         : m_kernel(kernel) {}
 
     cvt_writer(const cvt_writer&) = delete;
     cvt_writer& operator=(const cvt_writer&) = delete;
-    cvt_writer(cvt_writer&&) = default;
-    cvt_writer& operator=(cvt_writer&&) = default;
+    cvt_writer(cvt_writer&&) = delete;
+    cvt_writer& operator=(cvt_writer&&) = delete;
     ~cvt_writer() = default;
-
-    void set_kernel(KernelType* kernel) { m_kernel = kernel; }
 
     void reset(size_t buf_size)
     {
@@ -753,8 +747,6 @@ public:
 
     char_type* put_buf(size_t len)
     {
-        if (m_kernel == nullptr)
-            throw cvt_error("cvt_writer::put_buf fail, kernel is null.");
         if (len == 0)
             throw cvt_error("cvt_writer::put_buf fail, write size cannot be zero.");
         if (len > m_buf_size)
@@ -762,39 +754,39 @@ public:
 
         if constexpr (dev_cpt::support_get<device_type>)
         {
-            if (m_kernel->m_io_status != io_status::output)
-                m_kernel->switch_to_put();
+            if (m_kernel.m_io_status != io_status::output)
+                m_kernel.switch_to_put();
         }
-        if (m_kernel->m_io_status != io_status::output)
+        if (m_kernel.m_io_status != io_status::output)
             throw cvt_error("cvt_writer::put_buf fail, invalid io status");
 
-        const size_t buf_used = m_kernel->m_buf_cur - m_kernel->m_buffer.data();
+        const size_t buf_used = m_kernel.m_buf_cur - m_kernel.m_buffer.data();
         const size_t remain = KernelType::s_buffer_length - buf_used;
         if (len < remain)
         {
-            auto res = m_kernel->m_buf_cur;
-            m_kernel->m_buf_cur += len;
+            auto res = m_kernel.m_buf_cur;
+            m_kernel.m_buf_cur += len;
             return res;
         }
 
-        m_kernel->m_device.dput(m_kernel->m_buffer.data(), buf_used);
-        m_kernel->m_buf_cur = m_kernel->m_buffer.data() + len;
-        return m_kernel->m_buffer.data();
+        m_kernel.m_device.dput(m_kernel.m_buffer.data(), buf_used);
+        m_kernel.m_buf_cur = m_kernel.m_buffer.data() + len;
+        return m_kernel.m_buffer.data();
     }
 
     void rollback(size_t len)
     {
         if (len == 0)
             throw cvt_error("cvt_writer::rollback fail, length cannot be zero.");
-        if ((m_kernel == nullptr) || (m_kernel->m_buf_cur == nullptr) || (len > static_cast<size_t>(m_kernel->m_buf_cur - m_kernel->m_buffer.data())))
+        if ((m_kernel.m_buf_cur == nullptr) || (len > static_cast<size_t>(m_kernel.m_buf_cur - m_kernel.m_buffer.data())))
             throw cvt_error("cvt_writer::rollback fail, rollback length too large.");
-        m_kernel->m_buf_cur -= len;
+        m_kernel.m_buf_cur -= len;
     }
 
     void commit() {}
 
 private:
-    KernelType* m_kernel;
+    KernelType& m_kernel;
     size_t m_buf_size = 0;
 };
 
@@ -809,16 +801,14 @@ class cvt_reader<KernelType>
     using char_type = typename KernelType::internal_type;
 
 public:
-    explicit cvt_reader(KernelType* kernel)
+    explicit cvt_reader(KernelType& kernel, std::vector<char_type>&)
         : m_kernel(kernel) {}
 
     cvt_reader(const cvt_reader&) = delete;
     cvt_reader& operator=(const cvt_reader&) = delete;
-    cvt_reader(cvt_reader&&) = default;
-    cvt_reader& operator=(cvt_reader&&) = default;
+    cvt_reader(cvt_reader&&) = delete;
+    cvt_reader& operator=(cvt_reader&&) = delete;
     ~cvt_reader() = default;
-
-    void set_kernel(KernelType* kernel) { m_kernel = kernel; }
 
     void reset(size_t) {}
 
@@ -828,20 +818,16 @@ public:
     template <bool Saturate = false>
     auto get_buf(size_t to_max)
     {
-        if (m_kernel == nullptr)
-            throw cvt_error("cvt_reader::get_buf fail, kernel is null.");
-        return m_kernel->device().template get_buf<Saturate>(to_max);
+        return m_kernel.device().template get_buf<Saturate>(to_max);
     }
 
     void rollback(size_t len)
     {
-        if (m_kernel == nullptr)
-            throw cvt_error("cvt_reader::rollback fail, kernel is null.");
-        m_kernel->device().get_rollback(len);
+        m_kernel.device().get_rollback(len);
     }
 
 private:
-    KernelType* m_kernel;
+    KernelType& m_kernel;
 };
 
 // cvt_writer specialization for mem_device: directly access device buffer
@@ -855,36 +841,30 @@ class cvt_writer<KernelType>
     using char_type = typename KernelType::internal_type;
 
 public:
-    explicit cvt_writer(KernelType* kernel)
+    explicit cvt_writer(KernelType& kernel, std::vector<char_type>&)
         : m_kernel(kernel) {}
 
     cvt_writer(const cvt_writer&) = delete;
     cvt_writer& operator=(const cvt_writer&) = delete;
-    cvt_writer(cvt_writer&&) = default;
-    cvt_writer& operator=(cvt_writer&&) = default;
+    cvt_writer(cvt_writer&&) = delete;
+    cvt_writer& operator=(cvt_writer&&) = delete;
     ~cvt_writer() = default;
-
-    void set_kernel(KernelType* kernel) { m_kernel = kernel; }
 
     void reset(size_t) {}
 
     char_type* put_buf(size_t len)
     {
-        if (m_kernel == nullptr)
-            throw cvt_error("cvt_writer::put_buf fail, kernel is null.");
-        return m_kernel->device().put_buf(len);
+        return m_kernel.device().put_buf(len);
     }
 
     void rollback(size_t len)
     {
-        if (m_kernel == nullptr)
-            throw cvt_error("cvt_writer::rollback fail, kernel is null.");
-        m_kernel->device().put_rollback(len);
+        m_kernel.device().put_rollback(len);
     }
 
     void commit() {}
 
 private:
-    KernelType* m_kernel;
+    KernelType& m_kernel;
 };
 }

--- a/test/cvt/cvt_io/test_root_cvt_io.cpp
+++ b/test/cvt/cvt_io/test_root_cvt_io.cpp
@@ -16,7 +16,8 @@ void test_root_cvt_mem_input_1()
     {
         obj.bos(); obj.main_cont_beg();
 
-        cvt_reader<T> reader(&obj);
+        std::vector<typename T::internal_type> buf;
+        cvt_reader<T> reader(obj, buf);
         reader.reset(1024);
 
         auto [ptr, len] = reader.get_buf(3);
@@ -51,7 +52,8 @@ void test_root_cvt_mem_input_2()
     {
         obj.bos(); obj.main_cont_beg();
 
-        cvt_reader<T> reader(&obj);
+        std::vector<typename T::internal_type> buf;
+        cvt_reader<T> reader(obj, buf);
         reader.reset(5);
 
         auto [ptr, len] = reader.get_buf(5);
@@ -93,7 +95,8 @@ void test_root_cvt_mem_input_3()
 
         std::string res;
         {
-            cvt_reader<T> reader(&obj);
+            std::vector<typename T::internal_type> buf;
+            cvt_reader<T> reader(obj, buf);
             reader.reset(7);
 
             size_t cur = 0;
@@ -130,7 +133,8 @@ void test_root_cvt_mem_output_1()
         obj.bos(); obj.main_cont_beg();
 
         {
-            cvt_writer<T> writer(&obj);
+            std::vector<typename T::internal_type> buf;
+            cvt_writer<T> writer(obj, buf);
             writer.reset(1024);
 
             auto ptr = writer.put_buf(3);
@@ -169,7 +173,8 @@ void test_root_cvt_mem_output_2()
         obj.bos(); obj.main_cont_beg();
 
         {
-            cvt_writer<T> writer(&obj);
+            std::vector<typename T::internal_type> buf;
+            cvt_writer<T> writer(obj, buf);
             writer.reset(1024);
 
             auto ptr = writer.put_buf(5);
@@ -216,7 +221,8 @@ void test_root_cvt_mem_output_3()
             ref += 'a' + (i % 26);
 
         {
-            cvt_writer<T> writer(&obj);
+            std::vector<typename T::internal_type> buf;
+            cvt_writer<T> writer(obj, buf);
             writer.reset(10);
 
             size_t cur = 0;
@@ -260,7 +266,8 @@ void test_root_cvt_mem_saturate_input_1()
 
         std::string res;
         {
-            cvt_reader<T> reader(&obj);
+            std::vector<typename T::internal_type> buf;
+            cvt_reader<T> reader(obj, buf);
             reader.reset(7);
 
             size_t cur = 0;


### PR DESCRIPTION


Previously, cvt_reader and cvt_writer were stored as members of abs_cvt, holding raw pointers to m_kernel. Every move/copy required manually calling set_kernel() to keep those pointers valid — a silent correctness hazard.

This refactor:
- Changes cvt_reader/cvt_writer to hold KernelType& and std::vector& (references)
- Removes m_reader/m_writer from abs_cvt; introduces m_tmp_io_buffer as the shared buffer
- Creates reader/writer as stack-local objects inside get()/put() per call
- Passes reader/writer explicitly to get_main()/put_main() in derived classes
- Removes set_kernel(), null-pointer checks, and move/copy pointer-rebinding logic
- Updates all specializations (root_cvt.h) and derived converters (code_cvt, zlib_cvt, chacha20_cvt, hash_cvt, vigenere_cvt) to the new interface
- Updates test_root_cvt_io.cpp to construct reader/writer with the new signature