### PR TITLE
feat: enforce noexcept move semantics for converters and devices

### DIFF
--- a/include/cvt/abs_cvt.h
+++ b/include/cvt/abs_cvt.h
@@ -762,7 +762,7 @@ namespace IOv2
          * IO status is reset to `neutral` and its BOS-done flag is reset to `false`.
          * @endif
          */
-        abs_cvt(abs_cvt&& val) noexcept(std::is_nothrow_move_constructible_v<KernelType>)
+        abs_cvt(abs_cvt&& val) noexcept
             : m_kernel(std::move(val.m_kernel))
             , m_io_status(val.m_io_status)
             , m_is_bos_done(val.m_is_bos_done)
@@ -808,7 +808,7 @@ namespace IOv2
          * object's IO status and BOS-done flag are both reset.
          * @endif
          */
-        abs_cvt& operator=(abs_cvt&& val) noexcept(std::is_nothrow_move_assignable_v<KernelType>)
+        abs_cvt& operator=(abs_cvt&& val) noexcept
         {
             if (this != &val)
             {

--- a/include/cvt/code_cvt.h
+++ b/include/cvt/code_cvt.h
@@ -776,9 +776,7 @@ public:
      * after the move (`m_accu_len` is reset to 0).
      * @endif
      */
-    code_cvt(code_cvt&& val) noexcept(
-        std::is_nothrow_move_constructible_v<BT> &&
-        std::is_nothrow_move_constructible_v<codecvt_kernel<external_type, internal_type>>)
+    code_cvt(code_cvt&& val) noexcept
         : BT(std::move(val))
         , m_cvt_kernel(std::move(val.m_cvt_kernel))
         , m_accu_len(val.m_accu_len)
@@ -796,9 +794,7 @@ public:
      * state after the move (`m_accu_len` is reset to 0).
      * @endif
      */
-    code_cvt& operator=(code_cvt&& val) noexcept(
-        std::is_nothrow_move_assignable_v<BT> &&
-        std::is_nothrow_move_assignable_v<codecvt_kernel<external_type, internal_type>>)
+    code_cvt& operator=(code_cvt&& val) noexcept
     {
         if (this == &val) return *this;
         BT::operator=(std::move(val));

--- a/include/cvt/comp/zlib_cvt.h
+++ b/include/cvt/comp/zlib_cvt.h
@@ -8,6 +8,7 @@
 #include <cassert>
 #include <concepts>
 #include <limits>
+#include <memory>
 #include <string>
 #include <type_traits>
 #include <utility>
@@ -31,24 +32,25 @@ class zlib_cvt : public abs_cvt<zlib_cvt<KernelType, TInt>, KernelType, TInt, fa
     using BT = abs_cvt<zlib_cvt<KernelType, TInt>, KernelType, TInt, false, false>;
     friend BT;  // for put_main and get_main
 
-    // On the failure path, clear next_in/next_out so they cannot outlive the
-    // local buffers (e.g. header_buf) they may point into.
+    // On the failure path, call inflateEnd/deflateEnd and reset the unique_ptr
+    // so that close_stream() (and the destructor) see a null m_strm and skip
+    // redundant cleanup.  release() prevents the guard from running End on the
+    // success path (the stream remains alive, owned by m_strm).
     struct inflate_guard
     {
-        z_stream* strm;
-        explicit inflate_guard(z_stream& s) noexcept : strm(&s) {}
+        std::unique_ptr<z_stream>& strm_ref;
+        bool released = false;
+
+        explicit inflate_guard(std::unique_ptr<z_stream>& s) noexcept : strm_ref(s) {}
         ~inflate_guard() noexcept
         {
-            if (strm)
+            if (!released && strm_ref)
             {
-                inflateEnd(strm);
-                strm->next_in = nullptr;
-                strm->avail_in = 0;
-                strm->next_out = nullptr;
-                strm->avail_out = 0;
+                inflateEnd(strm_ref.get());
+                strm_ref.reset();
             }
         }
-        void release() noexcept { strm = nullptr; }
+        void release() noexcept { released = true; }
 
         inflate_guard(const inflate_guard&) = delete;
         inflate_guard& operator=(const inflate_guard&) = delete;
@@ -58,20 +60,19 @@ class zlib_cvt : public abs_cvt<zlib_cvt<KernelType, TInt>, KernelType, TInt, fa
 
     struct deflate_guard
     {
-        z_stream* strm;
-        explicit deflate_guard(z_stream& s) noexcept : strm(&s) {}
+        std::unique_ptr<z_stream>& strm_ref;
+        bool released = false;
+
+        explicit deflate_guard(std::unique_ptr<z_stream>& s) noexcept : strm_ref(s) {}
         ~deflate_guard() noexcept
         {
-            if (strm)
+            if (!released && strm_ref)
             {
-                deflateEnd(strm);
-                strm->next_in = nullptr;
-                strm->avail_in = 0;
-                strm->next_out = nullptr;
-                strm->avail_out = 0;
+                deflateEnd(strm_ref.get());
+                strm_ref.reset();
             }
         }
-        void release() noexcept { strm = nullptr; }
+        void release() noexcept { released = true; }
 
         deflate_guard(const deflate_guard&) = delete;
         deflate_guard& operator=(const deflate_guard&) = delete;
@@ -104,32 +105,36 @@ public:
     {
         try
         {
-            m_strm.state = Z_NULL;  // Ensure state is NULL if deflateCopy/inflateCopy fails partway
             if (BT::m_io_status == io_status::output)
-                zerr("zlib_cvt copy constructor fail", deflateCopy(&m_strm, const_cast<z_stream*>(&val.m_strm))); // NOLINT(cppcoreguidelines-pro-type-const-cast)
+            {
+                m_strm = std::make_unique<z_stream>();
+                zerr("zlib_cvt copy constructor fail", deflateCopy(m_strm.get(), val.m_strm.get())); // NOLINT(cppcoreguidelines-pro-type-const-cast)
+            }
             else if (BT::m_io_status == io_status::input)
-                zerr("zlib_cvt copy constructor fail", inflateCopy(&m_strm, const_cast<z_stream*>(&val.m_strm))); // NOLINT(cppcoreguidelines-pro-type-const-cast)
+            {
+                m_strm = std::make_unique<z_stream>();
+                zerr("zlib_cvt copy constructor fail", inflateCopy(m_strm.get(), val.m_strm.get())); // NOLINT(cppcoreguidelines-pro-type-const-cast)
+            }
         }
         catch(...)
         {
+            m_strm.reset();
             BT::m_io_status = io_status::neutral;
             throw;
         }
     }
 
+    // Move constructor: transfer the unique_ptr so the z_stream address is
+    // unchanged.  zlib's internal state keeps a back-pointer (state->strm) to
+    // the z_stream struct; a shallow struct copy would leave that pointer
+    // stale, causing deflate/inflate to return Z_STREAM_ERROR.  Moving the
+    // unique_ptr preserves the address and keeps the back-pointer valid.
     zlib_cvt(zlib_cvt&& val) noexcept
         : BT(std::move(val))
         , m_put_level(val.m_put_level)
         , m_sync_flush(val.m_sync_flush)
-        , m_strm(val.m_strm)
-    {
-        // Transfer ownership: null out source's state to prevent double-free.
-        // deflateEnd/inflateEnd will return Z_STREAM_ERROR on NULL state,
-        // which is safe (no cleanup performed, no crash).
-        val.m_strm.state = Z_NULL;
-        val.m_strm.next_in = nullptr;
-        val.m_strm.next_out = nullptr;
-    }
+        , m_strm(std::move(val.m_strm))
+    {}
 
     zlib_cvt& operator=(const zlib_cvt& val)
     {
@@ -142,13 +147,20 @@ public:
         try
         {
             if (BT::m_io_status == io_status::output)
-                zerr("zlib_cvt copy assignment fail", deflateCopy(&m_strm, const_cast<z_stream*>(&val.m_strm))); // NOLINT(cppcoreguidelines-pro-type-const-cast)
+            {
+                m_strm = std::make_unique<z_stream>();
+                zerr("zlib_cvt copy assignment fail", deflateCopy(m_strm.get(), val.m_strm.get())); // NOLINT(cppcoreguidelines-pro-type-const-cast)
+            }
             else if (BT::m_io_status == io_status::input)
-                zerr("zlib_cvt copy assignment fail", inflateCopy(&m_strm, const_cast<z_stream*>(&val.m_strm))); // NOLINT(cppcoreguidelines-pro-type-const-cast)
+            {
+                m_strm = std::make_unique<z_stream>();
+                zerr("zlib_cvt copy assignment fail", inflateCopy(m_strm.get(), val.m_strm.get())); // NOLINT(cppcoreguidelines-pro-type-const-cast)
+            }
             return *this;
         }
         catch(...)
         {
+            m_strm.reset();
             BT::set_tainted();
             throw;
         }
@@ -158,20 +170,13 @@ public:
     {
         if (this == &val) return *this;
 
-        // Best-effort cleanup of current stream; ignore exceptions since we're
-        // replacing the state anyway.
         try { close_stream(); }
         catch (...) {} // NOLINT(bugprone-empty-catch)
 
         BT::operator=(std::move(val));
         m_put_level = val.m_put_level;
         m_sync_flush = val.m_sync_flush;
-        m_strm = val.m_strm;
-
-        // Transfer ownership: null out source's state to prevent double-free.
-        val.m_strm.state = Z_NULL;
-        val.m_strm.next_in = nullptr;
-        val.m_strm.next_out = nullptr;
+        m_strm = std::move(val.m_strm);  // preserves z_stream address; see move ctor
 
         return *this;
     }
@@ -224,14 +229,15 @@ public:
         {
             if constexpr (cvt_cpt::support_get<KernelType>)
             {
-                m_strm.zalloc = Z_NULL;
-                m_strm.zfree = Z_NULL;
-                m_strm.opaque = Z_NULL;
-                m_strm.avail_in = 0;
-                m_strm.next_in = Z_NULL;
-                m_strm.state = Z_NULL;  // Ensure state is NULL if inflateInit fails partway
-                auto ret = inflateInit(&m_strm);
-                if (ret != Z_OK) throw cvt_error("zlib_cvt::bos fail: Cannot initialize zlib.");
+                m_strm = std::make_unique<z_stream>();
+                m_strm->zalloc = Z_NULL;
+                m_strm->zfree = Z_NULL;
+                m_strm->opaque = Z_NULL;
+                m_strm->avail_in = 0;
+                m_strm->next_in = Z_NULL;
+                m_strm->state = Z_NULL;
+                auto ret = inflateInit(m_strm.get());
+                if (ret != Z_OK) { m_strm.reset(); throw cvt_error("zlib_cvt::bos fail: Cannot initialize zlib."); }
                 inflate_guard zlib_guard(m_strm);
 
                 // Contract: kernel.get() on BOS path guarantees to return exactly the
@@ -243,22 +249,22 @@ public:
                 [[maybe_unused]] const size_t n = BT::m_kernel.get(header_buf.data(), zlib_header_size);
                 assert(n == zlib_header_size);
 
-                m_strm.avail_in = zlib_header_size;
-                m_strm.next_in = reinterpret_cast<unsigned char*>(header_buf.data()); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
+                m_strm->avail_in = zlib_header_size;
+                m_strm->next_in = reinterpret_cast<unsigned char*>(header_buf.data()); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
 
                 unsigned char ch = 0;
-                m_strm.avail_out = 1;
-                m_strm.next_out = &ch;
+                m_strm->avail_out = 1;
+                m_strm->next_out = &ch;
 
-                ret = inflate(&m_strm, Z_NO_FLUSH);
+                ret = inflate(m_strm.get(), Z_NO_FLUSH);
                 if (ret == Z_NEED_DICT)
                     throw cvt_error("zlib_cvt::bos fail: preset dictionary not supported");
                 zerr("zlib_cvt::bos fail", ret);
 
-                if ((m_strm.avail_in != 0) || (m_strm.avail_out != 1)) throw cvt_error("zlib_cvt::bos fail: Invalid zlib header");
-                m_strm.next_in = nullptr;
-                m_strm.avail_out = 0;
-                m_strm.next_out = nullptr;
+                if ((m_strm->avail_in != 0) || (m_strm->avail_out != 1)) throw cvt_error("zlib_cvt::bos fail: Invalid zlib header");
+                m_strm->next_in = nullptr;
+                m_strm->avail_out = 0;
+                m_strm->next_out = nullptr;
 
                 zlib_guard.release();
             }
@@ -267,13 +273,14 @@ public:
         {
             if constexpr (cvt_cpt::support_put<KernelType>)
             {
-                m_strm.zalloc = Z_NULL;
-                m_strm.zfree = Z_NULL;
-                m_strm.opaque = Z_NULL;
-                m_strm.state = Z_NULL;  // Ensure state is NULL if deflateInit fails partway
+                m_strm = std::make_unique<z_stream>();
+                m_strm->zalloc = Z_NULL;
+                m_strm->zfree = Z_NULL;
+                m_strm->opaque = Z_NULL;
+                m_strm->state = Z_NULL;
 
-                auto ret = deflateInit(&m_strm, static_cast<int>(m_put_level));
-                if (ret != Z_OK) throw cvt_error("zlib_cvt::bos fail: Cannot initialize zlib.");
+                auto ret = deflateInit(m_strm.get(), static_cast<int>(m_put_level));
+                if (ret != Z_OK) { m_strm.reset(); throw cvt_error("zlib_cvt::bos fail: Cannot initialize zlib."); }
                 deflate_guard zlib_guard(m_strm);
 
                 // Contract enforced below: after this deflate() call we require
@@ -286,26 +293,26 @@ public:
                 // a loud failure rather than silent framing corruption.
                 std::array<external_type, zlib_header_size + 1> header_buf{};
 
-                m_strm.avail_in = 0;
-                m_strm.next_in = nullptr;
-                m_strm.avail_out = zlib_header_size + 1;
-                m_strm.next_out = reinterpret_cast<unsigned char*>(header_buf.data()); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
-                ret = deflate(&m_strm, Z_NO_FLUSH);
+                m_strm->avail_in = 0;
+                m_strm->next_in = nullptr;
+                m_strm->avail_out = zlib_header_size + 1;
+                m_strm->next_out = reinterpret_cast<unsigned char*>(header_buf.data()); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
+                ret = deflate(m_strm.get(), Z_NO_FLUSH);
                 zerr("zlib_cvt::bos fail", ret);
 
-                if (m_strm.avail_out != 1)
+                if (m_strm->avail_out != 1)
                     throw cvt_error("zlib_cvt::bos fail: zlib did not emit exactly the header");
 
                 unsigned pending_bytes = 0;
                 int pending_bits = 0;
-                if (deflatePending(&m_strm, &pending_bytes, &pending_bits) != Z_OK ||
+                if (deflatePending(m_strm.get(), &pending_bytes, &pending_bits) != Z_OK ||
                     pending_bytes != 0 || pending_bits != 0)
                     throw cvt_error("zlib_cvt::bos fail: zlib has unflushed bytes after header");
 
                 BT::m_kernel.put(header_buf.data(), zlib_header_size);
 
-                m_strm.avail_out = 0;
-                m_strm.next_out = nullptr;
+                m_strm->avail_out = 0;
+                m_strm->next_out = nullptr;
 
                 zlib_guard.release();
             }
@@ -326,53 +333,53 @@ private:
         // The underlying converter already buffers, so this doesn't cause syscalls.
         reader.reset(1);
 
-        constexpr size_t max_type_limit = std::numeric_limits<decltype(m_strm.avail_out)>::max();
+        constexpr size_t max_type_limit = std::numeric_limits<decltype(m_strm->avail_out)>::max();
         constexpr size_t max_chunk = max_type_limit - (max_type_limit % sizeof(internal_type));
 
         auto aim_output = (max_chunk / sizeof(internal_type) > to_max)
-                        ? static_cast<decltype(m_strm.avail_out)>(to_max * sizeof(internal_type))
-                        : static_cast<decltype(m_strm.avail_out)>(max_chunk);
+                        ? static_cast<decltype(m_strm->avail_out)>(to_max * sizeof(internal_type))
+                        : static_cast<decltype(m_strm->avail_out)>(max_chunk);
 
-        m_strm.avail_out = aim_output;
-        m_strm.next_out = reinterpret_cast<unsigned char*>(to); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
-        auto ret = inflate(&m_strm, Z_NO_FLUSH);
+        m_strm->avail_out = aim_output;
+        m_strm->next_out = reinterpret_cast<unsigned char*>(to); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
+        auto ret = inflate(m_strm.get(), Z_NO_FLUSH);
         zerr<true>("zlib_cvt::get fail", ret);
 
-        while (m_strm.avail_out && ret != Z_STREAM_END)
+        while (m_strm->avail_out && ret != Z_STREAM_END)
         {
             auto [ptr, len] = reader.get_buf(1);
             if (len == 0) break;
-            m_strm.next_in = const_cast<unsigned char*>(reinterpret_cast<const unsigned char*>(ptr)); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast,cppcoreguidelines-pro-type-const-cast)
-            m_strm.avail_in = 1;
+            m_strm->next_in = const_cast<unsigned char*>(reinterpret_cast<const unsigned char*>(ptr)); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast,cppcoreguidelines-pro-type-const-cast)
+            m_strm->avail_in = 1;
             // Snapshot before the call so we can prove zlib made progress on at
             // least one axis (input consumed or output produced). The Z_OK
             // contract guarantees this, but enforcing it here turns a
             // hypothetical infinite loop into an explicit failure if the
             // library ever diverges from its contract.
-            const auto prev_avail_in = m_strm.avail_in;
-            const auto prev_avail_out = m_strm.avail_out;
-            ret = inflate(&m_strm, Z_NO_FLUSH);
+            const auto prev_avail_in = m_strm->avail_in;
+            const auto prev_avail_out = m_strm->avail_out;
+            ret = inflate(m_strm.get(), Z_NO_FLUSH);
             // Invariant: When output space is available, inflate() always consumes
             // all provided input into its internal state, even if no output is
             // produced yet. This assert guards against zlib misbehavior or memory
             // corruption during development.
-            assert(m_strm.avail_in == 0);
+            assert(m_strm->avail_in == 0);
             zerr("zlib_cvt::get fail", ret);
-            if (m_strm.avail_in == prev_avail_in && m_strm.avail_out == prev_avail_out)
+            if (m_strm->avail_in == prev_avail_in && m_strm->avail_out == prev_avail_out)
                 throw cvt_error("zlib_cvt::get fail: zlib made no progress");
         }
 
         // Exiting the loop with output space still available means the underlying
         // kernel ran out of bytes before zlib reached Z_STREAM_END. The compressed
         // stream is truncated and partial output would silently corrupt caller data.
-        if (ret != Z_STREAM_END && m_strm.avail_out != 0)
+        if (ret != Z_STREAM_END && m_strm->avail_out != 0)
             throw cvt_error("zlib_cvt::get fail: compressed stream truncated");
 
-        auto res = aim_output - m_strm.avail_out;
-        m_strm.next_in = nullptr;
-        m_strm.avail_in = 0;
-        m_strm.next_out = nullptr;
-        m_strm.avail_out = 0;
+        auto res = aim_output - m_strm->avail_out;
+        m_strm->next_in = nullptr;
+        m_strm->avail_in = 0;
+        m_strm->next_out = nullptr;
+        m_strm->avail_out = 0;
 
         if (res % sizeof(internal_type))
             throw cvt_error("zlib_cvt::get fail: partial sequence");
@@ -382,7 +389,7 @@ private:
     void put_main(cvt_writer<KernelType>& writer, const internal_type* _to, size_t to_size)
         requires (cvt_cpt::support_put<KernelType>)
     {
-        constexpr size_t max_type_limit = std::numeric_limits<decltype(m_strm.avail_out)>::max();
+        constexpr size_t max_type_limit = std::numeric_limits<decltype(m_strm->avail_out)>::max();
         constexpr size_t max_chunk = max_type_limit - (max_type_limit % sizeof(internal_type));
 
         auto to = reinterpret_cast<const unsigned char*>(_to); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
@@ -391,43 +398,43 @@ private:
         while (to_size > 0)
         {
             auto aim_output = (max_chunk / sizeof(internal_type) > to_size)
-                            ? static_cast<decltype(m_strm.avail_out)>(to_size * sizeof(internal_type))
-                            : static_cast<decltype(m_strm.avail_out)>(max_chunk);
+                            ? static_cast<decltype(m_strm->avail_out)>(to_size * sizeof(internal_type))
+                            : static_cast<decltype(m_strm->avail_out)>(max_chunk);
 
             size_t write_size = 0;
             while (aim_output != write_size)
             {
-                m_strm.next_in = const_cast<unsigned char*>(to + write_size); // NOLINT(cppcoreguidelines-pro-type-const-cast)
+                m_strm->next_in = const_cast<unsigned char*>(to + write_size); // NOLINT(cppcoreguidelines-pro-type-const-cast)
                 auto cur_put_size = static_cast<size_t>(aim_output - write_size);
-                m_strm.avail_in = static_cast<decltype(m_strm.avail_in)>(cur_put_size);
-                m_strm.next_out = reinterpret_cast<unsigned char*>(writer.put_buf(CHUNK)); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
-                m_strm.avail_out = CHUNK;
+                m_strm->avail_in = static_cast<decltype(m_strm->avail_in)>(cur_put_size);
+                m_strm->next_out = reinterpret_cast<unsigned char*>(writer.put_buf(CHUNK)); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
+                m_strm->avail_out = CHUNK;
 
                 // Snapshot before the call so we can prove zlib made progress on
                 // at least one axis (input consumed or output produced). The
                 // Z_OK contract guarantees this, but enforcing it here turns a
                 // hypothetical infinite loop into an explicit failure if the
                 // library ever diverges from its contract.
-                const auto prev_avail_in = m_strm.avail_in;
-                const auto prev_avail_out = m_strm.avail_out;
-                auto ret = deflate(&m_strm, Z_NO_FLUSH);
+                const auto prev_avail_in = m_strm->avail_in;
+                const auto prev_avail_out = m_strm->avail_out;
+                auto ret = deflate(m_strm.get(), Z_NO_FLUSH);
                 zerr("zlib_cvt::put fail", ret);
-                if (m_strm.avail_in == prev_avail_in && m_strm.avail_out == prev_avail_out)
+                if (m_strm->avail_in == prev_avail_in && m_strm->avail_out == prev_avail_out)
                     throw cvt_error("zlib_cvt::put fail: zlib made no progress");
-                write_size += cur_put_size - m_strm.avail_in;
+                write_size += cur_put_size - m_strm->avail_in;
 
-                if (m_strm.avail_out)
-                    writer.rollback(m_strm.avail_out);
+                if (m_strm->avail_out)
+                    writer.rollback(m_strm->avail_out);
             }
             to += aim_output;
             to_size -= aim_output / sizeof(internal_type);
         }
         // commit() is the responsibility of abs_cvt::put.
 
-        m_strm.next_out = nullptr;
-        m_strm.avail_out = 0;
-        m_strm.next_in = nullptr;
-        m_strm.avail_in = 0;
+        m_strm->next_out = nullptr;
+        m_strm->avail_out = 0;
+        m_strm->next_in = nullptr;
+        m_strm->avail_in = 0;
     }
 
     void do_flush()
@@ -445,20 +452,20 @@ private:
                     strm.next_out = nullptr;
                     strm.avail_out = 0;
                 }
-            } guard{m_strm};
+            } guard{*m_strm};
 
             std::array<external_type, CHUNK> local_buf{};
-            m_strm.next_in = nullptr;
-            m_strm.avail_in = 0;
+            m_strm->next_in = nullptr;
+            m_strm->avail_in = 0;
             while (true)
             {
-                m_strm.next_out = reinterpret_cast<unsigned char*>(local_buf.data()); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
-                m_strm.avail_out = CHUNK;
-                zerr("zlib_cvt::do_flush fail", deflate(&m_strm, Z_SYNC_FLUSH));
-                const size_t written = CHUNK - m_strm.avail_out;
+                m_strm->next_out = reinterpret_cast<unsigned char*>(local_buf.data()); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
+                m_strm->avail_out = CHUNK;
+                zerr("zlib_cvt::do_flush fail", deflate(m_strm.get(), Z_SYNC_FLUSH));
+                const size_t written = CHUNK - m_strm->avail_out;
                 if (written > 0)
                     BT::m_kernel.put(local_buf.data(), written);
-                if (m_strm.avail_out)
+                if (m_strm->avail_out)
                     break;
             }
         }
@@ -499,46 +506,47 @@ private:
                 self.BT::m_is_bos_done = false;
                 self.BT::m_io_status = io_status::neutral;
                 self.m_sync_flush = false;
-                self.m_strm.next_out = nullptr;
-                self.m_strm.avail_out = 0;
             }
         } sg{*this};
 
-        // Skip cleanup if zlib was never successfully initialized.
-        // z_stream.state is set to a valid pointer by inflateInit()/deflateInit()
-        // on success, and reset to Z_NULL by inflateEnd()/deflateEnd().
-        if (m_strm.state == Z_NULL)
+        // Skip cleanup if zlib was never successfully initialized (m_strm is
+        // null until bos() calls inflateInit/deflateInit, and is reset to null
+        // by the guards on both the success and failure paths).
+        if (!m_strm)
             return;
 
         if (BT::m_io_status == io_status::output)
         {
-            deflate_guard g(m_strm);
+            deflate_guard g(m_strm);  // calls deflateEnd + resets m_strm on scope exit
             if (BT::m_is_bos_done)
             {
                 std::array<external_type, CHUNK> local_buf{};
-                m_strm.next_in = nullptr;
-                m_strm.avail_in = 0;
+                m_strm->next_in = nullptr;
+                m_strm->avail_in = 0;
                 while (true)
                 {
-                    m_strm.next_out = reinterpret_cast<unsigned char*>(local_buf.data()); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
-                    m_strm.avail_out = CHUNK;
-                    zerr("zlib_cvt::close_stream fail", deflate(&m_strm, Z_FINISH));
-                    const size_t written = CHUNK - m_strm.avail_out;
+                    m_strm->next_out = reinterpret_cast<unsigned char*>(local_buf.data()); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
+                    m_strm->avail_out = CHUNK;
+                    zerr("zlib_cvt::close_stream fail", deflate(m_strm.get(), Z_FINISH));
+                    const size_t written = CHUNK - m_strm->avail_out;
                     if (written > 0)
                         BT::m_kernel.put(local_buf.data(), written);
-                    if (m_strm.avail_out)
+                    if (m_strm->avail_out)
                         break;
                 }
             }
         }
         else if (BT::m_io_status == io_status::input)
-            inflateEnd(&m_strm);
+        {
+            inflateEnd(m_strm.get());
+            m_strm.reset();
+        }
     }
 private:
     unsigned    m_put_level;
     bool        m_sync_flush{false};
 
-    z_stream    m_strm{};
+    std::unique_ptr<z_stream> m_strm;
 };
 
 template <typename TInt>

--- a/include/cvt/comp/zlib_cvt.h
+++ b/include/cvt/comp/zlib_cvt.h
@@ -117,39 +117,18 @@ public:
         }
     }
 
-    zlib_cvt(zlib_cvt&& val) // NOLINT(cppcoreguidelines-noexcept-move-operations,performance-noexcept-move-constructor)
+    zlib_cvt(zlib_cvt&& val) noexcept
         : BT(std::move(val))
         , m_put_level(val.m_put_level)
         , m_sync_flush(val.m_sync_flush)
+        , m_strm(val.m_strm)
     {
-        if (BT::m_io_status == io_status::output)
-        {
-            m_strm.state = Z_NULL;  // Ensure state is NULL if deflateCopy fails partway
-            deflate_guard g(val.m_strm);
-            try
-            {
-                zerr("zlib_cvt move constructor fail", deflateCopy(&m_strm, &val.m_strm));
-            }
-            catch (...)
-            {
-                BT::m_io_status = io_status::neutral;
-                throw;
-            }
-        }
-        else if (BT::m_io_status == io_status::input)
-        {
-            m_strm.state = Z_NULL;  // Ensure state is NULL if inflateCopy fails partway
-            inflate_guard g(val.m_strm);
-            try
-            {
-                zerr("zlib_cvt move constructor fail", inflateCopy(&m_strm, &val.m_strm));
-            }
-            catch (...)
-            {
-                BT::m_io_status = io_status::neutral;
-                throw;
-            }
-        }
+        // Transfer ownership: null out source's state to prevent double-free.
+        // deflateEnd/inflateEnd will return Z_STREAM_ERROR on NULL state,
+        // which is safe (no cleanup performed, no crash).
+        val.m_strm.state = Z_NULL;
+        val.m_strm.next_in = nullptr;
+        val.m_strm.next_out = nullptr;
     }
 
     zlib_cvt& operator=(const zlib_cvt& val)
@@ -175,40 +154,25 @@ public:
         }
     }
 
-    zlib_cvt& operator=(zlib_cvt&& val) // NOLINT(cppcoreguidelines-noexcept-move-operations,performance-noexcept-move-constructor)
+    zlib_cvt& operator=(zlib_cvt&& val) noexcept
     {
         if (this == &val) return *this;
-        close_stream();
+
+        // Best-effort cleanup of current stream; ignore exceptions since we're
+        // replacing the state anyway.
+        try { close_stream(); }
+        catch (...) {} // NOLINT(bugprone-empty-catch)
+
         BT::operator=(std::move(val));
         m_put_level = val.m_put_level;
         m_sync_flush = val.m_sync_flush;
+        m_strm = val.m_strm;
 
-        if (BT::m_io_status == io_status::output)
-        {
-            deflate_guard g(val.m_strm);
-            try
-            {
-                zerr("zlib_cvt move assignment fail", deflateCopy(&m_strm, &val.m_strm));
-            }
-            catch (...)
-            {
-                BT::set_tainted();
-                throw;
-            }
-        }
-        else if (BT::m_io_status == io_status::input)
-        {
-            inflate_guard g(val.m_strm);
-            try
-            {
-                zerr("zlib_cvt move assignment fail", inflateCopy(&m_strm, &val.m_strm));
-            }
-            catch (...)
-            {
-                BT::set_tainted();
-                throw;
-            }
-        }
+        // Transfer ownership: null out source's state to prevent double-free.
+        val.m_strm.state = Z_NULL;
+        val.m_strm.next_in = nullptr;
+        val.m_strm.next_out = nullptr;
+
         return *this;
     }
 

--- a/include/cvt/crypt/hash_cvt.h
+++ b/include/cvt/crypt/hash_cvt.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <memory>
+#include <type_traits>
 #include <botan/hash.h>
 #include <botan/hex.h>
 
@@ -68,7 +69,7 @@ public:
         , m_out_fmt(val.m_out_fmt)
     {}
 
-    hash_cvt(hash_cvt&& val)
+    hash_cvt(hash_cvt&& val) noexcept
         : BT(std::move(val))
         , m_hash(std::move(val.m_hash))
         , m_has_main_cont(val.m_has_main_cont)
@@ -92,12 +93,17 @@ public:
         return *this;
     }
     
-    hash_cvt& operator=(hash_cvt&& val)
+    hash_cvt& operator=(hash_cvt&& val) noexcept
     {
         if (this != &val)
         {
+            // Best-effort flush: if dump_stream fails, we accept data loss
+            // since the old state is being replaced anyway.
             if (m_has_main_cont)
-                dump_stream();
+            {
+                try { dump_stream(); }
+                catch (...) {} // NOLINT(bugprone-empty-catch)
+            }
             m_hash = std::move(val.m_hash);
             m_has_main_cont = val.m_has_main_cont;
             m_out_fmt = val.m_out_fmt;
@@ -111,7 +117,10 @@ public:
     ~hash_cvt()
     {
         if (m_has_main_cont)
-            dump_stream();
+        {
+            try { dump_stream(); }
+            catch (...) {} // NOLINT(bugprone-empty-catch)
+        }
     }
 
 // mandatory methods

--- a/include/cvt/cvt_concepts.h
+++ b/include/cvt/cvt_concepts.h
@@ -241,7 +241,8 @@ namespace IOv2
      * 满足此概念的类型 T 须同时具备：
      * - 至少支持读取（`support_get`）或写入（`support_put`）操作之一；
      * - 满足 `mandatory_methods` 所规定的全部基础接口；
-     * - 定义 `internal_type`（内部数据类型）和 `external_type`（外部数据类型）关联类型。
+     * - 定义 `internal_type`（内部数据类型）和 `external_type`（外部数据类型）关联类型；
+     * - 移动构造和移动赋值操作不能抛出异常。
      * @endif
      *
      * @lang{EN}
@@ -250,12 +251,15 @@ namespace IOv2
      * - Support at least one of `support_get` (read) or `support_put` (write);
      * - Satisfy all mandatory interfaces defined by `mandatory_methods`;
      * - Expose both `internal_type` (internal data type) and `external_type`
-     *   (external data type) as associated types.
+     *   (external data type) as associated types;
+     * - Have noexcept move construction and move assignment.
      * @endif
      */
     template<typename T>
     concept io_converter = (cvt_cpt::support_put<T> || cvt_cpt::support_get<T>) &&
         cvt_cpt::mandatory_methods<T> &&
+        std::is_nothrow_move_constructible_v<T> &&
+        std::is_nothrow_move_assignable_v<T> &&
         requires {
             typename T::internal_type;
             typename T::external_type;

--- a/include/cvt/root_cvt.h
+++ b/include/cvt/root_cvt.h
@@ -222,10 +222,7 @@ public:
      * @lang{ZH} 源对象，移动后处于有效但未指定的状态。 @endif
      * @lang{EN} Source object, left in a valid but unspecified state after the move. @endif
      */
-    root_cvt(root_cvt&& val) noexcept(
-                std::is_nothrow_move_constructible_v<device_type> &&
-                std::is_nothrow_move_constructible_v<std::vector<external_type>>
-            )
+    root_cvt(root_cvt&& val) noexcept
         : m_device(std::move(val.m_device))
         , m_bos_len(val.m_bos_len)
         , m_io_status(val.m_io_status)
@@ -296,8 +293,7 @@ public:
      * @lang{ZH} *this 的引用。 @endif
      * @lang{EN} Reference to *this. @endif
      */
-    root_cvt& operator=(root_cvt&& val)
-        noexcept(std::is_nothrow_move_assignable_v<device_type>)
+    root_cvt& operator=(root_cvt&& val) noexcept
     {
         if (this == &val) return *this;
 
@@ -1134,8 +1130,7 @@ public:
      * @lang{ZH} 源对象，移动后处于有效但未指定的状态。 @endif
      * @lang{EN} Source object, left in a valid but unspecified state after the move. @endif
      */
-    root_cvt(root_cvt&& val)
-        noexcept(std::is_nothrow_move_constructible_v<device_type>)
+    root_cvt(root_cvt&& val) noexcept
         : m_device(std::move(val.m_device))
         , m_bos_len(val.m_bos_len)
         , m_io_status(val.m_io_status)
@@ -1183,8 +1178,7 @@ public:
      * @lang{ZH} *this 的引用。 @endif
      * @lang{EN} Reference to *this. @endif
      */
-    root_cvt& operator=(root_cvt&& val)
-        noexcept(std::is_nothrow_move_assignable_v<device_type>)
+    root_cvt& operator=(root_cvt&& val) noexcept
     {
         if (this == &val) return *this;
         m_device = std::move(val.m_device);

--- a/include/cvt/runtime_cvt.h
+++ b/include/cvt/runtime_cvt.h
@@ -212,8 +212,9 @@ public:
     using external_type = typename device_type::char_type;
 
 public:
-    template <io_converter KernelType>
+    template <typename KernelType>
         requires (!std::is_same_v<std::remove_cvref_t<KernelType>, runtime_cvt> &&
+                  io_converter<std::remove_cvref_t<KernelType>> &&
                   (!std::is_lvalue_reference_v<KernelType> ||
                    std::copy_constructible<std::remove_cvref_t<KernelType>>))
     runtime_cvt(KernelType&& kernel)

--- a/include/device/device_concepts.h
+++ b/include/device/device_concepts.h
@@ -14,6 +14,7 @@
 #pragma once
 #include <concepts>
 #include <cstddef>
+#include <type_traits>
 #include <utility>
 
 namespace IOv2
@@ -106,20 +107,24 @@ namespace IOv2
      * @brief I/O 设备的统一概念。
      *
      * 一个类型如果能被称为 I/O 设备，它必须定义 `char_type` 类型，
-     * 并且至少支持读取（support_get）或写入（support_put）操作之一。
+     * 至少支持读取（support_get）或写入（support_put）操作之一，
+     * 并且移动构造和移动赋值操作不能抛出异常。
      * @tparam T 要检查的设备类型。
      * @endif
      *
      * @lang{EN}
      * @brief Unified concept for an I/O device.
      *
-     * For a type to be considered an I/O device, it must define the `char_type` type
-     * and support at least one of read (support_get) or write (support_put) operations.
+     * For a type to be considered an I/O device, it must define the `char_type` type,
+     * support at least one of read (support_get) or write (support_put) operations,
+     * and have noexcept move construction and move assignment.
      * @tparam T The device type to check.
      * @endif
      */
     template <typename T>
     concept io_device =
         requires{ typename T::char_type; } &&
+        std::is_nothrow_move_constructible_v<T> &&
+        std::is_nothrow_move_assignable_v<T> &&
         (dev_cpt::support_put<T> || dev_cpt::support_get<T>);
 }

--- a/include/device/mem_device.h
+++ b/include/device/mem_device.h
@@ -40,6 +40,8 @@ namespace IOv2
  * @tparam CharT 字符类型。
  * @tparam Traits 字符类型的特性，默认为 `std::char_traits<CharT>`。
  * @tparam Allocator 内存分配器，默认为 `std::allocator<CharT>`。
+ *         必须满足 `is_always_equal` 或 `propagate_on_container_move_assignment`，
+ *         以确保移动赋值操作为 noexcept。
  * @endif
  *
  * @lang{EN}
@@ -54,12 +56,16 @@ namespace IOv2
  * @tparam CharT The character type.
  * @tparam Traits The character traits, defaulting to `std::char_traits<CharT>`.
  * @tparam Allocator The memory allocator, defaulting to `std::allocator<CharT>`.
+ *         Must satisfy `is_always_equal` or `propagate_on_container_move_assignment`
+ *         to ensure noexcept move assignment.
  * @endif
  */
 template <class CharT,
           class Traits = std::char_traits<CharT>,
           class Allocator = std::allocator<CharT>>
-    requires std::is_trivially_copyable_v<CharT>
+    requires std::is_trivially_copyable_v<CharT> &&
+             (std::allocator_traits<Allocator>::is_always_equal::value ||
+              std::allocator_traits<Allocator>::propagate_on_container_move_assignment::value)
 class mem_device
 {
 public:
@@ -109,9 +115,7 @@ public:
         other.m_put_buf_checkpoint.reset();
     }
 
-    mem_device& operator=(mem_device&& other)
-        noexcept(std::allocator_traits<Allocator>::propagate_on_container_move_assignment::value ||
-                 std::allocator_traits<Allocator>::is_always_equal::value)
+    mem_device& operator=(mem_device&& other) noexcept
     {
         if (this != &other)
         {


### PR DESCRIPTION
- Enforce noexcept move construction/assignment in io_converter and io_device concepts.
- Implement noexcept move operations for abs_cvt, code_cvt, hash_cvt, root_cvt, and mem_device.
- Refactor zlib_cvt to use ownership-transfer move semantics instead of deflateCopy/inflateCopy, ensuring noexcept.
- Add allocator constraints to mem_device to guarantee noexcept move operations.