### PR TITLE
fix(cvt): defer state reset in attach/detach; tidy includes

### DIFF
--- a/include/cvt/abs_cvt.h
+++ b/include/cvt/abs_cvt.h
@@ -872,10 +872,11 @@ namespace IOv2
          */
         device_type detach()
         {
+            auto result = m_kernel.detach();
             m_io_status = io_status::neutral;
             m_is_bos_done = false;
             m_is_tainted = false;
-            return m_kernel.detach();
+            return result;
         }
 
         /**
@@ -905,10 +906,11 @@ namespace IOv2
          */
         device_type attach(device_type&& dev = device_type{})
         {
+            auto result = m_kernel.attach(std::move(dev));
             m_io_status = io_status::neutral;
             m_is_bos_done = false;
             m_is_tainted = false;
-            return m_kernel.attach(std::move(dev));
+            return result;
         }
 
         /**

--- a/include/cvt/cvt_pipe_creator.h
+++ b/include/cvt/cvt_pipe_creator.h
@@ -1,9 +1,9 @@
 #pragma once
-#include <common/metafunctions.h>
-#include <cvt/root_cvt.h>
+#include <cvt/cvt_concepts.h>
 
 #include <tuple>
 #include <type_traits>
+#include <utility>
 
 namespace IOv2
 {

--- a/include/cvt/runtime_cvt.h
+++ b/include/cvt/runtime_cvt.h
@@ -1,6 +1,8 @@
 #pragma once
+#include <common/defs.h>
 #include <cvt/cvt_concepts.h>
 #include <device/device_concepts.h>
+
 #include <memory>
 
 namespace IOv2
@@ -79,14 +81,16 @@ public:
 
     device_type detach() override
     {
+        auto result = m_kernel.detach();
         m_io_status = io_status::neutral;
-        return m_kernel.detach();
+        return result;
     }
 
     device_type attach(device_type&& dev = device_type{}) override
     {
+        auto result = m_kernel.attach(std::move(dev));
         m_io_status = io_status::neutral;
-        return m_kernel.attach(std::move(dev));
+        return result;
     }
 
     void adjust(const cvt_behavior& acc) override


### PR DESCRIPTION
abs_cvt.h, runtime_cvt.h:
  attach()/detach() previously cleared m_io_status (and, in abs_cvt,
  m_is_bos_done / m_is_tainted) BEFORE invoking the kernel. If the
  kernel call threw with the strong exception guarantee, the kernel
  was left in its prior state while the cached flags were wiped,
  desynchronizing the wrapper from reality. The most visible
  consequence: a subsequent switch_to_get()/switch_to_put() would
  miss its early-return fast-path and -- for kernels that do not
  support io_switch -- spuriously throw "kernel does not support
  I/O switch", even though the kernel was already in the desired
  direction. Reorder so the kernel call runs first; cached state
  is updated only on success, matching bos() and root_cvt's existing
  pattern.

cvt_pipe_creator.h:
  Drop unused <common/metafunctions.h> and <cvt/root_cvt.h>;
  add direct <cvt/cvt_concepts.h> (io_converter, cvt_creator,
  CvtCreatorCategory) and <utility> (std::forward, std::move),
  which were previously obtained transitively through root_cvt.h.

runtime_cvt.h:
  Add direct <common/defs.h> for cvt_error, previously obtained
  transitively via cvt_concepts.h.