### PR TITLE
test: further improve file_device.h coverage with system error simulation

### DIFF
--- a/test/device/file_device/test_file_io_char.cpp
+++ b/test/device/file_device/test_file_io_char.cpp
@@ -881,3 +881,73 @@ void test_file_device_char_open_modes()
 
     dump_info("Done\n");
 }
+
+void test_file_device_char_coverage_extra()
+{
+    using namespace IOv2;
+    dump_info("Test file_device<char> coverage extra...");
+
+    const char name[] = "extra_coverage_test.txt";
+
+    // 1. Missing Flag Combinations (fopen_mode)
+    // IsIn && IsOut + trunc | noreplace
+    {
+        file_guard g(name);
+        file_device<char> dev(name, file_open_flag::trunc | file_open_flag::noreplace);
+        VERIFY(dev.is_open());
+    }
+    // IsIn && IsOut + binary | trunc | noreplace
+    {
+        file_guard g(name);
+        file_device<char> dev(name, file_open_flag::binary | file_open_flag::trunc | file_open_flag::noreplace);
+        VERIFY(dev.is_open());
+    }
+    // IsOut + trunc | noreplace
+    {
+        file_guard g(name);
+        ofile_device<char> dev(name, file_open_flag::trunc | file_open_flag::noreplace);
+        VERIFY(dev.is_open());
+    }
+    // IsOut + binary | trunc | noreplace
+    {
+        file_guard g(name);
+        ofile_device<char> dev(name, file_open_flag::binary | file_open_flag::trunc | file_open_flag::noreplace);
+        VERIFY(dev.is_open());
+    }
+
+    // 2. Partial Write in dput (using /dev/full)
+    // Trigger line 490: throw device_error("file_device::dput fail: partial write");
+    try {
+        ofile_device<char> dev("/dev/full");
+        // Write a large buffer (1MB) to ensure we exceed internal FILE buffers
+        // and trigger a real syscall that fails on /dev/full.
+        std::string large_data(1024 * 1024, 'A');
+        dev.dput(large_data.data(), large_data.size());
+        VERIFY(false); 
+    } catch (const device_error&) {
+        // Expected: partial write or early failure
+    }
+
+    // 3. fseek failure in constructor (using /dev/stderr)
+    // /dev/stderr is usually a pipe or TTY, which is non-seekable (ESPIPE).
+    // Trigger line 169: throw device_error("cannot get file length...");
+    try {
+        ifile_device<char> dev("/dev/stderr");
+        // If constructor somehow succeeds (platform specific), try dseek
+        dev.dseek(1);
+    } catch (const device_error&) {
+        // Expected
+    }
+
+    // 4. try_open error path coverage
+    {
+        // Invalid mode for read-only (trunc) triggers exception in constructor,
+        // which try_open catches and returns as unexpected.
+        auto res = ifile_device<char>::try_open(name, file_open_flag::trunc);
+        VERIFY(!res);
+        VERIFY(!res.error().empty());
+    }
+
+    dump_info("Done\n");
+}
+

--- a/test/device/file_device/test_file_io_char8_t.cpp
+++ b/test/device/file_device/test_file_io_char8_t.cpp
@@ -614,15 +614,45 @@ void test_file_device_char8_t_error_1()
 
     // Case 4: Write mode with noreplace on existing file
     {
-        file_guard g("existing_file.txt", "content");
+        file_guard g("existing_file_u8.txt", u8"content");
         try
         {
-            basic_file_device<false, true, char8_t> fb("existing_file.txt", file_open_flag::noreplace);
+            basic_file_device<false, true, char8_t> fb("existing_file_u8.txt", file_open_flag::noreplace);
             VERIFY(false);
         }
         catch (const device_error&) {}
         
-        auto res = ofile_device<char8_t>::try_open("existing_file.txt", file_open_flag::noreplace);
+        auto res = ofile_device<char8_t>::try_open("existing_file_u8.txt", file_open_flag::noreplace);
+        VERIFY(!res);
+    }
+
+    dump_info("Done\n");
+}
+
+void test_file_device_char8_t_coverage_extra()
+{
+    using namespace IOv2;
+    dump_info("Test file_device<char8_t> coverage extra...");
+
+    const char name[] = "extra_coverage_test_u8.txt";
+
+    // 1. Missing Flag Combinations (fopen_mode)
+    // IsIn && IsOut + trunc | noreplace
+    {
+        file_guard g(name);
+        file_device<char8_t> dev(name, file_open_flag::trunc | file_open_flag::noreplace);
+        VERIFY(dev.is_open());
+    }
+    // IsOut + trunc | binary
+    {
+        file_guard g(name);
+        ofile_device<char8_t> dev(name, file_open_flag::trunc | file_open_flag::binary);
+        VERIFY(dev.is_open());
+    }
+
+    // 2. try_open error path coverage
+    {
+        auto res = ifile_device<char8_t>::try_open(name, file_open_flag::trunc);
         VERIFY(!res);
     }
 

--- a/test/device/test_device.cpp
+++ b/test/device/test_device.cpp
@@ -80,6 +80,7 @@ void test_file_device_char_move();
 void test_file_device_char_more_errors();
 void test_file_device_char_system_errors();
 void test_file_device_char_open_modes();
+void test_file_device_char_coverage_extra();
 
 void test_file_device_char8_t_gen_1();
 void test_file_device_char8_t_close_1();
@@ -101,6 +102,7 @@ void test_file_device_char8_t_error_1();
 void test_file_device_char8_t_move();
 void test_file_device_char8_t_more_errors();
 void test_file_device_char8_t_open_modes();
+void test_file_device_char8_t_coverage_extra();
 
 int main()
 {
@@ -184,6 +186,7 @@ int main()
         test_file_device_char_more_errors();
         test_file_device_char_system_errors();
         test_file_device_char_open_modes();
+        test_file_device_char_coverage_extra();
 
         test_file_device_char8_t_gen_1();
         test_file_device_char8_t_close_1();
@@ -205,6 +208,7 @@ int main()
         test_file_device_char8_t_move();
         test_file_device_char8_t_more_errors();
         test_file_device_char8_t_open_modes();
+        test_file_device_char8_t_coverage_extra();
 
         return 0;
     }


### PR DESCRIPTION
- Add tests using /dev/full to trigger partial write error paths in dput().
- Add tests using /dev/stderr to trigger seek failures in constructor and dseek().
- Add missing combinations of file open flags (noreplace, binary, trunc) for both char and char8_t.
- Integrate new coverage tests into the main test runner.