### PR TITLE
test(code_cvt): achieve 93.6% line coverage for code_cvt.h

### DIFF
--- a/test/cvt/code_cvt/code_cvt_mem_char8_t.cpp
+++ b/test/cvt/code_cvt/code_cvt_mem_char8_t.cpp
@@ -1050,3 +1050,296 @@ void test_code_cvt_mem_char8_t_io_2()
 
     dump_info("Done\n");
 }
+
+// Covers line 480 (char8_t::is_state_dep), lines 531-532 (out_helper 2-byte),
+// and lines 613-619 (in_helper 2-byte success path).
+void test_code_cvt_mem_char8_t_gen_6()
+{
+    using namespace IOv2;
+    dump_info("Test code_cvt<memory<char8_t>> general case 6 (2-byte UTF-8)...");
+
+    // Direct kernel instantiation: covers is_state_dep() (line 480)
+    {
+        codecvt_kernel<char8_t, char32_t> k;
+        VERIFY(!k.is_state_dep());
+    }
+
+    // é=U+00E9={0xC3,0xA9}, ñ=U+00F1={0xC3,0xB1}, µ=U+00B5={0xC2,0xB5}
+    std::u8string e_lit;
+    e_lit += char8_t(0xC3); e_lit += char8_t(0xA9);
+    e_lit += char8_t(0xC3); e_lit += char8_t(0xB1);
+    e_lit += char8_t(0xC2); e_lit += char8_t(0xB5);
+    e_lit += char8_t(0x41);  // 'A'
+    std::u32string i_lit = { U'é', U'ñ', U'µ', U'A' };
+
+    auto helper_get = [&](auto& obj) {
+        if (obj.bos() != io_status::input)
+            throw std::runtime_error("test_code_cvt_mem_char8_t_gen_6: bos fail");
+        obj.main_cont_beg();
+        std::u32string out(4, 0);
+        if (obj.get(out.data(), 4) != 4)
+            throw std::runtime_error("test_code_cvt_mem_char8_t_gen_6: get count fail");
+        if (out != i_lit)
+            throw std::runtime_error("test_code_cvt_mem_char8_t_gen_6: get content fail");
+    };
+
+    auto helper_put = [&](auto& obj) {
+        if (obj.bos() != io_status::output)
+            throw std::runtime_error("test_code_cvt_mem_char8_t_gen_6: bos fail");
+        obj.main_cont_beg();
+        obj.put(i_lit.data(), i_lit.size());
+        obj.flush();
+        if (obj.device().str() != e_lit)
+            throw std::runtime_error("test_code_cvt_mem_char8_t_gen_6: put content fail");
+    };
+
+    using CheckType = code_cvt<rb_root_cvt<mem_device<char8_t>>, char32_t>;
+
+    CheckType obj1{rb_root_cvt{mem_device(e_lit)}};
+    helper_get(obj1);
+    runtime_cvt obj1r{CheckType{rb_root_cvt{mem_device(e_lit)}}};
+    helper_get(obj1r);
+
+    CheckType obj2{rb_root_cvt{mem_device(std::u8string{})}};
+    helper_put(obj2);
+    runtime_cvt obj2r{CheckType{rb_root_cvt{mem_device(std::u8string{})}}};
+    helper_put(obj2r);
+
+    dump_info("Done\n");
+}
+
+// Covers lines 540-548 (out_helper 4-byte) and lines 635, 637-646
+// (in_helper 4-byte success path).
+void test_code_cvt_mem_char8_t_gen_7()
+{
+    using namespace IOv2;
+    dump_info("Test code_cvt<memory<char8_t>> general case 7 (4-byte UTF-8)...");
+
+    // 😀=U+1F600={0xF0,0x9F,0x98,0x80}, 💩=U+1F4A9={0xF0,0x9F,0x92,0xA9}
+    std::u8string e_lit;
+    e_lit += char8_t(0xF0); e_lit += char8_t(0x9F);
+    e_lit += char8_t(0x98); e_lit += char8_t(0x80);
+    e_lit += char8_t(0xF0); e_lit += char8_t(0x9F);
+    e_lit += char8_t(0x92); e_lit += char8_t(0xA9);
+    e_lit += char8_t(0x42);  // 'B'
+    std::u32string i_lit = { U'\U0001F600', U'\U0001F4A9', U'B' };
+
+    auto helper_get = [&](auto& obj) {
+        if (obj.bos() != io_status::input)
+            throw std::runtime_error("test_code_cvt_mem_char8_t_gen_7: bos fail");
+        obj.main_cont_beg();
+        std::u32string out(3, 0);
+        if (obj.get(out.data(), 3) != 3)
+            throw std::runtime_error("test_code_cvt_mem_char8_t_gen_7: get count fail");
+        if (out != i_lit)
+            throw std::runtime_error("test_code_cvt_mem_char8_t_gen_7: get content fail");
+    };
+
+    auto helper_put = [&](auto& obj) {
+        if (obj.bos() != io_status::output)
+            throw std::runtime_error("test_code_cvt_mem_char8_t_gen_7: bos fail");
+        obj.main_cont_beg();
+        obj.put(i_lit.data(), i_lit.size());
+        obj.flush();
+        if (obj.device().str() != e_lit)
+            throw std::runtime_error("test_code_cvt_mem_char8_t_gen_7: put content fail");
+    };
+
+    using CheckType = code_cvt<rb_root_cvt<mem_device<char8_t>>, char32_t>;
+
+    CheckType obj1{rb_root_cvt{mem_device(e_lit)}};
+    helper_get(obj1);
+    runtime_cvt obj1r{CheckType{rb_root_cvt{mem_device(e_lit)}}};
+    helper_get(obj1r);
+
+    CheckType obj2{rb_root_cvt{mem_device(std::u8string{})}};
+    helper_put(obj2);
+    runtime_cvt obj2r{CheckType{rb_root_cvt{mem_device(std::u8string{})}}};
+    helper_put(obj2r);
+
+    dump_info("Done\n");
+}
+
+// Covers line 525 (out_helper surrogate rejected), lines 547-548
+// (out_helper > 0x10FFFF rejected), and line 926 (put encoding error throw).
+void test_code_cvt_mem_char8_t_put_err_1()
+{
+    using namespace IOv2;
+    dump_info("Test code_cvt<memory<char8_t>>::put encoding error case 1...");
+
+    using CheckType = code_cvt<rb_root_cvt<mem_device<char8_t>>, char32_t>;
+
+    auto make_obj = [] {
+        return CheckType{rb_root_cvt{mem_device(std::u8string{})}};
+    };
+
+    auto try_put = [](auto& obj, char32_t ch) {
+        if (obj.bos() != io_status::output)
+            throw std::runtime_error("test_code_cvt_mem_char8_t_put_err_1: bos fail");
+        obj.main_cont_beg();
+        try {
+            obj.put(&ch, 1);
+            throw std::runtime_error("test_code_cvt_mem_char8_t_put_err_1: expected throw");
+        } catch (const cvt_error&) {}
+    };
+
+    // Surrogate U+D800 → line 525 → line 926
+    { auto o = make_obj(); try_put(o, static_cast<char32_t>(0xD800U)); }
+    // Surrogate U+DFFF → line 525 → line 926
+    { auto o = make_obj(); try_put(o, static_cast<char32_t>(0xDFFFU)); }
+    // > 0x10FFFF → lines 547-548 → line 926
+    { auto o = make_obj(); try_put(o, static_cast<char32_t>(0x110000U)); }
+
+    dump_info("Done\n");
+}
+
+// Covers lines 610-611 (invalid start byte), 614-615 (bad 2-byte continuation),
+// 617 (overlong 2-byte), 626-627 (bad 3-byte continuation), 631 (surrogate in 3-byte),
+// 641-642 (bad 4-byte continuation), 644 (4-byte out of range), 649 (byte >= 0xF8),
+// and line 986 (get invalid sequence throw).
+void test_code_cvt_mem_char8_t_get_err_1()
+{
+    using namespace IOv2;
+    dump_info("Test code_cvt<memory<char8_t>>::get error case 1...");
+
+    using CheckType = code_cvt<rb_root_cvt<mem_device<char8_t>>, char32_t>;
+
+    auto run_err = [](const std::u8string& bad_bytes) {
+        CheckType obj{rb_root_cvt{mem_device(bad_bytes)}};
+        if (obj.bos() != io_status::input)
+            throw std::runtime_error("test_code_cvt_mem_char8_t_get_err_1: bos fail");
+        obj.main_cont_beg();
+        char32_t buf[4];
+        try {
+            obj.get(buf, 4);
+            throw std::runtime_error("test_code_cvt_mem_char8_t_get_err_1: expected throw");
+        } catch (const cvt_error&) {}
+    };
+
+    // 0x80: continuation byte as start → lines 610-611
+    run_err({ char8_t(0x80) });
+    // {0xC3, 0x20}: bad continuation in 2-byte → lines 614-615
+    run_err({ char8_t(0xC3), char8_t(0x20) });
+    // {0xC0, 0x80}: overlong null (2-byte) → line 617
+    run_err({ char8_t(0xC0), char8_t(0x80) });
+    // {0xE6, 0x20, 0x8E}: bad c2 in 3-byte → lines 626-627
+    run_err({ char8_t(0xE6), char8_t(0x20), char8_t(0x8E) });
+    // {0xE6, 0x9D, 0x20}: bad c3 in 3-byte → lines 626-627
+    run_err({ char8_t(0xE6), char8_t(0x9D), char8_t(0x20) });
+    // {0xED, 0xA0, 0x80}: U+D800 encoded as 3-byte (surrogate) → line 631
+    run_err({ char8_t(0xED), char8_t(0xA0), char8_t(0x80) });
+    // {0xF0, 0x20, 0x80, 0x80}: bad c2 in 4-byte → lines 641-642
+    run_err({ char8_t(0xF0), char8_t(0x20), char8_t(0x80), char8_t(0x80) });
+    // {0xF4, 0x90, 0x80, 0x80}: U+110000 (> 0x10FFFF) → line 644
+    run_err({ char8_t(0xF4), char8_t(0x90), char8_t(0x80), char8_t(0x80) });
+    // {0xF0, 0x80, 0x80, 0x80}: U+0000 overlong 4-byte (< 0x10000) → line 644
+    run_err({ char8_t(0xF0), char8_t(0x80), char8_t(0x80), char8_t(0x80) });
+    // 0xFF: byte >= 0xF8 → line 649
+    run_err({ char8_t(0xFF) });
+
+    dump_info("Done\n");
+}
+
+// Covers line 612 (2-byte partial break), line 637 (4-byte partial break),
+// and line 972 (get partial input sequence throw).
+void test_code_cvt_mem_char8_t_get_partial_1()
+{
+    using namespace IOv2;
+    dump_info("Test code_cvt<memory<char8_t>>::get partial sequence case 1...");
+
+    using CheckType = code_cvt<rb_root_cvt<mem_device<char8_t>>, char32_t>;
+
+    auto run_partial = [](const std::u8string& partial) {
+        CheckType obj{rb_root_cvt{mem_device(partial)}};
+        if (obj.bos() != io_status::input)
+            throw std::runtime_error("test_code_cvt_mem_char8_t_get_partial_1: bos fail");
+        obj.main_cont_beg();
+        char32_t buf[4];
+        try {
+            obj.get(buf, 1);
+            throw std::runtime_error("test_code_cvt_mem_char8_t_get_partial_1: expected throw");
+        } catch (const cvt_error&) {}
+    };
+
+    // Single 2-byte start byte: line 612 break → line 972
+    run_partial({ char8_t(0xC3) });
+    // 3 bytes of a 4-byte sequence: line 637 break → line 972
+    run_partial({ char8_t(0xF0), char8_t(0x9F), char8_t(0x98) });
+
+    dump_info("Done\n");
+}
+
+// Covers lines 833-836 (code_cvt::attach), lines 1162-1163 (switch_to_put
+// from output, no-op) and lines 1164-1167 (switch_to_put from neutral).
+void test_code_cvt_attach_1()
+{
+    using namespace IOv2;
+    dump_info("Test code_cvt::attach and switch_to_put from neutral/output...");
+
+    using CheckType = code_cvt<rb_root_cvt<mem_device<char8_t>>, char32_t>;
+
+    CheckType obj{rb_root_cvt{mem_device(std::u8string{})}};
+
+    if (obj.bos() != io_status::output)
+        throw std::runtime_error("test_code_cvt_attach_1: bos fail");
+    obj.main_cont_beg();
+    char32_t ch = U'X';
+    obj.put(&ch, 1);
+
+    // switch_to_put when already in output: no-op (lines 1162-1163)
+    obj.switch_to_put();
+    VERIFY(obj.tell() == 1);
+
+    // attach() resets to neutral (lines 833-836, close_stream)
+    auto old_dev = obj.attach(mem_device(std::u8string{}));
+    VERIFY(old_dev.str().size() >= 1);
+
+    // switch_to_put from neutral (lines 1164-1167); skip bos() since
+    // switch_to_put already established the direction
+    obj.switch_to_put();
+    obj.main_cont_beg();
+    obj.put(&ch, 1);
+    obj.flush();
+    VERIFY(obj.device().str().size() == 1);  // 'X' (U+0058) = 1 UTF-8 byte
+
+    dump_info("Done\n");
+}
+
+// Covers lines 1207-1208 (switch_to_get from input, no-op) and
+// lines 1209-1212 (switch_to_get from neutral).
+void test_code_cvt_switch_1()
+{
+    using namespace IOv2;
+    dump_info("Test code_cvt::switch_to_get from input/neutral...");
+
+    using CheckType = code_cvt<rb_root_cvt<mem_device<char8_t>>, char32_t>;
+
+    // Input: é (U+00E9) = {0xC3, 0xA9}
+    std::u8string content = { char8_t(0xC3), char8_t(0xA9) };
+
+    CheckType obj{rb_root_cvt{mem_device(content)}};
+
+    if (obj.bos() != io_status::input)
+        throw std::runtime_error("test_code_cvt_switch_1: bos fail");
+    obj.main_cont_beg();
+
+    // switch_to_get when already in input: no-op (lines 1207-1208)
+    obj.switch_to_get();
+
+    char32_t ch = 0;
+    if (obj.get(&ch, 1) != 1 || ch != U'é')
+        throw std::runtime_error("test_code_cvt_switch_1: get fail");
+
+    // attach() resets to neutral
+    obj.attach(mem_device(content));
+
+    // switch_to_get from neutral (lines 1209-1212); skip bos() since
+    // switch_to_get already established the direction
+    obj.switch_to_get();
+    obj.main_cont_beg();
+    ch = 0;
+    if (obj.get(&ch, 1) != 1 || ch != U'é')
+        throw std::runtime_error("test_code_cvt_switch_1: get after neutral fail");
+
+    dump_info("Done\n");
+}

--- a/test/cvt/code_cvt/code_cvt_mem_char_char32_t.cpp
+++ b/test/cvt/code_cvt/code_cvt_mem_char_char32_t.cpp
@@ -1488,3 +1488,92 @@ void test_code_cvt_mem_char_io_4()
 
     dump_info("Done\n");
 }
+
+// Covers lines 267-268 (out_helper: wcrtomb returns -1, init_state + return false)
+// and line 926 (code_cvt::put throws encoding error).
+// Uses "C" locale (epc=1, ASCII only) and attempts to encode a Chinese character.
+void test_code_cvt_mem_char_put_err_1()
+{
+    using namespace IOv2;
+    dump_info("Test code_cvt<memory<char>, char32_t>::put encoding error case 1...");
+
+    using CheckType = code_cvt<rb_root_cvt<mem_device<char>>, char32_t>;
+
+    auto try_put = [](auto& obj, char32_t ch) {
+        if (obj.bos() != io_status::output)
+            throw std::runtime_error("test_code_cvt_mem_char_put_err_1: bos fail");
+        obj.main_cont_beg();
+        try {
+            obj.put(&ch, 1);
+            throw std::runtime_error("test_code_cvt_mem_char_put_err_1: expected throw");
+        } catch (const cvt_error&) {}
+    };
+
+    // In "C" locale, non-ASCII characters cannot be encoded (wcrtomb returns -1)
+    { CheckType o{rb_root_cvt{mem_device("")}, "C"}; try_put(o, U'李'); }
+    { CheckType o{rb_root_cvt{mem_device("")}, "C"}; try_put(o, U'伟'); }
+
+    dump_info("Done\n");
+}
+
+// Covers lines 339-340, 341, 343-344, 346-347, 350, 354-356 in in_helper:
+// null character ('\0') decoded via the special mbrtowc conv==0 path.
+void test_code_cvt_mem_char_get_null_1()
+{
+    using namespace IOv2;
+    dump_info("Test code_cvt<memory<char>, char32_t>::get null character case 1...");
+
+    // Content: 'a', '\0', 'b'  —  embed null byte using explicit construction
+    std::string buf;
+    buf += 'a'; buf += '\0'; buf += 'b';
+
+    using CheckType = code_cvt<rb_root_cvt<mem_device<char>>, char32_t>;
+
+    auto helper = [&](auto& obj) {
+        if (obj.bos() != io_status::input)
+            throw std::runtime_error("test_code_cvt_mem_char_get_null_1: bos fail");
+        obj.main_cont_beg();
+        char32_t out[3] = { 1, 1, 1 };
+        if (obj.get(out, 3) != 3)
+            throw std::runtime_error("test_code_cvt_mem_char_get_null_1: get count fail");
+        if (out[0] != U'a' || out[1] != U'\0' || out[2] != U'b')
+            throw std::runtime_error("test_code_cvt_mem_char_get_null_1: get content fail");
+    };
+
+    CheckType obj1{rb_root_cvt{mem_device(buf)}, "C"};
+    helper(obj1);
+    runtime_cvt obj1r{CheckType{rb_root_cvt{mem_device(buf)}, "C"}};
+    helper(obj1r);
+
+    dump_info("Done\n");
+}
+
+// Covers line 328 (in_helper: mbrtowc returns -1 for invalid byte)
+// and line 986 (code_cvt::get throws invalid external sequence).
+void test_code_cvt_mem_char_get_err_1()
+{
+    using namespace IOv2;
+    dump_info("Test code_cvt<memory<char>, char32_t>::get invalid sequence case 1...");
+
+    using CheckType = code_cvt<rb_root_cvt<mem_device<char>>, char32_t>;
+
+    // In "C" locale, 0xFF is not a valid single-byte character
+    auto run_err = [](const std::string& bad_bytes) {
+        CheckType obj{rb_root_cvt{mem_device(bad_bytes)}, "C"};
+        if (obj.bos() != io_status::input)
+            throw std::runtime_error("test_code_cvt_mem_char_get_err_1: bos fail");
+        obj.main_cont_beg();
+        char32_t buf[4];
+        try {
+            obj.get(buf, 4);
+            throw std::runtime_error("test_code_cvt_mem_char_get_err_1: expected throw");
+        } catch (const cvt_error&) {}
+    };
+
+    std::string inv1; inv1 += '\xff';
+    run_err(inv1);
+    std::string inv2; inv2 += '\xfe';
+    run_err(inv2);
+
+    dump_info("Done\n");
+}

--- a/test/cvt/code_cvt/test_code_cvt.cpp
+++ b/test/cvt/code_cvt/test_code_cvt.cpp
@@ -29,6 +29,9 @@ void test_code_cvt_mem_char_io_1();
 void test_code_cvt_mem_char_io_2();
 void test_code_cvt_mem_char_io_3();
 void test_code_cvt_mem_char_io_4();
+void test_code_cvt_mem_char_put_err_1();
+void test_code_cvt_mem_char_get_null_1();
+void test_code_cvt_mem_char_get_err_1();
 
 void test_code_cvt_mem_char8_t_gen_1();
 void test_code_cvt_mem_char8_t_gen_2();
@@ -52,6 +55,13 @@ void test_code_cvt_mem_char8_t_rseek_1();
 void test_code_cvt_mem_char8_t_rseek_2();
 void test_code_cvt_mem_char8_t_io_1();
 void test_code_cvt_mem_char8_t_io_2();
+void test_code_cvt_mem_char8_t_gen_6();
+void test_code_cvt_mem_char8_t_gen_7();
+void test_code_cvt_mem_char8_t_put_err_1();
+void test_code_cvt_mem_char8_t_get_err_1();
+void test_code_cvt_mem_char8_t_get_partial_1();
+void test_code_cvt_attach_1();
+void test_code_cvt_switch_1();
 
 void test_code_cvt_mem_char8_t_wchar_t_gen_1();
 void test_code_cvt_mem_char8_t_wchar_t_gen_2();
@@ -123,7 +133,10 @@ void test_code_cvt()
     test_code_cvt_mem_char_io_2();
     test_code_cvt_mem_char_io_3();
     test_code_cvt_mem_char_io_4();
-    
+    test_code_cvt_mem_char_put_err_1();
+    test_code_cvt_mem_char_get_null_1();
+    test_code_cvt_mem_char_get_err_1();
+
     test_code_cvt_mem_char8_t_gen_1();
     test_code_cvt_mem_char8_t_gen_2();
     test_code_cvt_mem_char8_t_gen_3();
@@ -146,6 +159,13 @@ void test_code_cvt()
     test_code_cvt_mem_char8_t_rseek_2();
     test_code_cvt_mem_char8_t_io_1();
     test_code_cvt_mem_char8_t_io_2();
+    test_code_cvt_mem_char8_t_gen_6();
+    test_code_cvt_mem_char8_t_gen_7();
+    test_code_cvt_mem_char8_t_put_err_1();
+    test_code_cvt_mem_char8_t_get_err_1();
+    test_code_cvt_mem_char8_t_get_partial_1();
+    test_code_cvt_attach_1();
+    test_code_cvt_switch_1();
 
     test_code_cvt_mem_char8_t_wchar_t_gen_1();
     test_code_cvt_mem_char8_t_wchar_t_gen_2();


### PR DESCRIPTION
Add unit tests covering previously uncovered paths in code_cvt.h:

- 2-byte and 4-byte UTF-8 encode/decode paths (gen_6, gen_7)
- is_state_dep() on char8_t kernel via direct instantiation
- surrogate and out-of-range code points in put (put_err_1)
- invalid UTF-8 byte sequences in get (get_err_1)
- partial multi-byte sequences triggering rollback throw (get_partial_1)
- attach() resetting to neutral and re-using the converter (attach_1)
- switch_to_put() no-op from output and transition from neutral (attach_1)
- switch_to_get() no-op from input and transition from neutral (switch_1)
- char locale encoding error path via "C" locale + non-ASCII char (put_err_1)
- null character decoding in char locale (get_null_1)
- invalid byte sequence in char locale get (get_err_1)