### PR TITLE
fix: reject UTF-8 continuation bytes as sequence leads and surrogates

### DIFF
--- a/include/cvt/code_cvt.h
+++ b/include/cvt/code_cvt.h
@@ -189,6 +189,8 @@ struct codecvt_kernel<char8_t, TInt>
             }
             else if (c1 < 0xE0)
             {
+                if (c1 < 0xC0) [[unlikely]]
+                    return std::pair{false, static_cast<size_t>(to - ori_to)};
                 if (from_end - from < 2) break;
                 auto c2 = static_cast<uint32_t>(from[1]);
                 if ((c2 & 0xC0) != 0x80) [[unlikely]]
@@ -207,6 +209,8 @@ struct codecvt_kernel<char8_t, TInt>
                     return std::pair{false, static_cast<size_t>(to - ori_to)};
                 auto c = (c1 << 12) + (c2 << 6) + c3 - 0xE2080;
                 if (c < 0x800) return std::pair{false, static_cast<size_t>(to - ori_to)};
+                if (c >= 0xD800 && c <= 0xDFFF) [[unlikely]]
+                    return std::pair{false, static_cast<size_t>(to - ori_to)};
                 *to++ = c;
                 from += 3;
             }


### PR DESCRIPTION
Two correctness bugs in code_cvt.h's UTF-8 decoder:

1. Continuation bytes (0x80–0xBF) entering the 2-byte branch (c1 < 0xE0) caused uint32_t wraparound, silently producing codepoints in the range [0xFFFFF000, 0xFFFFFFFF] and bypassing the overlong check. Fix: add an explicit `if (c1 < 0xC0) [[unlikely]]` guard.

2. The 3-byte branch accepted surrogate codepoints (U+D800–U+DFFF), which are invalid in UTF-8 per RFC 3629. Fix: add an `if (c >= 0xD800 && c <= 0xDFFF) [[unlikely]]` guard after the overlong check.