### PR TITLE
fix(cvt): add missing direct includes and replace raw-pointer overloads with string_view

### DIFF
--- a/include/cvt/code_cvt.h
+++ b/include/cvt/code_cvt.h
@@ -4,12 +4,16 @@
 #include <cvt/abs_cvt.h>
 #include <cvt/cvt_concepts.h>
 
+#include <algorithm>
 #include <climits>
 #include <cstdint>
+#include <cstdlib>
+#include <cwchar>
 #include <functional>
 #include <limits>
 #include <string>
 #include <type_traits>
+#include <utility>
 
 namespace IOv2
 {

--- a/include/cvt/code_cvt_stdio.h
+++ b/include/cvt/code_cvt_stdio.h
@@ -2,6 +2,7 @@
 #include <cvt/code_cvt.h>
 
 #include <string>
+#include <utility>
 
 namespace IOv2
 {

--- a/include/cvt/cvt_facilities.h
+++ b/include/cvt/cvt_facilities.h
@@ -5,6 +5,7 @@
 
 #include <array>
 #include <string>
+#include <string_view>
 
 namespace IOv2
 {
@@ -27,11 +28,10 @@ namespace IOv2
         return res;
     }
 
-    inline std::u32string to_u32string(const char* val, const std::string& locale_name)
+    inline std::u32string to_u32string(std::string_view val, const std::string& locale_name)
     {
-        if (val == nullptr) [[unlikely]] return {};
         using cvt_type = code_cvt<rb_root_cvt<mem_device<char>>, char32_t>;
-        cvt_type tmp_cvt(rb_root_cvt{mem_device(val)}, locale_name);
+        cvt_type tmp_cvt(rb_root_cvt{mem_device(std::string(val))}, locale_name);
         tmp_cvt.bos();
         tmp_cvt.main_cont_beg();
 
@@ -47,11 +47,10 @@ namespace IOv2
         return res;
     }
 
-    inline std::u32string to_u32string(const char8_t* val)
+    inline std::u32string to_u32string(std::u8string_view val)
     {
-        if (val == nullptr) [[unlikely]] return {};
         using cvt_type = code_cvt<rb_root_cvt<mem_device<char8_t>>, char32_t>;
-        cvt_type tmp_cvt(rb_root_cvt{mem_device(val)});
+        cvt_type tmp_cvt(rb_root_cvt{mem_device(std::u8string(val))});
         tmp_cvt.bos();
         tmp_cvt.main_cont_beg();
 


### PR DESCRIPTION


- code_cvt.h: directly include <algorithm>, <cstdlib>, <cwchar>, <utility>
  for std::max/min, MB_CUR_MAX/mbtowc, mbstate_t/wcrtomb/mbrtowc/mbsinit,
  and std::move/forward/pair/declval (previously relied on transitive includes)
- code_cvt_stdio.h: directly include <utility> for std::move/forward
- cvt_facilities.h: replace to_u32string(const char*, locale) and to_u32string(const char8_t*) with string_view overloads; remove dead nullptr guards that all call sites already rule out before calling