### PR TITLE
refactor: optimize internal IO in cvt classes and improve code quality

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
     - name: Run clang-tidy
       run: |
         # Use default clang-tidy from the image (which will be a recent version)
-        clang-tidy $(find include/common include/device -name '*.h') include/cvt/root_cvt.h \
+        clang-tidy $(find include/common include/device -name '*.h') include/cvt/root_cvt.h include/cvt/abs_cvt.h \
           --checks='bugprone-*,performance-*,modernize-*,cppcoreguidelines-*,-modernize-use-trailing-return-type,-cppcoreguidelines-avoid-magic-numbers,-cppcoreguidelines-pro-bounds-pointer-arithmetic,-cppcoreguidelines-pro-bounds-constant-array-index,-cppcoreguidelines-avoid-non-const-global-variables,-clang-diagnostic-pragma-once-outside-header' \
           --warnings-as-errors='bugprone-*' \
           -- -std=c++23 -x c++ -I include -I /usr/include -I /usr/include/botan-2

--- a/include/cvt/abs_cvt.h
+++ b/include/cvt/abs_cvt.h
@@ -706,7 +706,7 @@ namespace IOv2
          * IO status is reset to `neutral` and its BOS-done flag is reset to `false`.
          * @endif
          */
-        abs_cvt(abs_cvt&& val)
+        abs_cvt(abs_cvt&& val) noexcept(std::is_nothrow_move_constructible_v<KernelType>)
             : m_kernel(std::move(val.m_kernel))
             , m_io_status(val.m_io_status)
             , m_is_bos_done(val.m_is_bos_done)
@@ -749,7 +749,7 @@ namespace IOv2
          * object's IO status and BOS-done flag are both reset.
          * @endif
          */
-        abs_cvt& operator=(abs_cvt&& val)
+        abs_cvt& operator=(abs_cvt&& val) noexcept(std::is_nothrow_move_assignable_v<KernelType>)
         {
             if (this != &val)
             {
@@ -1056,7 +1056,9 @@ namespace IOv2
                 constexpr size_t ext_size = sizeof(external_type);
 
                 reader.reset(s_bos_chunk);
+                // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
                 char* dest_bytes = reinterpret_cast<char*>(to);
+                // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
                 const char* dest_bytes_end = reinterpret_cast<const char*>(to + to_max);
 
                 // BOS phase requires complete data: if the stream ends unexpectedly
@@ -1154,7 +1156,9 @@ namespace IOv2
 
                 constexpr size_t ext_size = sizeof(external_type);
 
+                // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
                 auto to_bytes = reinterpret_cast<const char*>(to);
+                // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
                 auto to_bytes_end = reinterpret_cast<const char*>(to + to_size);
 
                 // BOS phase writes complete external_type units. If the input data
@@ -1165,6 +1169,7 @@ namespace IOv2
                 {
                     auto dest_count = std::min<size_t>((to_bytes_end - to_bytes) / ext_size, s_bos_chunk);
                     auto ptr = writer.put_buf(dest_count);
+                    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
                     std::memcpy(reinterpret_cast<char*>(ptr), to_bytes, dest_count * ext_size);
                     to_bytes += dest_count * ext_size;
                 }
@@ -1176,7 +1181,9 @@ namespace IOv2
                     // static analyzer prove the bound for memset size calculation.
                     size_t remaining = static_cast<size_t>(to_bytes_end - to_bytes) % ext_size;
                     auto ptr = writer.put_buf(1);
+                    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
                     std::memcpy(reinterpret_cast<char*>(ptr), to_bytes, remaining);
+                    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
                     std::memset(reinterpret_cast<char*>(ptr) + remaining, 0, ext_size - remaining);
                 }
 
@@ -1233,7 +1240,7 @@ namespace IOv2
          * @lang{ZH} 当前流位置（从流起始处的 `external_type` 元素偏移量）。 @endif
          * @lang{EN} The current stream position as an offset in `external_type` elements from the start of the stream. @endif
          */
-        size_t tell() const
+        [[nodiscard]] size_t tell() const
             requires (default_positioning && cvt_cpt::support_positioning<KernelType>)
         {
             return m_kernel.tell();
@@ -1334,6 +1341,7 @@ namespace IOv2
         }
 
     protected:
+        // NOLINTBEGIN(cppcoreguidelines-non-private-member-variables-in-classes)
         /** @lang{ZH} 底层 IO 转换核心，持有对底层设备的所有权。 @endif
          *  @lang{EN} The underlying IO conversion kernel, which owns the underlying device. @endif */
         KernelType  m_kernel;
@@ -1360,7 +1368,9 @@ namespace IOv2
          *  Set to `true` by `main_cont_beg()`; reset to `false` by `detach()` and `attach()`.
          *  @endif */
         bool        m_is_bos_done = false;
+        // NOLINTEND(cppcoreguidelines-non-private-member-variables-in-classes)
 
+    private:
         /** @lang{ZH}
          *  临时 IO 缓冲区，供 `cvt_reader` 和 `cvt_writer` 在每次 `get`/`put` 调用时共用。
          *  缓冲区大小在首次使用时由 `reset()` 按需设置。

--- a/include/cvt/comp/zlib_cvt.h
+++ b/include/cvt/comp/zlib_cvt.h
@@ -34,6 +34,7 @@ public:
 
 private:
     constexpr static unsigned CHUNK = std::max<unsigned>(16, sizeof(internal_type));
+    constexpr static size_t zlib_header_size = 2;
 
 public:
     zlib_cvt(KernelType kernel, unsigned put_level = 6)
@@ -187,63 +188,63 @@ public:
         BT::bos();
         if (BT::m_io_status == io_status::input)
         {
-            m_strm.zalloc = Z_NULL;
-            m_strm.zfree = Z_NULL;
-            m_strm.opaque = Z_NULL;
-            m_strm.avail_in = 0;
-            m_strm.next_in = Z_NULL;
-            auto ret = inflateInit(&m_strm);
-            if (ret != Z_OK) throw cvt_error("zlib_cvt::bos fail: Cannot initialize zlib.");
-
-            cvt_reader<KernelType> bos_reader(this->m_kernel, this->m_tmp_io_buffer);
-            bos_reader.reset(2);
-            const external_type* ptr = nullptr;
             if constexpr (cvt_cpt::support_get<KernelType>)
-                ptr = bos_reader.template get_buf<true>(2);
-            else throw cvt_error("zlib_cvt::bos fail: kernel does not support get.");
+            {
+                m_strm.zalloc = Z_NULL;
+                m_strm.zfree = Z_NULL;
+                m_strm.opaque = Z_NULL;
+                m_strm.avail_in = 0;
+                m_strm.next_in = Z_NULL;
+                auto ret = inflateInit(&m_strm);
+                if (ret != Z_OK) throw cvt_error("zlib_cvt::bos fail: Cannot initialize zlib.");
 
-            m_strm.avail_in = 2;
-            m_strm.next_in = reinterpret_cast<unsigned char*>(const_cast<external_type*>(ptr));
-            
-            unsigned char ch;
-            m_strm.avail_out = 1;
-            m_strm.next_out = &ch;
-            
-            ret = inflate(&m_strm, Z_NO_FLUSH);
-            zerr("zlib_cvt::bos fail", ret);
-            
-            if ((m_strm.avail_in != 0) || (m_strm.avail_out != 1)) throw cvt_error("zlib_cvt::bos fail: Invalid zlib header");
-            m_strm.next_in = nullptr;
-            m_strm.avail_out = 0;
-            m_strm.next_out = nullptr;
+                external_type header_buf[zlib_header_size];
+                [[maybe_unused]] const size_t n = BT::m_kernel.get(header_buf, zlib_header_size);
+                assert(n == zlib_header_size);
+
+                m_strm.avail_in = zlib_header_size;
+                m_strm.next_in = reinterpret_cast<unsigned char*>(header_buf);
+
+                unsigned char ch;
+                m_strm.avail_out = 1;
+                m_strm.next_out = &ch;
+
+                ret = inflate(&m_strm, Z_NO_FLUSH);
+                zerr("zlib_cvt::bos fail", ret);
+
+                if ((m_strm.avail_in != 0) || (m_strm.avail_out != 1)) throw cvt_error("zlib_cvt::bos fail: Invalid zlib header");
+                m_strm.next_in = nullptr;
+                m_strm.avail_out = 0;
+                m_strm.next_out = nullptr;
+            }
         }
         else if (BT::m_io_status == io_status::output)
         {
-            m_strm.zalloc = Z_NULL;
-            m_strm.zfree = Z_NULL;
-            m_strm.opaque = Z_NULL;
+            if constexpr (cvt_cpt::support_put<KernelType>)
+            {
+                m_strm.zalloc = Z_NULL;
+                m_strm.zfree = Z_NULL;
+                m_strm.opaque = Z_NULL;
 
-            auto ret = deflateInit(&m_strm, static_cast<int>(m_put_level));
-            if (ret != Z_OK) throw cvt_error("zlib_cvt::bos fail: Cannot initialize zlib.");
+                auto ret = deflateInit(&m_strm, static_cast<int>(m_put_level));
+                if (ret != Z_OK) throw cvt_error("zlib_cvt::bos fail: Cannot initialize zlib.");
 
-            cvt_writer<KernelType> bos_writer(this->m_kernel, this->m_tmp_io_buffer);
-            bos_writer.reset(3);
-            auto ptr = bos_writer.put_buf(3);
+                external_type header_buf[zlib_header_size + 1];
 
-            m_strm.avail_in = 0;
-            m_strm.next_in = nullptr;
-            m_strm.avail_out = 3;
-            m_strm.next_out = reinterpret_cast<unsigned char*>(ptr);
-            ret = deflate(&m_strm, Z_NO_FLUSH);
-            assert(ret != Z_STREAM_ERROR);
+                m_strm.avail_in = 0;
+                m_strm.next_in = nullptr;
+                m_strm.avail_out = zlib_header_size + 1;
+                m_strm.next_out = reinterpret_cast<unsigned char*>(header_buf);
+                ret = deflate(&m_strm, Z_NO_FLUSH);
+                assert(ret != Z_STREAM_ERROR);
 
-            if (m_strm.avail_out != 1) throw cvt_error("zlib_cvt::bos fail: Invalid zlib header");
+                if (m_strm.avail_out != 1) throw cvt_error("zlib_cvt::bos fail: Invalid zlib header");
 
-            bos_writer.rollback(1);
-            bos_writer.commit();
+                BT::m_kernel.put(header_buf, zlib_header_size);
 
-            m_strm.avail_out = 0;
-            m_strm.next_out = nullptr;
+                m_strm.avail_out = 0;
+                m_strm.next_out = nullptr;
+            }
         }
         else
             throw cvt_error("zlib_cvt::bos fail: invalid response value.");
@@ -348,22 +349,20 @@ public:
 
         if (m_sync_flush)
         {
-            cvt_writer<KernelType> writer(this->m_kernel, this->m_tmp_io_buffer);
-            writer.reset(CHUNK);
+            external_type local_buf[CHUNK];
             m_strm.next_in = nullptr;
             m_strm.avail_in = 0;
             while (true)
             {
-                m_strm.next_out = reinterpret_cast<unsigned char*>(writer.put_buf(CHUNK));
+                m_strm.next_out = reinterpret_cast<unsigned char*>(local_buf);
                 m_strm.avail_out = CHUNK;
                 zerr("zlib_cvt::flush fail", deflate(&m_strm, Z_SYNC_FLUSH));
+                const size_t written = CHUNK - m_strm.avail_out;
+                if (written > 0)
+                    BT::m_kernel.put(local_buf, written);
                 if (m_strm.avail_out)
-                {
-                    writer.rollback(m_strm.avail_out);
                     break;
-                }
             }
-            writer.commit();
             m_strm.next_out = nullptr;
             m_strm.avail_out = 0;
             m_strm.next_in = nullptr;
@@ -404,22 +403,20 @@ private:
         {
             if (BT::m_is_bos_done)
             {
-                cvt_writer<KernelType> writer(this->m_kernel, this->m_tmp_io_buffer);
-                writer.reset(CHUNK);
+                external_type local_buf[CHUNK];
                 m_strm.next_in = nullptr;
                 m_strm.avail_in = 0;
                 while (true)
                 {
-                    m_strm.next_out = reinterpret_cast<unsigned char*>(writer.put_buf(CHUNK));
+                    m_strm.next_out = reinterpret_cast<unsigned char*>(local_buf);
                     m_strm.avail_out = CHUNK;
                     zerr("zlib_cvt::put_end fail", deflate(&m_strm, Z_FINISH));
+                    const size_t written = CHUNK - m_strm.avail_out;
+                    if (written > 0)
+                        BT::m_kernel.put(local_buf, written);
                     if (m_strm.avail_out)
-                    {
-                        writer.rollback(m_strm.avail_out);
                         break;
-                    }
                 }
-                writer.commit();
                 deflateEnd(&m_strm);
             }
         }

--- a/include/cvt/crypt/chacha20_cvt.h
+++ b/include/cvt/crypt/chacha20_cvt.h
@@ -82,26 +82,31 @@ public:
     {
         BT::bos();
         const size_t iv_len = m_cipher->default_iv_length();
+        std::vector<external_type> iv_buf(iv_len);
+
         if (BT::m_io_status == io_status::input)
         {
-            cvt_reader<KernelType> reader(this->m_kernel, this->m_tmp_io_buffer);
-            reader.reset(iv_len);
-            auto ptr = reader.template get_buf<true>(iv_len);
+            if constexpr (cvt_cpt::support_get<KernelType>)
+            {
+                [[maybe_unused]] const size_t n = BT::m_kernel.get(iv_buf.data(), iv_len);
+                assert(n == iv_len);
 
-            m_cipher->set_key(m_key);
-            m_cipher->set_iv(reinterpret_cast<const uint8_t*>(ptr), iv_len);
+                m_cipher->set_key(m_key);
+                m_cipher->set_iv(reinterpret_cast<const uint8_t*>(iv_buf.data()), iv_len);
+            }
         }
         else if (BT::m_io_status == io_status::output)
         {
-            Botan::AutoSeeded_RNG rng;
-            cvt_writer<KernelType> writer(this->m_kernel, this->m_tmp_io_buffer);
-            writer.reset(iv_len);
-            auto ptr = writer.put_buf(iv_len);
-            rng.randomize(reinterpret_cast<uint8_t*>(ptr), iv_len);
+            if constexpr (cvt_cpt::support_put<KernelType>)
+            {
+                Botan::AutoSeeded_RNG rng;
+                rng.randomize(reinterpret_cast<uint8_t*>(iv_buf.data()), iv_len);
 
-            m_cipher->set_key(m_key);
-            m_cipher->set_iv(reinterpret_cast<const uint8_t*>(ptr), iv_len);
-            writer.commit();
+                m_cipher->set_key(m_key);
+                m_cipher->set_iv(reinterpret_cast<const uint8_t*>(iv_buf.data()), iv_len);
+
+                BT::m_kernel.put(iv_buf.data(), iv_len);
+            }
         }
         else
             throw cvt_error("chacha20_cvt::bos fail: neither in input nor output mode");


### PR DESCRIPTION
- Refactor zlib_cvt and chacha20_cvt to use kernel get/put directly in bos/flush/put_end
- Add noexcept and [[nodiscard]] to abs_cvt
- Add clang-tidy suppressions and update CI workflow