### PR TITLE
refactor(cvt): replace default_flush param with concept-based do_flush dispatch

### DIFF
--- a/include/cvt/abs_cvt.h
+++ b/include/cvt/abs_cvt.h
@@ -670,14 +670,6 @@ namespace IOv2
      * @lang{ZH} 派生类对外暴露的字符类型（即 `get`/`put` 接口所使用的元素类型）。 @endif
      * @lang{EN} The character type exposed by the derived class (the element type used by the `get`/`put` interface). @endif
      *
-     * @tparam default_flush
-     * @lang{ZH}
-     * 若为 `true`（默认），且 kernel 支持 put，则 `flush()` 方法可用。
-     * @endif
-     * @lang{EN}
-     * When `true` (default) and the kernel supports put, the `flush()` method is available.
-     * @endif
-     *
      * @tparam default_positioning
      * @lang{ZH}
      * 若为 `true`（默认），且 kernel 支持定位，则 `tell()`/`seek()`/`rseek()` 方法可用。
@@ -697,7 +689,6 @@ namespace IOv2
     template <typename CurrentType,
               io_converter KernelType,
               typename InternalType,
-              bool default_flush = true,
               bool default_positioning = true,
               bool default_io_switch = true>
     class abs_cvt
@@ -1309,22 +1300,52 @@ namespace IOv2
 
         /**
          * @lang{ZH}
-         * 将 kernel 中所有缓冲数据强制刷出到底层设备。
+         * 将所有缓冲数据强制刷出到底层设备。
          *
-         * 仅在 `default_flush` 为 `true` 且 kernel 支持 put 操作时可用。
+         * 仅在派生类实现了 `put_main` 时可用。若当前不处于输出模式，则为空操作直接返回。
+         *
+         * 若派生类实现了 `do_flush()`，则先调用 `do_flush()` 执行派生类特定的刷出逻辑
+         * （例如 zlib 的 sync flush），再调用 `m_kernel.flush()` 将数据推送至底层设备。
+         * 若派生类未实现 `do_flush()`，则直接调用 `m_kernel.flush()`。
+         *
+         * 若刷出过程中抛出异常，转换器将进入污染状态，后续操作均不可用。
          * @endif
          *
          * @lang{EN}
-         * Force all buffered data in the kernel to be flushed to the underlying device.
+         * Force all buffered data to be flushed to the underlying device.
          *
-         * Only available when `default_flush` is `true` and the kernel supports the
-         * put operation.
+         * Only available when the derived class implements `put_main`. If the converter
+         * is not currently in output mode, this is a no-op and returns immediately.
+         *
+         * If the derived class implements `do_flush()`, it is called first to perform
+         * any derived-class-specific flushing (e.g., a zlib sync flush), after which
+         * `m_kernel.flush()` is called to push data through to the underlying device.
+         * If no `do_flush()` is provided, `m_kernel.flush()` is called directly.
+         *
+         * If an exception is thrown during flushing, the converter enters a tainted
+         * state and further operations are unavailable.
          * @endif
          */
         void flush()
-            requires (default_flush && cvt_cpt::support_put<KernelType>)
+            requires requires(CurrentType& t, cvt_writer<KernelType>& w, const internal_type* data, size_t len) {
+                { t.put_main(w, data, len) } -> std::same_as<void>;
+            }
         {
-            m_kernel.flush();
+            if (m_io_status != io_status::output)
+                return;
+
+            assert_not_tainted();
+            try
+            {
+                if constexpr (requires(CurrentType& t) { t.do_flush(); })
+                    static_cast<CurrentType*>(this)->do_flush();
+                m_kernel.flush();
+            }
+            catch (...)
+            {
+                m_is_tainted = true;
+                throw;
+            }
         }
 
         /**

--- a/include/cvt/code_cvt.h
+++ b/include/cvt/code_cvt.h
@@ -684,9 +684,9 @@ struct codecvt_kernel<char8_t, TInt>
  * @endif
  */
 template <io_converter KernelType, typename CharType>
-class code_cvt : public abs_cvt<code_cvt<KernelType, CharType>, KernelType, CharType, true, false, false>
+class code_cvt : public abs_cvt<code_cvt<KernelType, CharType>, KernelType, CharType, false, false>
 {
-    using BT = abs_cvt<code_cvt<KernelType, CharType>, KernelType, CharType, true, false, false>;
+    using BT = abs_cvt<code_cvt<KernelType, CharType>, KernelType, CharType, false, false>;
     friend BT; // for put_main, get_main
 
 public:

--- a/include/cvt/comp/zlib_cvt.h
+++ b/include/cvt/comp/zlib_cvt.h
@@ -26,9 +26,9 @@ struct zlib_sync_flush : cvt_behavior
 
 template <io_converter KernelType, typename TInt = typename KernelType::internal_type>
     requires (sizeof(typename KernelType::internal_type) == sizeof(unsigned char))
-class zlib_cvt : public abs_cvt<zlib_cvt<KernelType, TInt>, KernelType, TInt, false, false, false>
+class zlib_cvt : public abs_cvt<zlib_cvt<KernelType, TInt>, KernelType, TInt, false, false>
 {
-    using BT = abs_cvt<zlib_cvt<KernelType, TInt>, KernelType, TInt, false, false, false>;
+    using BT = abs_cvt<zlib_cvt<KernelType, TInt>, KernelType, TInt, false, false>;
     friend BT;  // for put_main and get_main
 
     // On the failure path, clear next_in/next_out so they cannot outlive the
@@ -248,7 +248,7 @@ public:
         BT::main_cont_beg();
 
         if (BT::m_io_status == io_status::output)
-            flush();
+            BT::flush();
         else if (BT::m_io_status == io_status::neutral)
             throw cvt_error("zlib_cvt::main_cont_beg fail: bos() has not been called before main_cont_beg");
     }
@@ -466,16 +466,9 @@ private:
         m_strm.avail_in = 0;
     }
 public:
-    void flush()
+    void do_flush()
         requires (cvt_cpt::support_put<KernelType>)
     {
-        BT::assert_not_tainted();
-        if (!BT::m_is_bos_done)
-            return BT::m_kernel.flush();
-
-        if (BT::m_io_status != io_status::output)
-            throw cvt_error("zlib_cvt::flush fail: not available");
-
         if (m_sync_flush)
         {
             struct buf_guard
@@ -497,7 +490,7 @@ public:
             {
                 m_strm.next_out = reinterpret_cast<unsigned char*>(local_buf.data()); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
                 m_strm.avail_out = CHUNK;
-                zerr("zlib_cvt::flush fail", deflate(&m_strm, Z_SYNC_FLUSH));
+                zerr("zlib_cvt::do_flush fail", deflate(&m_strm, Z_SYNC_FLUSH));
                 const size_t written = CHUNK - m_strm.avail_out;
                 if (written > 0)
                     BT::m_kernel.put(local_buf.data(), written);
@@ -505,7 +498,6 @@ public:
                     break;
             }
         }
-        BT::m_kernel.flush();
     }
 
 private:

--- a/include/cvt/crypt/chacha20_cvt.h
+++ b/include/cvt/crypt/chacha20_cvt.h
@@ -28,9 +28,9 @@ inline Botan::secure_vector<uint8_t> key_gen(std::string_view key)
 template <io_converter KernelType, typename TInt = typename KernelType::internal_type>
     requires (std::is_integral_v<typename KernelType::internal_type> &&
               sizeof(typename KernelType::internal_type) == sizeof(uint8_t))
-class chacha20_cvt : public abs_cvt<chacha20_cvt<KernelType, TInt>, KernelType, TInt, true, false, false>
+class chacha20_cvt : public abs_cvt<chacha20_cvt<KernelType, TInt>, KernelType, TInt, false, false>
 {
-    using BT = abs_cvt<chacha20_cvt<KernelType, TInt>, KernelType, TInt, true, false, false>;
+    using BT = abs_cvt<chacha20_cvt<KernelType, TInt>, KernelType, TInt, false, false>;
     friend BT; // for put_main and get_main
 public:
     using device_type = typename KernelType::device_type;

--- a/include/cvt/crypt/hash_cvt.h
+++ b/include/cvt/crypt/hash_cvt.h
@@ -40,9 +40,9 @@ struct dump_hash : cvt_behavior
 template <io_converter KernelType, typename TInt = typename KernelType::internal_type>
     requires (std::is_integral_v<typename KernelType::internal_type> &&
               sizeof(typename KernelType::internal_type) == sizeof(uint8_t))
-class hash_cvt : public abs_cvt<hash_cvt<KernelType, TInt>, KernelType, TInt, true, false, false>
+class hash_cvt : public abs_cvt<hash_cvt<KernelType, TInt>, KernelType, TInt, false, false>
 {
-    using BT = abs_cvt<hash_cvt<KernelType, TInt>, KernelType, TInt, true, false, false>;
+    using BT = abs_cvt<hash_cvt<KernelType, TInt>, KernelType, TInt, false, false>;
     friend BT;  // fot put_main
 
     static_assert(cvt_cpt::support_put<KernelType>);

--- a/include/cvt/crypt/vigenere_cvt.h
+++ b/include/cvt/crypt/vigenere_cvt.h
@@ -31,9 +31,9 @@ namespace IOv2::Crypt::Classic
 /// @see chacha20_cvt for cryptographically secure encryption
 template <io_converter KernelType>
     requires std::is_integral_v<typename KernelType::internal_type>
-class vigenere_cvt : public abs_cvt<vigenere_cvt<KernelType>, KernelType, typename KernelType::internal_type, true, false, true>
+class vigenere_cvt : public abs_cvt<vigenere_cvt<KernelType>, KernelType, typename KernelType::internal_type, false, true>
 {
-    using BT = abs_cvt<vigenere_cvt<KernelType>, KernelType, typename KernelType::internal_type, true, false, true>;
+    using BT = abs_cvt<vigenere_cvt<KernelType>, KernelType, typename KernelType::internal_type, false, true>;
     friend BT;  // for put_main and get_main
     constexpr static size_t s_buf_len = 16;
 public:

--- a/test/cvt/cvt_io/test_root_cvt_io.cpp
+++ b/test/cvt/cvt_io/test_root_cvt_io.cpp
@@ -62,10 +62,10 @@ template <IOv2::io_converter KernelType>
     requires std::is_same_v<typename KernelType::internal_type, wchar_t>
 struct wext_char_cvt
     : public IOv2::abs_cvt<wext_char_cvt<KernelType>, KernelType, char,
-                           /*flush=*/true, /*position=*/false, /*io_switch=*/false>
+                           /*position=*/false, /*io_switch=*/false>
 {
     using BT = IOv2::abs_cvt<wext_char_cvt<KernelType>, KernelType, char,
-                              true, false, false>;
+                              false, false>;
     friend BT;
 public:
     using device_type  = typename KernelType::device_type;
@@ -84,11 +84,11 @@ template <IOv2::io_converter KernelType>
 struct no_switch_cvt
     : public IOv2::abs_cvt<no_switch_cvt<KernelType>, KernelType,
                            typename KernelType::internal_type,
-                           /*flush=*/true, /*position=*/false, /*io_switch=*/false>
+                           /*position=*/false, /*io_switch=*/false>
 {
     using IT = typename KernelType::internal_type;
     using BT = IOv2::abs_cvt<no_switch_cvt<KernelType>, KernelType, IT,
-                              true, false, false>;
+                              false, false>;
     friend BT;
 public:
     using device_type  = typename KernelType::device_type;


### PR DESCRIPTION


Remove the `default_flush` boolean template parameter from `abs_cvt`. `flush()` is now available whenever the derived class implements `put_main`, detected via a requires-expression at compile time.

Introduce a `do_flush()` dispatch mechanism: if the derived class provides `do_flush()`, `flush()` calls it first (for class-specific work such as zlib sync flush), then always calls `m_kernel.flush()`. This cleanly separates derived-class flushing logic from kernel flushing.

Refactor `zlib_cvt::flush()` into `do_flush()`, stripping the state-guard boilerplate now handled uniformly by the base class.