### PR TITLE
test: improve file_device.h branch coverage

### DIFF
--- a/test/device/file_device/test_file_io_char.cpp
+++ b/test/device/file_device/test_file_io_char.cpp
@@ -680,3 +680,204 @@ void test_file_device_char_error_1()
 
     dump_info("Done\n");
 }
+
+void test_file_device_char_move()
+{
+    using namespace IOv2;
+    dump_info("Test file_device<char> move semantics...");
+    const char name[] = "move_test.txt";
+    file_guard g(name, "move content");
+    
+    basic_file_device<true, true, char> dev1(name);
+    VERIFY(dev1.is_open());
+    size_t len = dev1.dsize();
+    
+    // Move constructor
+    basic_file_device<true, true, char> dev2(std::move(dev1));
+    VERIFY(dev2.is_open());
+    VERIFY(dev2.dsize() == len);
+    VERIFY(!dev1.is_open());
+    
+    // Move assignment
+    basic_file_device<true, true, char> dev3;
+    dev3 = std::move(dev2);
+    VERIFY(dev3.is_open());
+    VERIFY(dev3.dsize() == len);
+    VERIFY(!dev2.is_open());
+
+    // Self-assignment
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wself-move"
+    dev3 = std::move(dev3);
+#pragma GCC diagnostic pop
+    VERIFY(dev3.is_open());
+    VERIFY(dev3.dsize() == len);
+    
+    dump_info("Done\n");
+}
+
+void test_file_device_char_more_errors()
+{
+    using namespace IOv2;
+    dump_info("Test file_device<char> more errors...");
+    
+    // Invalid seek in input mode
+    {
+        file_guard g("seek_err.txt", "123");
+        ifile_device<char> dev("seek_err.txt");
+        try {
+            dev.dseek(10); // Beyond end in In mode
+            VERIFY(false);
+        } catch (const device_error&) {}
+    }
+    
+    // dtell/dsize/dseek on closed file
+    {
+        ifile_device<char> dev;
+        try { (void)dev.dtell(); VERIFY(false); } catch (const device_error&) {}
+        try { (void)dev.dsize(); VERIFY(false); } catch (const device_error&) {}
+        try { dev.dseek(0); VERIFY(false); } catch (const device_error&) {}
+        try { dev.drseek(0); VERIFY(false); } catch (const device_error&) {}
+        try { (void)dev.deof(); VERIFY(true); } catch (...) { VERIFY(false); }
+    }
+    
+    // dput on closed file or null buffer
+    {
+        ofile_device<char> dev;
+        try { dev.dput("a", 1); VERIFY(false); } catch (const device_error&) {}
+        
+        file_guard g("put_err.txt");
+        ofile_device<char> dev2("put_err.txt");
+        try { dev2.dput(nullptr, 1); VERIFY(false); } catch (const device_error&) {}
+    }
+
+    // Invalid open modes
+    try {
+        basic_file_device<true, false, char> dev("test.txt", file_open_flag::trunc);
+        VERIFY(false);
+    } catch (const device_error&) {}
+
+    // dflush on closed file (should be no-op)
+    {
+        ofile_device<char> dev;
+        dev.dflush();
+    }
+
+    // drseek: offset > m_file_len  (covers the "invalid parameter" path in drseek)
+    {
+        file_guard g("drseek_err.txt", "hello"); // 5 bytes
+        ifile_device<char> dev("drseek_err.txt");
+        try { dev.drseek(1000); VERIFY(false); } catch (const device_error&) {}
+    }
+
+    // dseek: position exceeds INT64_MAX  (covers the overflow guard in dseek)
+    {
+        file_guard g("dseek_overflow.txt", "hi");
+        ofile_device<char> dev("dseek_overflow.txt");
+        try {
+            dev.dseek(std::numeric_limits<size_t>::max());
+            VERIFY(false);
+        } catch (const device_error&) {}
+    }
+
+    dump_info("Done\n");
+}
+
+void test_file_device_char_system_errors()
+{
+    using namespace IOv2;
+    dump_info("Test file_device<char> system errors...");
+
+    // dflush error on /dev/full
+    try {
+        ofile_device<char> dev("/dev/full");
+        dev.dput("some data", 9);
+        dev.dflush();
+    } catch (const device_error&) {
+        // Expected failure
+    }
+
+    // close error recovery
+    try {
+        ofile_device<char> dev("/dev/full");
+        dev.dput("some data", 9);
+        dev.close(); // Should throw because dflush fails, but file should still be closed
+    } catch (const device_error&) {
+        // Expected failure
+    }
+
+    dump_info("Done\n");
+}
+
+void test_file_device_char_open_modes()
+{
+    using namespace IOv2;
+    dump_info("Test file_device<char> open modes...");
+
+    const char name[] = "modes_test.txt";
+    
+    // noreplace
+    {
+        file_guard g(name);
+        ofile_device<char> dev(name, file_open_flag::noreplace);
+        VERIFY(dev.is_open());
+    }
+
+    // noreplace + binary
+    {
+        file_guard g(name);
+        ofile_device<char> dev(name, file_open_flag::noreplace | file_open_flag::binary);
+        VERIFY(dev.is_open());
+    }
+
+    // rw + trunc
+    {
+        file_guard g(name, "existing");
+        file_device<char> dev(name, file_open_flag::trunc);
+        VERIFY(dev.dsize() == 0);
+    }
+
+    // rw + binary
+    {
+        file_guard g(name, "existing");
+        file_device<char> dev(name, file_open_flag::binary);
+        VERIFY(dev.dsize() == 8);
+    }
+
+    // rw + trunc + binary
+    {
+        file_guard g(name, "existing");
+        file_device<char> dev(name, file_open_flag::trunc | file_open_flag::binary);
+        VERIFY(dev.dsize() == 0);
+    }
+
+    // rw + noreplace
+    {
+        file_guard g(name);
+        file_device<char> dev(name, file_open_flag::noreplace);
+        VERIFY(dev.is_open());
+    }
+
+    // rw + noreplace + binary
+    {
+        file_guard g(name);
+        file_device<char> dev(name, file_open_flag::noreplace | file_open_flag::binary);
+        VERIFY(dev.is_open());
+    }
+
+    // in + binary  → fopen_mode "rb"  (covers the previously-missed return "rb" path)
+    {
+        file_guard g(name, "existing");
+        ifile_device<char> dev(name, file_open_flag::binary);
+        VERIFY(dev.is_open());
+    }
+
+    // out + binary  → fopen_mode "wb"  (covers the previously-missed return "wb" path)
+    {
+        file_guard g(name);
+        ofile_device<char> dev(name, file_open_flag::binary);
+        VERIFY(dev.is_open());
+    }
+
+    dump_info("Done\n");
+}

--- a/test/device/file_device/test_file_io_char8_t.cpp
+++ b/test/device/file_device/test_file_io_char8_t.cpp
@@ -628,3 +628,143 @@ void test_file_device_char8_t_error_1()
 
     dump_info("Done\n");
 }
+
+void test_file_device_char8_t_move()
+{
+    using namespace IOv2;
+    dump_info("Test file_device<char8_t> move semantics...");
+    const char name[] = "move_test_u8.txt";
+    file_guard g(name, u8"move content");
+    
+    basic_file_device<true, true, char8_t> dev1(name);
+    VERIFY(dev1.is_open());
+    size_t len = dev1.dsize();
+    
+    // Move constructor
+    basic_file_device<true, true, char8_t> dev2(std::move(dev1));
+    VERIFY(dev2.is_open());
+    VERIFY(dev2.dsize() == len);
+    VERIFY(!dev1.is_open());
+    
+    // Move assignment
+    basic_file_device<true, true, char8_t> dev3;
+    dev3 = std::move(dev2);
+    VERIFY(dev3.is_open());
+    VERIFY(dev3.dsize() == len);
+    VERIFY(!dev2.is_open());
+
+    // Self-assignment
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wself-move"
+    dev3 = std::move(dev3);
+#pragma GCC diagnostic pop
+    VERIFY(dev3.is_open());
+    VERIFY(dev3.dsize() == len);
+    
+    dump_info("Done\n");
+}
+
+void test_file_device_char8_t_more_errors()
+{
+    using namespace IOv2;
+    dump_info("Test file_device<char8_t> more errors...");
+    
+    // Invalid seek in input mode
+    {
+        file_guard g("seek_err_u8.txt", u8"123");
+        ifile_device<char8_t> dev("seek_err_u8.txt");
+        try {
+            dev.dseek(10); // Beyond end in In mode
+            VERIFY(false);
+        } catch (const device_error&) {}
+    }
+    
+    // dtell/dsize/dseek on closed file
+    {
+        ifile_device<char8_t> dev;
+        try { (void)dev.dtell(); VERIFY(false); } catch (const device_error&) {}
+        try { (void)dev.dsize(); VERIFY(false); } catch (const device_error&) {}
+        try { dev.dseek(0); VERIFY(false); } catch (const device_error&) {}
+        try { dev.drseek(0); VERIFY(false); } catch (const device_error&) {}
+        try { (void)dev.deof(); VERIFY(true); } catch (...) { VERIFY(false); }
+    }
+
+    // dput on closed file or null buffer
+    {
+        ofile_device<char8_t> dev;
+        try { dev.dput(u8"a", 1); VERIFY(false); } catch (const device_error&) {}
+
+        file_guard g("put_err_u8.txt");
+        ofile_device<char8_t> dev2("put_err_u8.txt");
+        try { dev2.dput(nullptr, 1); VERIFY(false); } catch (const device_error&) {}
+    }
+
+    // Invalid open modes
+    try {
+        basic_file_device<true, false, char8_t> dev("test_u8.txt", file_open_flag::trunc);
+        VERIFY(false);
+    } catch (const device_error&) {}
+
+    // dflush on closed file
+    {
+        ofile_device<char8_t> dev;
+        dev.dflush();
+    }
+
+    // drseek: offset > m_file_len
+    {
+        file_guard g("drseek_err_u8.txt", u8"hello");
+        ifile_device<char8_t> dev("drseek_err_u8.txt");
+        try { dev.drseek(1000); VERIFY(false); } catch (const device_error&) {}
+    }
+
+    // dseek: position exceeds INT64_MAX
+    {
+        file_guard g("dseek_overflow_u8.txt", u8"hi");
+        ofile_device<char8_t> dev("dseek_overflow_u8.txt");
+        try {
+            dev.dseek(std::numeric_limits<size_t>::max());
+            VERIFY(false);
+        } catch (const device_error&) {}
+    }
+
+    dump_info("Done\n");
+}
+
+void test_file_device_char8_t_open_modes()
+{
+    using namespace IOv2;
+    dump_info("Test file_device<char8_t> open modes...");
+
+    const char name[] = "modes_test_u8.txt";
+    
+    // noreplace
+    {
+        file_guard g(name);
+        ofile_device<char8_t> dev(name, file_open_flag::noreplace);
+        VERIFY(dev.is_open());
+    }
+
+    // rw + noreplace
+    {
+        file_guard g(name);
+        file_device<char8_t> dev(name, file_open_flag::noreplace);
+        VERIFY(dev.is_open());
+    }
+
+    // in + binary  → fopen_mode "rb"
+    {
+        file_guard g(name, u8"existing");
+        ifile_device<char8_t> dev(name, file_open_flag::binary);
+        VERIFY(dev.is_open());
+    }
+
+    // out + binary  → fopen_mode "wb"
+    {
+        file_guard g(name);
+        ofile_device<char8_t> dev(name, file_open_flag::binary);
+        VERIFY(dev.is_open());
+    }
+
+    dump_info("Done\n");
+}

--- a/test/device/test_device.cpp
+++ b/test/device/test_device.cpp
@@ -76,6 +76,10 @@ void test_file_device_char_seek_7();
 void test_file_device_char_seek_8();
 void test_file_device_char_edge_cases();
 void test_file_device_char_error_1();
+void test_file_device_char_move();
+void test_file_device_char_more_errors();
+void test_file_device_char_system_errors();
+void test_file_device_char_open_modes();
 
 void test_file_device_char8_t_gen_1();
 void test_file_device_char8_t_close_1();
@@ -94,6 +98,9 @@ void test_file_device_char8_t_seek_6();
 void test_file_device_char8_t_seek_7();
 void test_file_device_char8_t_seek_8();
 void test_file_device_char8_t_error_1();
+void test_file_device_char8_t_move();
+void test_file_device_char8_t_more_errors();
+void test_file_device_char8_t_open_modes();
 
 int main()
 {
@@ -173,6 +180,10 @@ int main()
         test_file_device_char_seek_8();
         test_file_device_char_edge_cases();
         test_file_device_char_error_1();
+        test_file_device_char_move();
+        test_file_device_char_more_errors();
+        test_file_device_char_system_errors();
+        test_file_device_char_open_modes();
 
         test_file_device_char8_t_gen_1();
         test_file_device_char8_t_close_1();
@@ -191,6 +202,9 @@ int main()
         test_file_device_char8_t_seek_7();
         test_file_device_char8_t_seek_8();
         test_file_device_char8_t_error_1();
+        test_file_device_char8_t_move();
+        test_file_device_char8_t_more_errors();
+        test_file_device_char8_t_open_modes();
 
         return 0;
     }


### PR DESCRIPTION
Add missing test cases for basic_file_device<> to cover branches that were previously untouched:

- Binary-mode open for read-only ("rb") and write-only ("wb") variants
- drseek with offset > m_file_len (invalid parameter path)
- dseek with position > INT64_MAX (overflow guard path)
- dflush error path via /dev/full, including close() exception recovery
- Move constructor and move-assignment operator
- More error paths: null buffer, closed-file guards, invalid open modes

Register all new test functions in test_device.cpp.