### PR TITLE
feat(cvt): update detach() to return exception_ptr for safe cleanup

### DIFF
--- a/include/cvt/abs_cvt.h
+++ b/include/cvt/abs_cvt.h
@@ -26,6 +26,8 @@
 #include <cvt/cvt_concepts.h>
 
 #include <cstring>
+#include <exception>
+#include <utility>
 #include <vector>
 
 namespace IOv2
@@ -847,6 +849,10 @@ namespace IOv2
          * 分离并返回底层设备，同时将转换器状态重置为初始状态。
          *
          * 调用后 `m_io_status` 恢复为 `neutral`，`m_is_bos_done` 恢复为 `false`。
+         *
+         * 本函数为 `noexcept`：底层 kernel `detach()` 的清理异常通过其返回值的 `exception_ptr`
+         * 透传，本层不再额外捕获或转换（first-failure-wins）。设备始终通过返回值的 `first`
+         * 无条件交还给调用方。
          * @endif
          *
          * @lang{EN}
@@ -855,13 +861,18 @@ namespace IOv2
          *
          * After the call `m_io_status` is reset to `neutral` and `m_is_bos_done`
          * is reset to `false`.
+         *
+         * This function is `noexcept`: the kernel's cleanup exception (if any) is
+         * forwarded unchanged via the returned `exception_ptr` (first-failure-wins);
+         * this layer does not capture or rewrap it. The device is always handed back
+         * unconditionally via `first`.
          * @endif
          *
          * @return
-         * @lang{ZH} 已从 kernel 中分离的底层设备对象（右值）。 @endif
-         * @lang{EN} The underlying device object detached from the kernel (returned by value). @endif
+         * @lang{ZH} pair：`first` 为已从 kernel 中分离的底层设备对象（右值），`second` 为底层清理捕获的首个异常（`nullptr` 表示无异常）。 @endif
+         * @lang{EN} A pair: `first` is the device detached from the kernel (rvalue); `second` is the first exception captured by the underlying cleanup (`nullptr` if none). @endif
          */
-        device_type detach()
+        std::pair<device_type, std::exception_ptr> detach() noexcept
         {
             auto result = m_kernel.detach();
             m_io_status = io_status::neutral;

--- a/include/cvt/code_cvt.h
+++ b/include/cvt/code_cvt.h
@@ -36,6 +36,7 @@
 #include <cstdint>
 #include <cstdlib>
 #include <cwchar>
+#include <exception>
 #include <functional>
 #include <limits>
 #include <string>
@@ -836,20 +837,32 @@ public:
      * @lang{ZH}
      * 关闭当前流并移除底层设备，返回该设备的所有权。
      *
-     * @return 底层设备的所有权。
+     * 本函数为 `noexcept`：`close_stream()` 的清理异常被捕获为返回值 `second`
+     * 中的 `exception_ptr`，并按 first-failure-wins 与底层 `BT::detach()` 返回的
+     * 异常合并（本层捕获到的异常优先）。设备始终通过返回值 `first` 无条件交还。
+     *
+     * @return pair：`first` 为底层设备所有权，`second` 为捕获的首个清理异常（`nullptr` 表示无异常）。
      * @endif
      *
      * @lang{EN}
      * Close the current stream, remove the underlying device, and return
      * ownership of it.
      *
-     * @return Ownership of the underlying device.
+     * This function is `noexcept`: any exception from `close_stream()` is captured
+     * into the returned pair's `second` (`exception_ptr`) and merged under
+     * first-failure-wins with the one returned by `BT::detach()` (local exception
+     * wins). The device is always handed back unconditionally via `first`.
+     *
+     * @return A pair: `first` is ownership of the underlying device; `second` is the first captured cleanup exception (`nullptr` if none).
      * @endif
      */
-    device_type detach()
+    std::pair<device_type, std::exception_ptr> detach() noexcept
     {
-        close_stream();
-        return BT::detach();
+        std::exception_ptr local_err;
+        try { close_stream(); }
+        catch (...) { local_err = std::current_exception(); }
+        auto [dev, inner_err] = BT::detach();
+        return { std::move(dev), local_err ? local_err : inner_err };
     }
 
     /**

--- a/include/cvt/comp/zlib_cvt.h
+++ b/include/cvt/comp/zlib_cvt.h
@@ -7,6 +7,7 @@
 #include <array>
 #include <cassert>
 #include <concepts>
+#include <exception>
 #include <limits>
 #include <memory>
 #include <string>
@@ -198,10 +199,13 @@ public:
         return BT::attach(std::move(dev));
     }
 
-    device_type detach()
+    std::pair<device_type, std::exception_ptr> detach() noexcept
     {
-        close_stream();
-        return BT::detach();
+        std::exception_ptr local_err;
+        try { close_stream(); }
+        catch (...) { local_err = std::current_exception(); }
+        auto [dev, inner_err] = BT::detach();
+        return { std::move(dev), local_err ? local_err : inner_err };
     }
 
     void adjust(const cvt_behavior& acc)

--- a/include/cvt/crypt/chacha20_cvt.h
+++ b/include/cvt/crypt/chacha20_cvt.h
@@ -1,7 +1,9 @@
 #pragma once
+#include <exception>
 #include <memory>
 #include <string>
 #include <string_view>
+#include <utility>
 #include <vector>
 #include <botan/auto_rng.h>
 #include <botan/stream_cipher.h>
@@ -72,10 +74,13 @@ public:
         return BT::attach(std::move(dev));
     }
     
-    device_type detach()
+    std::pair<device_type, std::exception_ptr> detach() noexcept
     {
-        m_cipher->clear();
-        return BT::detach();
+        std::exception_ptr local_err;
+        try { m_cipher->clear(); }
+        catch (...) { local_err = std::current_exception(); }
+        auto [dev, inner_err] = BT::detach();
+        return { std::move(dev), local_err ? local_err : inner_err };
     }
     
     io_status bos()

--- a/include/cvt/crypt/hash_cvt.h
+++ b/include/cvt/crypt/hash_cvt.h
@@ -1,6 +1,8 @@
 #pragma once
+#include <exception>
 #include <memory>
 #include <type_traits>
+#include <utility>
 #include <botan/hash.h>
 #include <botan/hex.h>
 
@@ -147,13 +149,15 @@ public:
         return BT::attach(std::move(dev));
     }
 
-    device_type detach()
+    std::pair<device_type, std::exception_ptr> detach() noexcept
     {
-        if (m_has_main_cont)
-            dump_stream();
+        std::exception_ptr local_err;
+        try { if (m_has_main_cont) dump_stream(); }
+        catch (...) { local_err = std::current_exception(); }
         m_has_main_cont = false;
         m_out_fmt = hash_fmt::lower_hex;
-        return BT::detach();
+        auto [dev, inner_err] = BT::detach();
+        return { std::move(dev), local_err ? local_err : inner_err };
     }
     
     void adjust(const cvt_behavior& acc)

--- a/include/cvt/crypt/vigenere_cvt.h
+++ b/include/cvt/crypt/vigenere_cvt.h
@@ -1,6 +1,8 @@
 #pragma once
+#include <exception>
 #include <stdexcept>
 #include <string_view>
+#include <utility>
 #include <vector>
 #include <cvt/cvt_concepts.h>
 #include <cvt/abs_cvt.h>
@@ -59,7 +61,7 @@ public:
         return BT::attach(std::move(dev));
     }
 
-    device_type detach()
+    std::pair<device_type, std::exception_ptr> detach() noexcept
     {
         m_pos = 0;
         return BT::detach();

--- a/include/cvt/cvt_concepts.h
+++ b/include/cvt/cvt_concepts.h
@@ -19,6 +19,7 @@
 
 #include <concepts>
 #include <cstddef>
+#include <exception>
 #include <type_traits>
 #include <utility>
 
@@ -224,7 +225,7 @@ namespace IOv2
                                              const cvt_behavior& b, cvt_status& s)
             {
                 { a.device() } -> std::same_as<typename T::device_type&>;
-                { a.detach() } -> std::same_as<typename T::device_type>;
+                { a.detach() } noexcept -> std::same_as<std::pair<typename T::device_type, std::exception_ptr>>;
                 { a.attach(std::declval<typename T::device_type>()) } -> std::same_as<typename T::device_type>;
 
                 { a.bos() } -> std::same_as<io_status>;

--- a/include/cvt/cvt_facilities.h
+++ b/include/cvt/cvt_facilities.h
@@ -17,8 +17,10 @@
 #include <device/mem_device.h>
 
 #include <array>
+#include <exception>
 #include <string>
 #include <string_view>
+#include <utility>
 
 namespace IOv2::detail
 {
@@ -199,7 +201,9 @@ namespace IOv2::detail
         tmp_cvt.main_cont_beg();
 
         tmp_cvt.put(val.data(), val.size());
-        return tmp_cvt.detach().str();
+        auto res = tmp_cvt.detach();
+        if (res.second) std::rethrow_exception(res.second);
+        return std::move(res.first).str();
     }
 
     /**
@@ -233,6 +237,8 @@ namespace IOv2::detail
         tmp_cvt.main_cont_beg();
 
         tmp_cvt.put(&val, 1);
-        return tmp_cvt.detach().str();
+        auto res = tmp_cvt.detach();
+        if (res.second) std::rethrow_exception(res.second);
+        return std::move(res.first).str();
     }
 }

--- a/include/cvt/root_cvt.h
+++ b/include/cvt/root_cvt.h
@@ -18,6 +18,7 @@
 #include <device/mem_device.h>
 
 #include <cassert>
+#include <exception>
 #include <limits>
 #include <type_traits>
 #include <utility>
@@ -370,37 +371,50 @@ public:
     /**
      * @lang{ZH}
      * 将底层设备从 root_cvt 中分离并返回。
-     * - 若当前处于输出状态，先将缓冲区刷入设备。
+     * - 若当前处于输出状态，先尝试将缓冲区刷入设备。
      * - 若当前处于输入状态且缓冲区中仍有未消费数据，则将设备位置倒回到未消费数据的起始处（需设备支持定位）。
      *
+     * 本函数为 `noexcept`：清理阶段的异常会被捕获并存入返回值的 `second`（`exception_ptr`），
+     * 设备始终通过返回值的 `first` 无条件交还给调用方，即便清理失败。
      * 调用后，root_cvt 内部状态被重置为初始状态，不再持有有效设备。
      * @endif
      *
      * @lang{EN}
      * Detaches the underlying device from root_cvt and returns it.
-     * - If currently in output mode, flushes buffered data to the device first.
+     * - If currently in output mode, attempts to flush buffered data to the device.
      * - If currently in input mode with unconsumed buffered data, seeks the device
      *   back to the start of unconsumed data (requires the device to support positioning).
      *
+     * This function is `noexcept`: any exception thrown during cleanup is captured
+     * into the returned pair's `second` (`exception_ptr`); the device is always
+     * handed back unconditionally via `first` even if cleanup failed.
      * After this call, root_cvt's internal state is reset and it no longer holds a valid device.
      * @endif
      *
      * @return
-     * @lang{ZH} 已分离的设备对象（通过移动语义返回）。 @endif
-     * @lang{EN} The detached device object, returned via move semantics. @endif
+     * @lang{ZH} pair：`first` 为已分离的设备对象（通过移动语义返回），`second` 为清理阶段捕获的首个异常（`nullptr` 表示无异常）。 @endif
+     * @lang{EN} A pair: `first` is the detached device (returned via move); `second` is the first exception captured during cleanup (`nullptr` if none). @endif
      */
-    device_type detach()
+    std::pair<device_type, std::exception_ptr> detach() noexcept
     {
-        if (m_io_status == io_status::output)
+        std::exception_ptr err;
+        try
         {
-            if constexpr (dev_cpt::support_put<device_type>)
-                flush();
+            if (m_io_status == io_status::output)
+            {
+                if constexpr (dev_cpt::support_put<device_type>)
+                    flush();
+            }
+            else if ((m_io_status == io_status::input) &&
+                     (m_buf_cur != m_buf_end))
+            {
+                if constexpr (dev_cpt::support_positioning<device_type>)
+                    seek(tell());
+            }
         }
-        else if ((m_io_status == io_status::input) &&
-                 (m_buf_cur != m_buf_end))
+        catch (...)
         {
-            if constexpr (dev_cpt::support_positioning<device_type>)
-                seek(tell());
+            err = std::current_exception();
         }
 
         m_bos_len = 0;
@@ -408,7 +422,7 @@ public:
         m_buf_end = m_buffer.data();
         m_io_status = io_status::neutral;
 
-        return std::move(m_device);
+        return {std::move(m_device), err};
     }
 
     /**
@@ -432,7 +446,7 @@ public:
      */
     device_type attach(device_type&& dev = device_type{})
     {
-        auto res = detach();
+        auto detach_res = detach();
         m_device = std::move(dev);
         m_bos_len = 0;
 
@@ -440,7 +454,8 @@ public:
         m_buf_cur = m_buffer.data();
         m_buf_end = m_buffer.data();
         m_io_status = io_status::neutral;
-        return res;
+        if (detach_res.second) std::rethrow_exception(detach_res.second);
+        return std::move(detach_res.first);
     }
 
     /**
@@ -1213,25 +1228,26 @@ public:
     /**
      * @lang{ZH}
      * 将底层 mem_device 从 root_cvt 中分离并返回。
-     * mem_device 无需刷新，直接移动返回。
-     * 调用后，root_cvt 内部状态被重置为初始状态。
+     * mem_device 无需刷新，无清理动作可抛出异常；返回 pair 的 `second` 始终为 `nullptr`。
+     * 调用后，root_cvt 内部状态被重置为初始状态。本函数为 `noexcept`。
      * @endif
      *
      * @lang{EN}
      * Detaches the underlying mem_device from root_cvt and returns it.
-     * No flush is needed for mem_device; the device is returned via move.
-     * After this call, root_cvt's internal state is reset to initial values.
+     * No flush is needed for mem_device and no cleanup step can throw; the returned
+     * pair's `second` is always `nullptr`. After this call, root_cvt's internal state
+     * is reset to initial values. This function is `noexcept`.
      * @endif
      *
      * @return
-     * @lang{ZH} 已分离的设备对象（通过移动语义返回）。 @endif
-     * @lang{EN} The detached device object, returned via move semantics. @endif
+     * @lang{ZH} pair：`first` 为已分离的设备对象（通过移动语义返回），`second` 始终为 `nullptr`。 @endif
+     * @lang{EN} A pair: `first` is the detached device (returned via move); `second` is always `nullptr`. @endif
      */
-    device_type detach()
+    std::pair<device_type, std::exception_ptr> detach() noexcept
     {
         m_bos_len = 0;
         m_io_status = io_status::neutral;
-        return std::move(m_device);
+        return {std::move(m_device), nullptr};
     }
 
     /**
@@ -1253,12 +1269,12 @@ public:
      */
     device_type attach(device_type&& dev = device_type{})
     {
-        auto res = detach();
+        auto detach_res = detach();  // detach_res.second is always nullptr for mem_device
         m_device = std::move(dev);
         m_bos_len = 0;
 
         m_io_status = io_status::neutral;
-        return res;
+        return std::move(detach_res.first);
     }
 
     /**

--- a/include/cvt/runtime_cvt.h
+++ b/include/cvt/runtime_cvt.h
@@ -5,6 +5,7 @@
 #include <device/device_concepts.h>
 
 #include <concepts>
+#include <exception>
 #include <memory>
 #include <type_traits>
 #include <utility>
@@ -31,7 +32,7 @@ public:
     virtual std::unique_ptr<abs_runtime_cvt_imp> clone() const & = 0;
 
     virtual device_type& device() = 0;
-    virtual device_type detach() = 0;
+    virtual std::pair<device_type, std::exception_ptr> detach() noexcept = 0;
     virtual device_type attach(device_type&& dev = device_type{}) = 0;
     virtual void adjust(const cvt_behavior& acc) = 0;
     virtual void retrieve(cvt_status& acc) const = 0;
@@ -83,7 +84,7 @@ public:
         return m_kernel.device();
     }
 
-    device_type detach() override
+    std::pair<device_type, std::exception_ptr> detach() noexcept override
     {
         auto result = m_kernel.detach();
         m_io_status = io_status::neutral;
@@ -241,9 +242,11 @@ public:
         return m_ptr->device();
     }
 
-    device_type detach()
+    std::pair<device_type, std::exception_ptr> detach() noexcept
     {
-        if (!m_ptr) throw cvt_error("runtime_cvt: null instance");
+        if (!m_ptr)
+            return { device_type{},
+                     std::make_exception_ptr(cvt_error("runtime_cvt: null instance")) };
         return m_ptr->detach();
     }
 

--- a/include/io/objects/in_impl.h
+++ b/include/io/objects/in_impl.h
@@ -46,17 +46,18 @@ public:
             return old_sync_state;
         m_sync_with_stdio = sync;
 
-        auto dev = m_streambuf.detach();
+        auto [dev, err] = m_streambuf.detach();
         if constexpr (std::is_same_v<char_type, char>)
             m_streambuf = istreambuf<device_type, char_type>(std::move(dev), !sync);
         else if constexpr (std::is_same_v<char_type, wchar_t>)
             m_streambuf = istreambuf<device_type, wchar_t>(std::move(dev), code_cvt_stdio_creator(code()), !sync);
         else
             static_assert(dependent_false_v<char_type>, "invalid character type");
+        if (err) std::rethrow_exception(err);
         return old_sync_state;
     }
 
-    device_type detach()= delete;
+    std::pair<device_type, std::exception_ptr> detach() = delete;
     device_type attach(device_type&&) = delete;
 
     void reset() // mainly used for unit-test

--- a/include/io/objects/out_impl.h
+++ b/include/io/objects/out_impl.h
@@ -69,7 +69,7 @@ public:
         return res;
     }
 
-    device_type detach() = delete;
+    std::pair<device_type, std::exception_ptr> detach() = delete;
     device_type attach(device_type&& dev = device_type{}) = delete;
 
     void reset() // mainly used for unit-test

--- a/include/io/streambuf.h
+++ b/include/io/streambuf.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <deque>
+#include <exception>
 #include <optional>
 #include <type_traits>
 #include <utility>
@@ -197,7 +198,7 @@ public:
         return m_cvt.device();
     }
 
-    device_type detach()
+    std::pair<device_type, std::exception_ptr> detach() noexcept
     {
         if constexpr (IsIn)
             m_read_buf.clear();

--- a/include/io/utilities/stream_common_operators.h
+++ b/include/io/utilities/stream_common_operators.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <exception>
+#include <utility>
+
 #include <io/utilities/istream_operators.h>
 #include <io/utilities/ostream_operators.h>
 
@@ -63,7 +66,7 @@ struct stream_common_operators
         return obj.m_streambuf.device();
     }
 
-    TDevice detach()
+    std::pair<TDevice, std::exception_ptr> detach() noexcept
     {
         T& obj = static_cast<T&>(*this);
         return obj.m_streambuf.detach();

--- a/test/cvt/code_cvt/code_cvt_mem_char8_t.cpp
+++ b/test/cvt/code_cvt/code_cvt_mem_char8_t.cpp
@@ -319,7 +319,8 @@ void test_code_cvt_mem_char8_t_bos_2()
         obj.main_cont_beg();
         if (obj.tell() != 0) throw std::runtime_error("code_cvt<memory<char8_t>>::bos fail");
 
-        if (obj.detach().dtell() != 12) throw std::runtime_error("code_cvt<...char...>::bos fail");
+        auto [detach_dev, detach_err] = obj.detach();
+        if (detach_dev.dtell() != 12) throw std::runtime_error("code_cvt<...char...>::bos fail");
     };
     
     using CheckType = code_cvt<rb_root_cvt<mem_device<char8_t>>, char32_t>;
@@ -353,7 +354,8 @@ void test_code_cvt_mem_char8_t_bos_3()
         obj.main_cont_beg();
         if (obj.tell() != 0) throw std::runtime_error("code_cvt<memory<char8_t>>::bos fail");
 
-        if (obj.detach().dtell() != 12) throw std::runtime_error("code_cvt<memory<char8_t>>::bos fail");
+        auto [detach_dev, detach_err] = obj.detach();
+        if (detach_dev.dtell() != 12) throw std::runtime_error("code_cvt<memory<char8_t>>::bos fail");
     };
     
     using CheckType = code_cvt<rb_root_cvt<mem_device<char8_t>>, char32_t>;

--- a/test/cvt/code_cvt/code_cvt_mem_char8_t_wchar_t.cpp
+++ b/test/cvt/code_cvt/code_cvt_mem_char8_t_wchar_t.cpp
@@ -319,7 +319,8 @@ void test_code_cvt_mem_char8_t_wchar_t_bos_2()
         obj.main_cont_beg();
         if (obj.tell() != 0) throw std::runtime_error("code_cvt<memory<char8_t>>::bos fail");
 
-        if (obj.detach().dtell() != 12) throw std::runtime_error("code_cvt<...char...>::bos fail");
+        auto [detach_dev, detach_err] = obj.detach();
+        if (detach_dev.dtell() != 12) throw std::runtime_error("code_cvt<...char...>::bos fail");
     };
     
     using CheckType = code_cvt<rb_root_cvt<mem_device<char8_t>>, wchar_t>;
@@ -353,7 +354,8 @@ void test_code_cvt_mem_char8_t_wchar_t_bos_3()
         obj.main_cont_beg();
         if (obj.tell() != 0) throw std::runtime_error("code_cvt<memory<char8_t>>::bos fail");
 
-        if (obj.detach().dtell() != 12) throw std::runtime_error("code_cvt<memory<char8_t>>::bos fail");
+        auto [detach_dev, detach_err] = obj.detach();
+        if (detach_dev.dtell() != 12) throw std::runtime_error("code_cvt<memory<char8_t>>::bos fail");
     };
     
     using CheckType = code_cvt<rb_root_cvt<mem_device<char8_t>>, wchar_t>;

--- a/test/cvt/code_cvt/code_cvt_mem_char_char32_t.cpp
+++ b/test/cvt/code_cvt/code_cvt_mem_char_char32_t.cpp
@@ -214,7 +214,7 @@ void test_code_cvt_mem_char_gen_4()
             obj = obj2;
         }
 
-        auto dev = obj.detach();
+        auto [dev, err] = obj.detach();
         if (dev.str() != e_lit) throw std::runtime_error("code_cvt<memory<char>, char32_t>::put response incorrect");
     };
 
@@ -274,7 +274,7 @@ void test_code_cvt_mem_char_gen_5()
             obj = std::move(obj2);
         }
 
-        auto dev = obj.detach();
+        auto [dev, err] = obj.detach();
         if (dev.str() != e_lit) throw std::runtime_error("code_cvt<memory<char>, char32_t>::put response incorrect");
     };
 
@@ -367,7 +367,7 @@ void test_code_cvt_mem_char_bos_3()
         obj.main_cont_beg();
         if (obj.tell() != 0) throw std::runtime_error("code_cvt<memory<char>, char32_t>::bos fail");
 
-        const auto& dev = obj.detach();
+        auto [dev, err] = obj.detach();
         if (dev.dtell() != 12) throw std::runtime_error("code_cvt<memory<char>, char32_t>::bos fail");
     };
     
@@ -618,7 +618,7 @@ void test_code_cvt_mem_char_put_1()
             if (obj.tell() != total_count) throw std::runtime_error("code_cvt<memory<char>, char32_t>::tell response incorrect");
         }
 
-        auto dev = obj.detach();
+        auto [dev, err] = obj.detach();
         if (dev.str() != e_lit) throw std::runtime_error("code_cvt<memory<char>, char32_t>::put response incorrect");
     };
 
@@ -661,7 +661,7 @@ void test_code_cvt_mem_char_put_2()
         obj.main_cont_beg();
         obj.put(i_lit.data(), i_lit.size());
 
-        auto dev = obj.detach();
+        auto [dev, err] = obj.detach();
         if (dev.str() != e_lit) throw std::runtime_error("code_cvt<memory<char>, char32_t>::put response incorrect");        
     };
 
@@ -718,7 +718,8 @@ void test_code_cvt_mem_char_put_3()
             if (obj.tell() != total_count) throw std::runtime_error("code_cvt<memory<char>, char32_t>::tell response incorrect");
         }
 
-        if (obj.detach().str() != e_lit) throw std::runtime_error("code_cvt<memory<char>, char32_t>::put response incorrect");
+        auto [detach_dev, detach_err] = obj.detach();
+        if (detach_dev.str() != e_lit) throw std::runtime_error("code_cvt<memory<char>, char32_t>::put response incorrect");
     };
 
     using CheckType = code_cvt<no_rb_root_cvt<mem_device<char>>, char32_t>;
@@ -759,7 +760,8 @@ void test_code_cvt_mem_char_put_4()
         if (obj.bos() != io_status::output) throw std::runtime_error("code_cvt<mem_device>::bos response incorrect");
         obj.main_cont_beg();
         obj.put(i_lit.data(), i_lit.size());
-        if (obj.detach().str() != e_lit) throw std::runtime_error("code_cvt<memory<char>, char32_t>::put response incorrect");
+        auto [detach_dev, detach_err] = obj.detach();
+        if (detach_dev.str() != e_lit) throw std::runtime_error("code_cvt<memory<char>, char32_t>::put response incorrect");
     };
 
     using CheckType = code_cvt<rb_root_cvt<mem_device<char>>, char32_t>;
@@ -1025,7 +1027,7 @@ void test_code_cvt_mem_char_seek_3()
         char32_t c[] = U"xy";
         obj.put(c, 2);
 
-        auto dev = obj.detach();
+        auto [dev, err] = obj.detach();
         if (dev.str() != "李x伟xy") throw std::runtime_error("code_cvt<memory<char>, char32_t> response incorrect");
     };
 
@@ -1068,7 +1070,7 @@ void test_code_cvt_mem_char_seek_4()
         char32_t c[] = U"xy";
         obj.put(c, 2);
 
-        auto dev = obj.detach();
+        auto [dev, err] = obj.detach();
         if (dev.str() != "axy") throw std::runtime_error("code_cvt<memory<char>, char32_t> response incorrect");
     };
 

--- a/test/cvt/comp/zlib_cvt_char.cpp
+++ b/test/cvt/comp/zlib_cvt_char.cpp
@@ -74,8 +74,8 @@ void test_zlib_cvt_gen_2()
             obj.put(s_e_lit.data() + 1024, 4102 - 1024);
             obj2.put(s_e_lit.data() + 1024, 4102 - 1024);
             
-            auto dev1 = obj.detach();
-            auto dev2 = obj2.detach();
+            auto [dev1, err1] = obj.detach();
+            auto [dev2, err2] = obj2.detach();
             
             if (dev1.str() != dev2.str())
                 throw std::runtime_error("zlib_cvt copy constructor response incorrect");
@@ -128,8 +128,8 @@ void test_zlib_cvt_gen_3()
             obj.put(s_e_lit.data() + 1024, 4102 - 1024);
             obj2.put(s_e_lit.data() + 1024, 4102 - 1024);
             
-            auto dev1 = obj.detach();
-            auto dev2 = obj2.detach();
+            auto [dev1, err1] = obj.detach();
+            auto [dev2, err2] = obj2.detach();
             
             if (dev1.str() != dev2.str())
                 throw std::runtime_error("zlib_cvt copy assignment response incorrect");
@@ -182,8 +182,8 @@ void test_zlib_cvt_gen_4()
     
             T obj2(std::move(obj));
             obj2.put(s_e_lit.data() + 1024, 4102 - 1024);
-            auto dev = obj2.detach();
-            
+            auto [dev, err] = obj2.detach();
+
             compress_res = dev.str();
         }
     
@@ -229,8 +229,8 @@ void test_zlib_cvt_gen_5()
             T obj2(Comp::zlib_cvt{rb_root_cvt{mem_device("")}, 8});
             obj2 = std::move(obj);
             obj2.put(s_e_lit.data() + 1024, 4102 - 1024);
-            auto dev = obj2.detach();
-            
+            auto [dev, err] = obj2.detach();
+
             compress_res = dev.str();
         }
     
@@ -370,8 +370,8 @@ void test_zlib_cvt_io_1()
                 buffer_id %= std::size(buffer_size);
                 cur_pos += dest_size;
             }
-            auto dev = obj.detach();
-    
+            auto [dev, err] = obj.detach();
+
             if (cur_pos != s_e_lit.data() + 4102) throw std::runtime_error("zlib_cvt::put response incorrect");
             compress_res = dev.str();
         }
@@ -420,8 +420,8 @@ void test_zlib_cvt_io_2()
                 buffer_id %= std::size(buffer_size);
                 cur_pos += dest_size;
             }
-            auto dev = obj.detach();
-    
+            auto [dev, err] = obj.detach();
+
             if (cur_pos != s_e_lit.data() + 4102) throw std::runtime_error("zlib_cvt::put response incorrect");
             compress_res = dev.str();
         }
@@ -460,8 +460,8 @@ void test_zlib_cvt_io_3()
             if (obj.bos() != io_status::output) throw std::runtime_error("zlib_cvt::bos response incorrect");
             obj.main_cont_beg();
             obj.put(s_e_lit.data(), 4102);
-            auto dev = obj.detach();
-    
+            auto [dev, err] = obj.detach();
+
             compress_res = dev.str();
         }
         
@@ -525,8 +525,8 @@ void test_zlib_cvt_flush_1()
                 buffer_id %= std::size(buffer_size);
                 cur_pos += dest_size;
             }
-            auto dev = obj.detach();
-    
+            auto [dev, err] = obj.detach();
+
             if (cur_pos != s_e_lit.data() + 4102) throw std::runtime_error("zlib_cvt::put response incorrect");
             compress_res = dev.str();
         }
@@ -546,7 +546,7 @@ void test_zlib_cvt_flush_1()
                 buffer_id %= std::size(buffer_size);
                 cur_pos += dest_size;
             }
-            auto dev = local_obj.detach();
+            auto [dev, err] = local_obj.detach();
             if (compress_res != dev.str()) throw std::runtime_error("zlib_cvt::flush response incorrect");
         }
     };
@@ -584,8 +584,8 @@ void test_zlib_cvt_flush_2()
                 buffer_id %= std::size(buffer_size);
                 cur_pos += dest_size;
             }
-            auto dev = obj.detach();
-    
+            auto [dev, err] = obj.detach();
+
             if (cur_pos != s_e_lit.data() + 4102) throw std::runtime_error("zlib_cvt::put response incorrect");
             compress_res = dev.str();
         }
@@ -613,7 +613,7 @@ void test_zlib_cvt_flush_2()
                 buffer_id %= std::size(buffer_size);
                 cur_pos += dest_size;
             }
-            auto dev = local_obj.detach();
+            auto [dev, err] = local_obj.detach();
             if (compress_res == dev.str()) throw std::runtime_error("zlib_cvt::flush response incorrect");
             
             compress_res = dev.str();
@@ -685,7 +685,7 @@ void test_zlib_cvt_reset_1()
                 buffer_id %= std::size(buffer_size);
                 cur_pos += dest_size;
             }
-            auto dev = local_obj.detach();
+            auto [dev, err] = local_obj.detach();
             if (compress_res != dev.str()) throw std::runtime_error("zlib_cvt::flush response incorrect");
         }
     };

--- a/test/cvt/comp/zlib_cvt_wchar_t.cpp
+++ b/test/cvt/comp/zlib_cvt_wchar_t.cpp
@@ -74,9 +74,9 @@ void test_zlib_cvt_wchar_t_gen_2()
             obj.put(s_e_lit.data() + 1024, 4102 - 1024);
             obj2.put(s_e_lit.data() + 1024, 4102 - 1024);
             
-            auto dev1 = obj.detach();
-            auto dev2 = obj2.detach();
-            
+            auto [dev1, err1] = obj.detach();
+            auto [dev2, err2] = obj2.detach();
+
             if (dev1.str() != dev2.str())
                 throw std::runtime_error("zlib_cvt copy constructor response incorrect");
             compress_res = dev1.str();
@@ -130,9 +130,9 @@ void test_zlib_cvt_wchar_t_gen_3()
             obj.put(s_e_lit.data() + 1024, 4102 - 1024);
             obj2.put(s_e_lit.data() + 1024, 4102 - 1024);
             
-            auto dev1 = obj.detach();
-            auto dev2 = obj2.detach();
-            
+            auto [dev1, err1] = obj.detach();
+            auto [dev2, err2] = obj2.detach();
+
             if (dev1.str() != dev2.str())
                 throw std::runtime_error("zlib_cvt copy assignment response incorrect");
             compress_res = dev1.str();
@@ -185,8 +185,8 @@ void test_zlib_cvt_wchar_t_gen_4()
     
             T obj2(std::move(obj));
             obj2.put(s_e_lit.data() + 1024, 4102 - 1024);
-            auto dev = obj2.detach();
-            
+            auto [dev, err] = obj2.detach();
+
             compress_res = dev.str();
         }
     
@@ -233,8 +233,8 @@ void test_zlib_cvt_wchar_t_gen_5()
             T obj2{creator.create(rb_root_cvt{mem_device("")})};
             obj2 = std::move(obj);
             obj2.put(s_e_lit.data() + 1024, 4102 - 1024);
-            auto dev = obj2.detach();
-            
+            auto [dev, err] = obj2.detach();
+
             compress_res = dev.str();
         }
     
@@ -338,8 +338,8 @@ void test_zlib_cvt_wchar_t_io_1()
                 buffer_id %= std::size(buffer_size);
                 cur_pos += dest_size;
             }
-            auto dev = obj.detach();
-    
+            auto [dev, err] = obj.detach();
+
             if (cur_pos != s_e_lit.data() + 4102) throw std::runtime_error("zlib_cvt::put response incorrect");
             compress_res = dev.str();
         }
@@ -389,8 +389,8 @@ void test_zlib_cvt_wchar_t_io_2()
                 buffer_id %= std::size(buffer_size);
                 cur_pos += dest_size;
             }
-            auto dev = obj.detach();
-    
+            auto [dev, err] = obj.detach();
+
             if (cur_pos != s_e_lit.data() + 4102) throw std::runtime_error("zlib_cvt::put response incorrect");
             compress_res = dev.str();
         }
@@ -429,8 +429,8 @@ void test_zlib_cvt_wchar_t_io_3()
             if (obj.bos() != io_status::output) throw std::runtime_error("zlib_cvt::bos response incorrect");
             obj.main_cont_beg();
             obj.put(s_e_lit.data(), 4102);
-            auto dev = obj.detach();
-    
+            auto [dev, err] = obj.detach();
+
             compress_res = dev.str();
         }
         
@@ -494,8 +494,8 @@ void test_zlib_cvt_wchar_t_flush_1()
                 buffer_id %= std::size(buffer_size);
                 cur_pos += dest_size;
             }
-            auto dev = obj.detach();
-    
+            auto [dev, err] = obj.detach();
+
             if (cur_pos != s_e_lit.data() + 4102) throw std::runtime_error("zlib_cvt::put response incorrect");
             compress_res = dev.str();
         }
@@ -516,7 +516,7 @@ void test_zlib_cvt_wchar_t_flush_1()
                 buffer_id %= std::size(buffer_size);
                 cur_pos += dest_size;
             }
-            auto dev = local_obj.detach();
+            auto [dev, err] = local_obj.detach();
             if (compress_res != dev.str()) throw std::runtime_error("zlib_cvt::flush response incorrect");
         }
     };
@@ -553,8 +553,8 @@ void test_zlib_cvt_wchar_t_flush_2()
                 buffer_id %= std::size(buffer_size);
                 cur_pos += dest_size;
             }
-            auto dev = obj.detach();
-    
+            auto [dev, err] = obj.detach();
+
             if (cur_pos != s_e_lit.data() + 4102) throw std::runtime_error("zlib_cvt::put response incorrect");
             compress_res = dev.str();
         }
@@ -583,7 +583,7 @@ void test_zlib_cvt_wchar_t_flush_2()
                 buffer_id %= std::size(buffer_size);
                 cur_pos += dest_size;
             }
-            auto dev = local_obj.detach();
+            auto [dev, err] = local_obj.detach();
             if (compress_res == dev.str()) throw std::runtime_error("zlib_cvt::flush response incorrect");
             
             compress_res = dev.str();
@@ -656,7 +656,7 @@ void test_zlib_cvt_wchar_t_reset_1()
                 buffer_id %= std::size(buffer_size);
                 cur_pos += dest_size;
             }
-            auto dev = local_obj.detach();
+            auto [dev, err] = local_obj.detach();
             if (compress_res != dev.str()) throw std::runtime_error("zlib_cvt::flush response incorrect");
         }
     };

--- a/test/cvt/crypt/chacha20_cvt.cpp
+++ b/test/cvt/crypt/chacha20_cvt.cpp
@@ -76,7 +76,7 @@ void test_chacha20_cvt_gen_2()
                 obj = std::move(obj2);
             }
     
-            auto dev = obj.detach();
+            auto [dev, err] = obj.detach();
             enc_msg = dev.str();
         }
     
@@ -160,7 +160,7 @@ void test_chacha20_cvt_put_1()
                 total_count += dest_size;
             }
     
-            auto dev = obj.detach();
+            auto [dev, err] = obj.detach();
             return dev.str();
         };
         
@@ -223,7 +223,7 @@ void test_chacha20_cvt_io_1()
                 total_count += dest_size;
             }
     
-            auto dev = obj.detach();
+            auto [dev, err] = obj.detach();
             enc_msg = dev.str();
         }
     
@@ -266,7 +266,8 @@ void test_chacha20_cvt_key_1()
         obj.bos();
         obj.main_cont_beg();
         obj.put(msg.data(), msg.size());
-        enc_msg = obj.detach().str();
+        auto [dev, err] = obj.detach();
+        enc_msg = dev.str();
     }
 
     {

--- a/test/cvt/crypt/charchar20_cvt_wchar_t.cpp
+++ b/test/cvt/crypt/charchar20_cvt_wchar_t.cpp
@@ -77,7 +77,7 @@ void test_chacha20_cvt_wchar_t_gen_2()
                 obj = std::move(obj2);
             }
     
-            auto dev = obj.detach();
+            auto [dev, err] = obj.detach();
             enc_msg = dev.str();
         }
     
@@ -158,7 +158,7 @@ void test_chacha20_cvt_wchar_t_put_1()
                 total_count += dest_size;
             }
     
-            auto dev = obj.detach();
+            auto [dev, err] = obj.detach();
             return dev.str();
         };
         
@@ -220,7 +220,7 @@ void test_chacha20_cvt_wchar_t_io_1()
                 total_count += dest_size;
             }
     
-            auto dev = obj.detach();
+            auto [dev, err] = obj.detach();
             enc_msg = dev.str();
         }
     

--- a/test/cvt/crypt/md5_cvt.cpp
+++ b/test/cvt/crypt/md5_cvt.cpp
@@ -59,9 +59,9 @@ void test_md5_cvt_gen_2()
         obj.put("he", 2);
         auto obj2(obj);
         obj2.put("llo", 3);
-        auto dev = obj2.detach();
+        auto [dev, err] = obj2.detach();
         if (dev.str() != hello_md5_hex_low) throw std::runtime_error("md5_cvt<mem_device>::put response incorrect");
-        auto dev2 = obj.detach();
+        auto [dev2, err2] = obj.detach();
         if (dev2.str() == hello_md5_hex_low) throw std::runtime_error("md5_cvt<mem_device>::put response incorrect");
     };
 
@@ -90,9 +90,9 @@ void test_md5_cvt_gen_3()
         T obj2(creator.create(rb_root_cvt{mem_device{""}}));
         obj2 = obj;
         obj2.put("llo", 3);
-        auto dev = obj2.detach();
+        auto [dev, err] = obj2.detach();
         if (dev.str() != hello_md5_hex_low) throw std::runtime_error("md5_cvt<mem_device>::put response incorrect");
-        auto dev2 = obj.detach();
+        auto [dev2, err2] = obj.detach();
         if (dev2.str() == hello_md5_hex_low) throw std::runtime_error("md5_cvt<mem_device>::put response incorrect");
     };
 
@@ -118,7 +118,7 @@ void test_md5_cvt_gen_4()
         obj.put("he", 2);
         auto obj2(std::move(obj));
         obj2.put("llo", 3);
-        auto dev = obj2.detach();
+        auto [dev, err] = obj2.detach();
         if (dev.str() != hello_md5_hex_low) throw std::runtime_error("md5_cvt<mem_device>::put response incorrect");
     };
 
@@ -147,7 +147,7 @@ void test_md5_cvt_gen_5()
         T obj2(creator.create(rb_root_cvt{mem_device{""}}));
         obj2 = std::move(obj);
         obj2.put("llo", 3);
-        auto dev = obj2.detach();
+        auto [dev, err] = obj2.detach();
         if (dev.str() != hello_md5_hex_low) throw std::runtime_error("md5_cvt<mem_device>::put response incorrect");
     };
 
@@ -171,7 +171,7 @@ void test_md5_cvt_put_1()
         if (obj.bos() != io_status::output) throw std::runtime_error("md5_cvt<mem_device>::bos response incorrect");
         obj.main_cont_beg();
 
-        auto dev = obj.detach();
+        auto [dev, err] = obj.detach();
         if (!dev.str().empty()) throw std::runtime_error("md5_cvt<mem_device>::put response incorrect");
     };
 
@@ -264,7 +264,7 @@ void test_md5_cvt_put_3()
             obj.adjust(Crypt::dump_hash('*'));
             obj.adjust(Crypt::set_hash_fmt(Crypt::hash_fmt::upper_hex));
             obj.put("hello", 5);
-            auto dev = obj.detach();
+            auto [dev, err] = obj.detach();
             if (dev.str() != hello_md5_hex_low + '*' + hello_md5_hex_up) throw std::runtime_error("md5_cvt<mem_device>::put response incorrect");
         }
     };
@@ -291,7 +291,7 @@ void test_md5_cvt_put_4()
         obj.main_cont_beg();
         obj.put("he", 2);
         obj.put("llo", 3);
-        auto dev = obj.detach();
+        auto [dev, err] = obj.detach();
         if (dev.str() != hello_md5_hex_low) throw std::runtime_error("md5_cvt<mem_device>::put response incorrect");
     };
 

--- a/test/cvt/crypt/sha256_cvt.cpp
+++ b/test/cvt/crypt/sha256_cvt.cpp
@@ -28,9 +28,9 @@ void test_sha256_cvt_gen_1()
         obj.put("he", 2);
         auto obj2(obj);
         obj2.put("llo", 3);
-        auto dev = obj2.detach();
+        auto [dev, err] = obj2.detach();
         if (dev.str() != hello_hex_low) throw std::runtime_error("sha256_cvt<mem_device>::put response incorrect");
-        auto dev2 = obj.detach();
+        auto [dev2, err2] = obj.detach();
         if (dev2.str() == hello_hex_low) throw std::runtime_error("sha256_cvt<mem_device>::put response incorrect");
     };
 
@@ -59,9 +59,9 @@ void test_sha256_cvt_gen_2()
         T obj2(creator.create(rb_root_cvt{mem_device{""}}));
         obj2 = obj;
         obj2.put("llo", 3);
-        auto dev = obj2.detach();
+        auto [dev, err] = obj2.detach();
         if (dev.str() != hello_hex_low) throw std::runtime_error("sha256_cvt<mem_device>::put response incorrect");
-        auto dev2 = obj.detach();
+        auto [dev2, err2] = obj.detach();
         if (dev2.str() == hello_hex_low) throw std::runtime_error("sha256_cvt<mem_device>::put response incorrect");
     };
 
@@ -87,7 +87,7 @@ void test_sha256_cvt_gen_3()
         obj.put("he", 2);
         auto obj2(std::move(obj));
         obj2.put("llo", 3);
-        auto dev = obj2.detach();
+        auto [dev, err] = obj2.detach();
         if (dev.str() != hello_hex_low) throw std::runtime_error("sha256_cvt<mem_device>::put response incorrect");
     };
 
@@ -116,7 +116,7 @@ void test_sha256_cvt_gen_4()
         T obj2(creator.create(rb_root_cvt{mem_device{""}}));
         obj2 = std::move(obj);
         obj2.put("llo", 3);
-        auto dev = obj2.detach();
+        auto [dev, err] = obj2.detach();
         if (dev.str() != hello_hex_low) throw std::runtime_error("sha256_cvt<mem_device>::put response incorrect");
     };
 
@@ -140,7 +140,7 @@ void test_sha256_cvt_put_1()
         if (obj.bos() != io_status::output) throw std::runtime_error("sha256_cvt<mem_device>::bos response incorrect");
         obj.main_cont_beg();
 
-        auto dev = obj.detach();
+        auto [dev, err] = obj.detach();
         if (!dev.str().empty()) throw std::runtime_error("sha256_cvt<mem_device>::put response incorrect");
     };
 
@@ -260,7 +260,7 @@ void test_sha256_cvt_put_4()
         obj.main_cont_beg();
         obj.put("he", 2);
         obj.put("llo", 3);
-        auto dev = obj.detach();
+        auto [dev, err] = obj.detach();
         if (dev.str() != hello_hex_low) throw std::runtime_error("sha256_cvt<mem_device>::put response incorrect");
     };
 

--- a/test/cvt/cvt_io/test_root_cvt_io.cpp
+++ b/test/cvt/cvt_io/test_root_cvt_io.cpp
@@ -256,7 +256,8 @@ void test_root_cvt_mem_output_1()
             writer.commit();
         }
 
-        VERIFY(obj.detach().str() == "1234567");
+        auto [dev, err] = obj.detach();
+        VERIFY(dev.str() == "1234567");
     };
 
     auto obj1 = rb_root_cvt{mem_device{""}};
@@ -299,7 +300,8 @@ void test_root_cvt_mem_output_2()
             writer.commit();
         }
 
-        VERIFY(obj.detach().str() == "1234567");
+        auto [dev, err] = obj.detach();
+        VERIFY(dev.str() == "1234567");
     };
 
     auto obj1 = rb_root_cvt{mem_device{""}};
@@ -344,7 +346,8 @@ void test_root_cvt_mem_output_3()
             writer.commit();
         }
 
-        VERIFY(obj.detach().str() == ref);
+        auto [dev, err] = obj.detach();
+        VERIFY(dev.str() == ref);
     };
 
     auto obj1 = rb_root_cvt{mem_device{""}};

--- a/test/cvt/cvt_pipe_creator/test_cvt_pipe_creator.cpp
+++ b/test/cvt/cvt_pipe_creator/test_cvt_pipe_creator.cpp
@@ -54,7 +54,7 @@ void test_cvt_pipe_creator_put_1()
             if (obj.tell() != total_count) throw std::runtime_error("cvt_pipe::tell response incorrect");
         }
 
-        auto dev = obj.detach();
+        auto [dev, err] = obj.detach();
         if (dev.str() != e_lit) throw std::runtime_error("cvt_pipe::put response incorrect");
     };
     
@@ -108,7 +108,7 @@ void test_cvt_pipe_creator_put_2()
             total_count += dest_size;
         }
 
-        auto dev = obj.detach();
+        auto [dev, err] = obj.detach();
         return dev.str();
     };
 
@@ -170,7 +170,7 @@ void test_cvt_pipe_creator_put_3()
             total_count += dest_size;
         }
 
-        auto dev = obj.detach();
+        auto [dev, err] = obj.detach();
         return dev.str();
     };
 
@@ -290,7 +290,7 @@ void test_cvt_pipe_creator_io_1()
         obj.main_cont_beg();
         obj.put(i_lit.data(), i_lit.size());
     
-        auto dev = obj.detach();
+        auto [dev, err] = obj.detach();
         e_lit = dev.str();
         
         T obj2 = p_creator.create(rb_root_cvt{mem_device(e_lit)});
@@ -337,7 +337,7 @@ void test_cvt_pipe_creator_io_2()
         obj.main_cont_beg();
         obj.put(i_lit.data(), i_lit.size());
     
-        auto dev = obj.detach();
+        auto [dev, err] = obj.detach();
         e_lit = dev.str();
         
         T obj2 = p_creator.create(rb_root_cvt{mem_device(e_lit)});

--- a/test/cvt/root_cvt/root_cvt_file.cpp
+++ b/test/cvt/root_cvt/root_cvt_file.cpp
@@ -697,18 +697,21 @@ void test_root_cvt_file_device_1()
         obj.bos(); obj.main_cont_beg();
         obj.put("abc", 3);
 
-        f1 = obj.detach();
+        auto [detach1_dev, detach1_err] = obj.detach();
+        f1 = std::move(detach1_dev);
         file_guard g2("test_file2", "");
         obj.attach(device_type("test_file2", file_open_flag::trunc));
         obj.bos(); obj.main_cont_beg();
         obj.put("123", 3);
-        
-        device_type f2 = obj.detach();
+
+        auto [detach2_dev, detach2_err] = obj.detach();
+        device_type f2 = std::move(detach2_dev);
         obj.attach(std::move(f1));
         obj.bos(); obj.main_cont_beg();
         obj.put("def", 3);
-        
-        f1 = obj.detach();
+
+        auto [detach3_dev, detach3_err] = obj.detach();
+        f1 = std::move(detach3_dev);
         f1.close();
         f2.close();
         if (g1.contents() != "abcdef") throw std::runtime_error("root_cvt<file_device> output incorrect");
@@ -755,7 +758,7 @@ void test_root_cvt_file_detach_1()
         VERIFY(ch == '1');
         VERIFY(obj.device().dtell() == 8);
         
-        auto dev = obj.detach();
+        auto [dev, err] = obj.detach();
         VERIFY(dev.dtell() == 1);
     };
 
@@ -783,7 +786,7 @@ void test_root_cvt_file_detach_2()
         obj.put("123", 3);
         VERIFY(obj.device().dtell() == 0);
         
-        auto dev = obj.detach();
+        auto [dev, err] = obj.detach();
         VERIFY(dev.dtell() == 3);
     };
 

--- a/test/cvt/root_cvt/root_cvt_mem.cpp
+++ b/test/cvt/root_cvt/root_cvt_mem.cpp
@@ -469,7 +469,8 @@ void test_root_cvt_mem_device_1()
         obj.bos(); obj.main_cont_beg();
         obj.put("abc", 3);
 
-        f1 = obj.detach();
+        auto [detach1_dev, detach1_err] = obj.detach();
+        f1 = std::move(detach1_dev);
         obj.attach(device_type(""));
         obj.bos(); obj.main_cont_beg();
         obj.put("123", 3);
@@ -477,8 +478,9 @@ void test_root_cvt_mem_device_1()
         device_type f2 = obj.attach(std::move(f1));
         obj.bos(); obj.main_cont_beg();
         obj.put("def", 3);
-        
-        f1 = obj.detach();
+
+        auto [detach2_dev, detach2_err] = obj.detach();
+        f1 = std::move(detach2_dev);
         if (f1.str() != "abcdef") throw std::runtime_error("root_cvt<file_device> output incorrect");
         if (f2.str() != "123") throw std::runtime_error("root_cvt<file_device> output incorrect");
     };
@@ -507,7 +509,7 @@ void test_root_cvt_mem_detach_1()
         VERIFY(ch == '1');
         VERIFY(obj.device().dtell() == 1);
         
-        auto dev = obj.detach();
+        auto [dev, err] = obj.detach();
         VERIFY(dev.dtell() == 1);
     };
     {
@@ -532,7 +534,7 @@ void test_root_cvt_mem_detach_2()
         obj.put("123", 3);
         VERIFY(obj.device().dtell() == 3);
         
-        auto dev = obj.detach();
+        auto [dev, err] = obj.detach();
         VERIFY(dev.dtell() == 3);
     };
     {

--- a/test/cvt/runtime_cvt/test_runtime_root_cvt.cpp
+++ b/test/cvt/runtime_cvt/test_runtime_root_cvt.cpp
@@ -70,7 +70,11 @@ void test_runtime_cvt_null_instance()
         cvt_status    stat;
 
         must_throw([&] { (void)src.device();              });
-        must_throw([&] { (void)src.detach();              });
+        // detach() is noexcept - check it returns an exception_ptr instead of throwing
+        {
+            auto [dev, err] = src.detach();
+            VERIFY(err != nullptr);
+        }
         must_throw([&] { src.attach(mem_device<char>{}); });
         must_throw([&] { src.adjust(beh);                 });
         must_throw([&] { src.retrieve(stat);              });

--- a/test/io/io_base/manipulators/test_io_base_manipulators_adjustfield.cpp
+++ b/test/io/io_base/manipulators/test_io_base_manipulators_adjustfield.cpp
@@ -79,8 +79,9 @@ void test_io_base_manipulators_adjustfield_char_1()
     oss << ":" << IOv2::setw(6) << IOv2::right << false << ":" << IOv2::endl;
 
     if (!oss.good()) throw std::runtime_error("ios_base<char> adjustfield check fail");
-    
-    if (oss.detach().str() != lit) throw std::runtime_error("ios_base<char> adjustfield check fail");
+
+    auto [dev1, err1] = oss.detach();
+    if (dev1.str() != lit) throw std::runtime_error("ios_base<char> adjustfield check fail");
     dump_info("Done\n");
 }
 
@@ -89,16 +90,19 @@ void test_io_base_manipulators_adjustfield_char_2()
     dump_info("Test ios_base<char> adjustfield case 2...");
     IOv2::ostream o{IOv2::mem_device{""}};
     o << IOv2::setw(6) << IOv2::right << "san";
-    if (o.detach().str() != "   san") throw std::runtime_error("ios_base<char> adjustfield check fail");
+    auto [dev2, err2] = o.detach();
+    if (dev2.str() != "   san") throw std::runtime_error("ios_base<char> adjustfield check fail");
     o.attach(IOv2::mem_device{""});
 
     o << IOv2::setw(6) << IOv2::internal << "fran";
-    if (o.detach().str() != "  fran") throw std::runtime_error("ios_base<char> adjustfield check fail");
+    auto [dev3, err3] = o.detach();
+    if (dev3.str() != "  fran") throw std::runtime_error("ios_base<char> adjustfield check fail");
     o.attach(IOv2::mem_device{""});
 
     o << IOv2::setw(6) << IOv2::left << "cisco";
-    if (o.detach().str() != "cisco ") throw std::runtime_error("ios_base<char> adjustfield check fail");
-    
+    auto [dev4, err4] = o.detach();
+    if (dev4.str() != "cisco ") throw std::runtime_error("ios_base<char> adjustfield check fail");
+
     dump_info("Done\n");
 }
 
@@ -142,7 +146,8 @@ void test_io_base_manipulators_adjustfield_wchar_t_1()
     oss << L":" << IOv2::setw(6) << IOv2::right << false << L":" << IOv2::endl;
 
     if (!oss.good()) throw std::runtime_error("ios_base<wchar_t> adjustfield check fail");
-    if (oss.detach().str() != lit) throw std::runtime_error("ios_base<wchar_t> adjustfield check fail");
+    auto [dev5, err5] = oss.detach();
+    if (dev5.str() != lit) throw std::runtime_error("ios_base<wchar_t> adjustfield check fail");
     dump_info("Done\n");
 }
 
@@ -151,15 +156,18 @@ void test_io_base_manipulators_adjustfield_wchar_t_2()
     dump_info("Test ios_base<wchar_t> adjustfield case 2...");
     IOv2::ostream o{IOv2::mem_device{L""}};
     o << IOv2::setw(6) << IOv2::right << L"san";
-    if (o.detach().str() != L"   san") throw std::runtime_error("ios_base<wchar_t> adjustfield check fail");
+    auto [dev6, err6] = o.detach();
+    if (dev6.str() != L"   san") throw std::runtime_error("ios_base<wchar_t> adjustfield check fail");
     o.attach(IOv2::mem_device{L""});
 
     o << IOv2::setw(6) << IOv2::internal << L"fran";
-    if (o.detach().str() != L"  fran") throw std::runtime_error("ios_base<wchar_t> adjustfield check fail");
+    auto [dev7, err7] = o.detach();
+    if (dev7.str() != L"  fran") throw std::runtime_error("ios_base<wchar_t> adjustfield check fail");
     o.attach(IOv2::mem_device{L""});
 
     o << IOv2::setw(6) << IOv2::left << L"cisco";
-    if (o.detach().str() != L"cisco ") throw std::runtime_error("ios_base<wchar_t> adjustfield check fail");
-    
+    auto [dev8, err8] = o.detach();
+    if (dev8.str() != L"cisco ") throw std::runtime_error("ios_base<wchar_t> adjustfield check fail");
+
     dump_info("Done\n");
 }

--- a/test/io/io_base/manipulators/test_io_base_manipulators_basefield.cpp
+++ b/test/io/io_base/manipulators/test_io_base_manipulators_basefield.cpp
@@ -105,7 +105,8 @@ void test_io_base_manipulators_basefield_char_1()
     oss << 0x12345678l << "|" << IOv2::endl;
     
     if (!oss.good()) throw std::runtime_error("ios_base<char> adjustfield check fail");
-    if (oss.detach().str() != lit) throw std::runtime_error("ios_base<char> adjustfield check fail");
+    auto [dev, err] = oss.detach();
+    if (dev.str() != lit) throw std::runtime_error("ios_base<char> adjustfield check fail");
     dump_info("Done\n");
 }
 
@@ -175,6 +176,7 @@ void test_io_base_manipulators_basefield_wchar_t_1()
     oss << 0x12345678l << L"|" << IOv2::endl;
     
     if (!oss.good()) throw std::runtime_error("ios_base<char> adjustfield check fail");
-    if (oss.detach().str() != lit) throw std::runtime_error("ios_base<char> adjustfield check fail");
+    auto [dev, err] = oss.detach();
+    if (dev.str() != lit) throw std::runtime_error("ios_base<char> adjustfield check fail");
     dump_info("Done\n");
 }

--- a/test/io/io_base/manipulators/test_io_base_manipulators_money.cpp
+++ b/test/io/io_base/manipulators/test_io_base_manipulators_money.cpp
@@ -19,7 +19,8 @@ void test_io_base_manipulators_put_money_char_1()
     const std::string str("720000000000");
     oss << IOv2::put_money(str);
     if (!oss.good()) throw std::runtime_error("ios_base<char> put_money check fail");
-    if (oss.detach().str() != "7.200.000.000,00 ") throw std::runtime_error("ios_base<char> put_money check fail");
+    auto [dev1, err1] = oss.detach();
+    if (dev1.str() != "7.200.000.000,00 ") throw std::runtime_error("ios_base<char> put_money check fail");
 
     dump_info("Done\n");
 }
@@ -35,7 +36,8 @@ void test_io_base_manipulators_put_money_char_2()
 
     oss << IOv2::put_money(str);
     if (!oss.cvt_fail()) throw std::runtime_error("ios_base<char> put_money check fail");
-    if (!oss.detach().str().empty()) throw std::runtime_error("ios_base<char> put_money check fail");
+    auto [dev2, err2] = oss.detach();
+    if (!dev2.str().empty()) throw std::runtime_error("ios_base<char> put_money check fail");
 
     dump_info("Done\n");
 }
@@ -49,7 +51,8 @@ void test_io_base_manipulators_put_money_wchar_t_1()
     const std::wstring str(L"720000000000");
     oss << IOv2::put_money(str);
     if (!oss.good()) throw std::runtime_error("ios_base<wchar_t> put_money check fail");
-    if (oss.detach().str() != L"7.200.000.000,00 ") throw std::runtime_error("ios_base<wchar_t> put_money check fail");
+    auto [dev3, err3] = oss.detach();
+    if (dev3.str() != L"7.200.000.000,00 ") throw std::runtime_error("ios_base<wchar_t> put_money check fail");
 
     dump_info("Done\n");
 }
@@ -65,7 +68,8 @@ void test_io_base_manipulators_put_money_wchar_t_2()
 
     oss << IOv2::put_money(str);
     if (!oss.cvt_fail()) throw std::runtime_error("ios_base<wchar_t> put_money check fail");
-    if (!oss.detach().str().empty()) throw std::runtime_error("ios_base<wchar_t> put_money check fail");
+    auto [dev4, err4] = oss.detach();
+    if (!dev4.str().empty()) throw std::runtime_error("ios_base<wchar_t> put_money check fail");
 
     dump_info("Done\n");
 }

--- a/test/io/io_base/manipulators/test_io_base_manipulators_time.cpp
+++ b/test/io/io_base/manipulators/test_io_base_manipulators_time.cpp
@@ -35,7 +35,8 @@ void test_io_base_manipulators_put_time_char_1()
     IOv2::ostream oss{IOv2::mem_device{""}};
     const tm time1 = test_tm(0, 0, 12, 4, 3, 71, 0, 93, 0);
     oss << IOv2::put_time(&time1, "%a %Y");
-    if (oss.detach().str() != "Sun 1971") throw std::runtime_error("ios_base<char> put_time check fail");
+    auto [dev1, err1] = oss.detach();
+    if (dev1.str() != "Sun 1971") throw std::runtime_error("ios_base<char> put_time check fail");
 
     dump_info("Done\n");
 }
@@ -47,7 +48,8 @@ void test_io_base_manipulators_put_time_char_2()
     IOv2::ostream oss{IOv2::mem_device{""}, IOv2::locale<char>("de_DE.UTF-8")};
     const tm time1 = test_tm(0, 0, 12, 4, 3, 71, 0, 93, 0);
     oss << IOv2::put_time(&time1, "%A %Y");
-    if (oss.detach().str() != "Sonntag 1971") throw std::runtime_error("ios_base<char> put_time check fail");
+    auto [dev2, err2] = oss.detach();
+    if (dev2.str() != "Sonntag 1971") throw std::runtime_error("ios_base<char> put_time check fail");
 
     dump_info("Done\n");
 }
@@ -59,7 +61,8 @@ void test_io_base_manipulators_put_time_wchar_t_1()
     IOv2::ostream oss{IOv2::mem_device{L""}};
     const tm time1 = test_tm(0, 0, 12, 4, 3, 71, 0, 93, 0);
     oss << IOv2::put_time(&time1, L"%a %Y");
-    if (oss.detach().str() != L"Sun 1971") throw std::runtime_error("ios_base<wchar_t> put_time check fail");
+    auto [dev3, err3] = oss.detach();
+    if (dev3.str() != L"Sun 1971") throw std::runtime_error("ios_base<wchar_t> put_time check fail");
 
     dump_info("Done\n");
 }
@@ -71,7 +74,8 @@ void test_io_base_manipulators_put_time_wchar_t_2()
     IOv2::ostream oss{IOv2::mem_device{L""}, IOv2::locale<wchar_t>("de_DE.UTF-8")};
     const tm time1 = test_tm(0, 0, 12, 4, 3, 71, 0, 93, 0);
     oss << IOv2::put_time(&time1, L"%A %Y");
-    if (oss.detach().str() != L"Sonntag 1971") throw std::runtime_error("ios_base<wchar_t> put_time check fail");
+    auto [dev4, err4] = oss.detach();
+    if (dev4.str() != L"Sonntag 1971") throw std::runtime_error("ios_base<wchar_t> put_time check fail");
 
     dump_info("Done\n");
 }

--- a/test/io/io_base/test_io_base_state.cpp
+++ b/test/io/io_base/test_io_base_state.cpp
@@ -17,12 +17,14 @@ void test_io_base_boolalpha_1()
     ostr01.flags(IOv2::ios_defs::boolalpha);
 
     ostr01 << true;
-    std::string str02 = ostr01.detach().str();
+    auto [dev1, err1] = ostr01.detach();
+    std::string str02 = dev1.str();
     if (str02 != strue) throw std::runtime_error("ios_base::boolalpha check fail");
 
     ostr01.attach(IOv2::mem_device{""});
     ostr01 << false;
-    str02 = ostr01.detach().str();
+    auto [dev2, err2] = ostr01.detach();
+    str02 = dev2.str();
     if (str02 != sfalse) throw std::runtime_error("ios_base::boolalpha check fail");
 
     dump_info("Done\n");

--- a/test/io/iostream/switch_to_get/test_iostream_switch_to_get_char.cpp
+++ b/test/io/iostream/switch_to_get/test_iostream_switch_to_get_char.cpp
@@ -58,7 +58,8 @@ void test_iostream_switch_to_get_char_2()
                        IOv2::Comp::zlib_cvt_creator<char>{6});
     ostr << s_e_lit;
     VERIFY(static_cast<bool>(ostr));
-    std::string compress_res = ostr.detach().str();
+    auto [dev, err] = ostr.detach();
+    std::string compress_res = dev.str();
 
     VERIFY(!compress_res.empty());
     VERIFY(compress_res.size() < s_e_lit.size());

--- a/test/io/iostream/switch_to_get/test_iostream_switch_to_get_wchar_t.cpp
+++ b/test/io/iostream/switch_to_get/test_iostream_switch_to_get_wchar_t.cpp
@@ -55,7 +55,8 @@ void test_iostream_switch_to_get_wchar_t_2()
         IOv2::Comp::zlib_cvt_creator<char>{6} | IOv2::code_cvt_creator<char, wchar_t>("zh_CN.UTF-8"));
     ostr << s_e_lit;
     VERIFY(static_cast<bool>(ostr));
-    auto compress_res = ostr.detach().str();
+    auto [dev, err] = ostr.detach();
+    auto compress_res = dev.str();
 
     VERIFY(!compress_res.empty());
     VERIFY(compress_res.size() < s_e_lit.size() / 3 * 7);

--- a/test/io/iostream/switch_to_put/test_iostream_switch_to_put_char.cpp
+++ b/test/io/iostream/switch_to_put/test_iostream_switch_to_put_char.cpp
@@ -59,7 +59,8 @@ void test_iostream_switch_to_put_char_2()
                        IOv2::Comp::zlib_cvt_creator<char>{6});
     ostr << s_e_lit;
     VERIFY(static_cast<bool>(ostr));
-    std::string compress_res = ostr.detach().str();
+    auto [dev, err] = ostr.detach();
+    std::string compress_res = dev.str();
 
     VERIFY(!compress_res.empty());
     VERIFY(compress_res.size() < s_e_lit.size());

--- a/test/io/iostream/switch_to_put/test_iostream_switch_to_put_wchar_t.cpp
+++ b/test/io/iostream/switch_to_put/test_iostream_switch_to_put_wchar_t.cpp
@@ -56,7 +56,8 @@ void test_iostream_switch_to_put_wchar_t_2()
                        IOv2::Comp::zlib_cvt_creator<char>{6} | IOv2::code_cvt_creator<char, wchar_t>("zh_CN.UTF-8"));
     ostr << s_e_lit;
     VERIFY(static_cast<bool>(ostr));
-    auto compress_res = ostr.detach().str();
+    auto [dev, err] = ostr.detach();
+    auto compress_res = dev.str();
 
     VERIFY(!compress_res.empty());
     VERIFY(compress_res.size() < s_e_lit.size() / 3 * 7);

--- a/test/io/istream/extractors_arithmetic/test_istream_extractors_arithmetic_char.cpp
+++ b/test/io/istream/extractors_arithmetic/test_istream_extractors_arithmetic_char.cpp
@@ -131,7 +131,7 @@ void test_istream_extractors_arithmetic_char_3()
     {
         IOv2::ostream ostr(IOv2::mem_device{""});
         ostr << "12220101";
-        auto dev = ostr.detach();
+        auto [dev, err] = ostr.detach();
         dev.dseek(0);
 
         T istr(std::move(dev));
@@ -653,7 +653,7 @@ void test_istream_extractors_arithmetic_char_13()
         short s1 = 0;
         IOv2::ostream oss1{IOv2::mem_device{""}};
         oss1 << std::numeric_limits<short>::max();
-        auto dev = oss1.detach(); dev.dseek(0);
+        auto [dev, err] = oss1.detach(); dev.dseek(0);
         T iss1{std::move(dev)};
         iss1 >> s1;
         VERIFY(s1 == std::numeric_limits<short>::max());
@@ -663,7 +663,7 @@ void test_istream_extractors_arithmetic_char_13()
         short s2 = 0;
         IOv2::ostream oss2{IOv2::mem_device{""}};
         oss2 << static_cast<long long>(std::numeric_limits<short>::max()) + 1;
-        auto dev2 = oss2.detach(); dev2.dseek(0);
+        auto [dev2, err2] = oss2.detach(); dev2.dseek(0);
         T iss2{std::move(dev2)};
         iss2 >> s2;
         VERIFY(s2 == std::numeric_limits<short>::max());
@@ -673,7 +673,7 @@ void test_istream_extractors_arithmetic_char_13()
         short s3 = 0;
         IOv2::ostream oss3{IOv2::mem_device{""}};
         oss3 << std::numeric_limits<short>::min();
-        auto dev3 = oss3.detach(); dev3.dseek(0);
+        auto [dev3, err3] = oss3.detach(); dev3.dseek(0);
         T iss3{std::move(dev3)};
         iss3 >> s3;
         VERIFY(s3 == std::numeric_limits<short>::min());
@@ -683,7 +683,7 @@ void test_istream_extractors_arithmetic_char_13()
         short s4 = 0;
         IOv2::ostream oss4{IOv2::mem_device{""}};
         oss4 << static_cast<long long>(std::numeric_limits<short>::min()) - 1;
-        auto dev4 = oss4.detach(); dev4.dseek(0);
+        auto [dev4, err4] = oss4.detach(); dev4.dseek(0);
         T iss4{std::move(dev4)};
         iss4 >> s4;
         VERIFY(s4 == std::numeric_limits<short>::min());
@@ -693,7 +693,7 @@ void test_istream_extractors_arithmetic_char_13()
         int i1 = 0;
         IOv2::ostream oss5{IOv2::mem_device{""}};
         oss5 << std::numeric_limits<int>::max();
-        auto dev5 = oss5.detach(); dev5.dseek(0);
+        auto [dev5, err5] = oss5.detach(); dev5.dseek(0);
         T iss5{std::move(dev5)};
         iss5 >> i1;
         VERIFY(i1 == std::numeric_limits<int>::max());
@@ -703,7 +703,7 @@ void test_istream_extractors_arithmetic_char_13()
         int i2 = 0;
         IOv2::ostream oss6{IOv2::mem_device{""}};
         oss6 << static_cast<long long>(std::numeric_limits<int>::max()) + 1;
-        auto dev6 = oss6.detach(); dev6.dseek(0);
+        auto [dev6, err6] = oss6.detach(); dev6.dseek(0);
         T iss6{std::move(dev6)};
         iss6 >> i2;
         VERIFY(i2 == std::numeric_limits<int>::max());
@@ -713,7 +713,7 @@ void test_istream_extractors_arithmetic_char_13()
         int i3 = 0;
         IOv2::ostream oss7{IOv2::mem_device{""}};
         oss7 << std::numeric_limits<int>::min();
-        auto dev7 = oss7.detach(); dev7.dseek(0);
+        auto [dev7, err7] = oss7.detach(); dev7.dseek(0);
         T iss7{std::move(dev7)};
         iss7 >> i3;
         VERIFY(i3 == std::numeric_limits<int>::min());
@@ -723,7 +723,7 @@ void test_istream_extractors_arithmetic_char_13()
         int i4 = 0;
         IOv2::ostream oss8{IOv2::mem_device{""}};
         oss8 << static_cast<long long>(std::numeric_limits<int>::min()) - 1;
-        auto dev8 = oss8.detach(); dev8.dseek(0);
+        auto [dev8, err8] = oss8.detach(); dev8.dseek(0);
         T iss8{std::move(dev8)};
         iss8 >> i4;
         VERIFY(i4 == std::numeric_limits<int>::min());

--- a/test/io/istream/extractors_arithmetic/test_istream_extractors_arithmetic_wchar_t.cpp
+++ b/test/io/istream/extractors_arithmetic/test_istream_extractors_arithmetic_wchar_t.cpp
@@ -130,7 +130,7 @@ void test_istream_extractors_arithmetic_wchar_t_3()
     {
         IOv2::ostream ostr(IOv2::mem_device{L""});
         ostr << L"12220101";
-        auto dev = ostr.detach();
+        auto [dev, err] = ostr.detach();
         dev.dseek(0);
 
         T istr(std::move(dev));
@@ -652,7 +652,7 @@ void test_istream_extractors_arithmetic_wchar_t_13()
         short s1 = 0;
         IOv2::ostream oss1{IOv2::mem_device{L""}};
         oss1 << std::numeric_limits<short>::max();
-        auto dev = oss1.detach(); dev.dseek(0);
+        auto [dev, err] = oss1.detach(); dev.dseek(0);
         T iss1{std::move(dev)};
         iss1 >> s1;
         VERIFY(s1 == std::numeric_limits<short>::max());
@@ -662,7 +662,7 @@ void test_istream_extractors_arithmetic_wchar_t_13()
         short s2 = 0;
         IOv2::ostream oss2{IOv2::mem_device{L""}};
         oss2 << static_cast<long long>(std::numeric_limits<short>::max()) + 1;
-        auto dev2 = oss2.detach(); dev2.dseek(0);
+        auto [dev2, err2] = oss2.detach(); dev2.dseek(0);
         T iss2{std::move(dev2)};
         iss2 >> s2;
         VERIFY(s2 == std::numeric_limits<short>::max());
@@ -672,7 +672,7 @@ void test_istream_extractors_arithmetic_wchar_t_13()
         short s3 = 0;
         IOv2::ostream oss3{IOv2::mem_device{L""}};
         oss3 << std::numeric_limits<short>::min();
-        auto dev3 = oss3.detach(); dev3.dseek(0);
+        auto [dev3, err3] = oss3.detach(); dev3.dseek(0);
         T iss3{std::move(dev3)};
         iss3 >> s3;
         VERIFY(s3 == std::numeric_limits<short>::min());
@@ -682,7 +682,7 @@ void test_istream_extractors_arithmetic_wchar_t_13()
         short s4 = 0;
         IOv2::ostream oss4{IOv2::mem_device{L""}};
         oss4 << static_cast<long long>(std::numeric_limits<short>::min()) - 1;
-        auto dev4 = oss4.detach(); dev4.dseek(0);
+        auto [dev4, err4] = oss4.detach(); dev4.dseek(0);
         T iss4{std::move(dev4)};
         iss4 >> s4;
         VERIFY(s4 == std::numeric_limits<short>::min());
@@ -692,7 +692,7 @@ void test_istream_extractors_arithmetic_wchar_t_13()
         int i1 = 0;
         IOv2::ostream oss5{IOv2::mem_device{L""}};
         oss5 << std::numeric_limits<int>::max();
-        auto dev5 = oss5.detach(); dev5.dseek(0);
+        auto [dev5, err5] = oss5.detach(); dev5.dseek(0);
         T iss5{std::move(dev5)};
         iss5 >> i1;
         VERIFY(i1 == std::numeric_limits<int>::max());
@@ -702,7 +702,7 @@ void test_istream_extractors_arithmetic_wchar_t_13()
         int i2 = 0;
         IOv2::ostream oss6{IOv2::mem_device{L""}};
         oss6 << static_cast<long long>(std::numeric_limits<int>::max()) + 1;
-        auto dev6 = oss6.detach(); dev6.dseek(0);
+        auto [dev6, err6] = oss6.detach(); dev6.dseek(0);
         T iss6{std::move(dev6)};
         iss6 >> i2;
         VERIFY(i2 == std::numeric_limits<int>::max());
@@ -712,7 +712,7 @@ void test_istream_extractors_arithmetic_wchar_t_13()
         int i3 = 0;
         IOv2::ostream oss7{IOv2::mem_device{L""}};
         oss7 << std::numeric_limits<int>::min();
-        auto dev7 = oss7.detach(); dev7.dseek(0);
+        auto [dev7, err7] = oss7.detach(); dev7.dseek(0);
         T iss7{std::move(dev7)};
         iss7 >> i3;
         VERIFY(i3 == std::numeric_limits<int>::min());
@@ -722,7 +722,7 @@ void test_istream_extractors_arithmetic_wchar_t_13()
         int i4 = 0;
         IOv2::ostream oss8{IOv2::mem_device{L""}};
         oss8 << static_cast<long long>(std::numeric_limits<int>::min()) - 1;
-        auto dev8 = oss8.detach(); dev8.dseek(0);
+        auto [dev8, err8] = oss8.detach(); dev8.dseek(0);
         T iss8{std::move(dev8)};
         iss8 >> i4;
         VERIFY(i4 == std::numeric_limits<int>::min());

--- a/test/io/istream/extractors_character/test_istream_extractors_character_char.cpp
+++ b/test/io/istream/extractors_character/test_istream_extractors_character_char.cpp
@@ -263,11 +263,13 @@ void test_istream_extractors_character_char_4()
         const std::string data = prepare(666, nchunks);
         IOv2::ostream ofstream(IOv2::ofile_device<char>{filename});
         ofstream.write(data.data(), data.size());
-        ofstream.detach().close();
+        auto [odev, oerr] = ofstream.detach();
+        odev.close();
 
         T ifstrm(IOv2::ifile_device<char>{filename});
         check(ifstrm, data, nchunks);
-        ifstrm.detach().close();
+        auto [idev, ierr] = ifstrm.detach();
+        idev.close();
     };
 
     helper.operator()<IOv2::istream>();

--- a/test/io/istream/extractors_character/test_istream_extractors_character_wchar_t.cpp
+++ b/test/io/istream/extractors_character/test_istream_extractors_character_wchar_t.cpp
@@ -213,12 +213,14 @@ void test_istream_extractors_character_wchar_t_4()
         IOv2::ostream ofstream(IOv2::ofile_device<char>{filename},
                             IOv2::code_cvt_creator<char, wchar_t>("zh_CN.UTF-8"));
         ofstream.write(data.data(), data.size());
-        ofstream.detach().close();
+        auto [odev, oerr] = ofstream.detach();
+        odev.close();
 
         T ifstrm(IOv2::ifile_device<char>{filename},
                  IOv2::code_cvt_creator<char, wchar_t>("zh_CN.UTF-8"));
         check(ifstrm, data, nchunks);
-        ifstrm.detach().close();
+        auto [idev, ierr] = ifstrm.detach();
+        idev.close();
     };
 
     helper.operator()<IOv2::istream>();

--- a/test/io/istream/getline/test_istream_getline_char.cpp
+++ b/test/io/istream/getline/test_istream_getline_char.cpp
@@ -302,7 +302,8 @@ void test_istream_getline_char_5()
 
         T ifstrm(IOv2::ifile_device<char>{filename});
         check(ifstrm, data, nchunks, delim);
-        ifstrm.detach().close();
+        auto [dev, err] = ifstrm.detach();
+        dev.close();
     };
 
     helper.operator()<IOv2::istream>();

--- a/test/io/istream/getline/test_istream_getline_wchar_t.cpp
+++ b/test/io/istream/getline/test_istream_getline_wchar_t.cpp
@@ -308,7 +308,8 @@ void test_istream_getline_wchar_t_5()
         T ifstrm(IOv2::ifile_device<char>{filename},
                  IOv2::code_cvt_creator<char, wchar_t>("C"));
         check(ifstrm, wdata, nchunks, delim);
-        ifstrm.detach().close();
+        auto [dev, err] = ifstrm.detach();
+        dev.close();
     };
 
     helper.operator()<IOv2::istream>();

--- a/test/io/istream/ignore/test_istream_ignore_char.cpp
+++ b/test/io/istream/ignore/test_istream_ignore_char.cpp
@@ -99,7 +99,8 @@ void test_istream_ignore_char_2()
     
         T ifstrm(IOv2::ifile_device<char>{filename});
         check(ifstrm, data, nchunks, delim);
-        ifstrm.detach().close();
+        auto [dev, err] = ifstrm.detach();
+        dev.close();
     };
 
     helper.operator()<IOv2::istream>();

--- a/test/io/istream/ignore/test_istream_ignore_wchar_t.cpp
+++ b/test/io/istream/ignore/test_istream_ignore_wchar_t.cpp
@@ -106,7 +106,8 @@ void test_istream_ignore_wchar_t_2()
         T ifstrm(IOv2::ifile_device<char>{filename},
                  IOv2::code_cvt_creator<char, wchar_t>("C"));
         check(ifstrm, wdata, nchunks, delim);
-        ifstrm.detach().close();
+        auto [dev, err] = ifstrm.detach();
+        dev.close();
     };
 
     helper.operator()<IOv2::istream>();

--- a/test/io/ostream/appmode/test_ostream_appmode_char.cpp
+++ b/test/io/ostream/appmode/test_ostream_appmode_char.cpp
@@ -105,7 +105,8 @@ void test_ostream_appmode_char_2()
         ostr << IOv2::appmode;
         ostr.flush();
         VERIFY(static_cast<bool>(ostr));
-        ostr.detach().close();
+        auto [dev1, err1] = ostr.detach();
+        dev1.close();
 
         VERIFY(g.contents() == "LYcdeWX");
     };
@@ -135,7 +136,8 @@ void test_ostream_appmode_char_sync_2()
         IOv2::sync(ostr).stream << IOv2::appmode;
         IOv2::sync(ostr).stream.flush();
         VERIFY(static_cast<bool>(IOv2::sync(ostr).stream));
-        IOv2::sync(ostr).stream.detach().close();
+        auto [dev2, err2] = IOv2::sync(ostr).stream.detach();
+        dev2.close();
 
         VERIFY(g.contents() == "LYcdeWX");
     };
@@ -164,7 +166,8 @@ void test_ostream_appmode_char_3()
 
     str << " hello";
 
-    VERIFY(str.detach().str() == "abcdeW hello");
+    auto [dev3, err3] = str.detach();
+    VERIFY(dev3.str() == "abcdeW hello");
 
     dump_info("Done\n");
 }
@@ -186,7 +189,8 @@ void test_ostream_appmode_char_sync_3()
 
     IOv2::sync(str).stream << " hello";
 
-    VERIFY(IOv2::sync(str).stream.detach().str() == "abcdeW hello");
+    auto [dev4, err4] = IOv2::sync(str).stream.detach();
+    VERIFY(dev4.str() == "abcdeW hello");
 
     dump_info("Done\n");
 }

--- a/test/io/ostream/appmode/test_ostream_appmode_wchar_t.cpp
+++ b/test/io/ostream/appmode/test_ostream_appmode_wchar_t.cpp
@@ -107,7 +107,8 @@ void test_ostream_appmode_wchar_t_2()
         ostr << IOv2::appmode;
         ostr.flush();
         VERIFY(static_cast<bool>(ostr));
-        ostr.detach().close();
+        auto [dev1, err1] = ostr.detach();
+        dev1.close();
 
         VERIFY(g.contents() == "LYcdeWX");
     };
@@ -138,7 +139,8 @@ void test_ostream_appmode_wchar_t_sync_2()
         IOv2::sync(ostr).stream << IOv2::appmode;
         IOv2::sync(ostr).stream.flush();
         VERIFY(static_cast<bool>(IOv2::sync(ostr).stream));
-        IOv2::sync(ostr).stream.detach().close();
+        auto [dev2, err2] = IOv2::sync(ostr).stream.detach();
+        dev2.close();
 
         VERIFY(g.contents() == "LYcdeWX");
     };
@@ -167,7 +169,8 @@ void test_ostream_appmode_wchar_t_3()
 
     str << L" hello";
 
-    VERIFY(str.detach().str() == L"abcdeW hello");
+    auto [dev3, err3] = str.detach();
+    VERIFY(dev3.str() == L"abcdeW hello");
 
     dump_info("Done\n");
 }
@@ -190,7 +193,8 @@ void test_ostream_appmode_wchar_t_sync_3()
 
     IOv2::sync(str).stream << L" hello";
 
-    VERIFY(IOv2::sync(str).stream.detach().str() == L"abcdeW hello");
+    auto [dev4, err4] = IOv2::sync(str).stream.detach();
+    VERIFY(dev4.str() == L"abcdeW hello");
 
     dump_info("Done\n");
 }

--- a/test/io/ostream/cvt/test_ostream_cvt.cpp
+++ b/test/io/ostream/cvt/test_ostream_cvt.cpp
@@ -30,8 +30,9 @@ void test_ostream_cvt_1()
         static_assert(std::is_same_v<typename decltype(os)::char_type, char32_t>);
     
         os << 1024 << U' ' << U"李伟";
-    
-        auto str = os.detach().str();
+
+        auto [dev1, err1] = os.detach();
+        auto str = dev1.str();
         VERIFY(os.good());
         VERIFY(str.size() == 11);
         VERIFY((unsigned char)str[ 0] == (unsigned char)('1' + 'a'));
@@ -66,8 +67,9 @@ void test_ostream_cvt_sync_1()
         static_assert(std::is_same_v<typename decltype(os)::char_type, char32_t>);
     
         IOv2::sync(os).stream << 1024 << U' ' << U"李伟";
-    
-        auto str = IOv2::sync(os).stream.detach().str();
+
+        auto [dev2, err2] = IOv2::sync(os).stream.detach();
+        auto str = dev2.str();
         VERIFY(os.good());
         VERIFY(str.size() == 11);
         VERIFY((unsigned char)str[ 0] == (unsigned char)('1' + 'a'));

--- a/test/io/ostream/derive/test_ostream_derive.cpp
+++ b/test/io/ostream/derive/test_ostream_derive.cpp
@@ -68,7 +68,8 @@ void test_ostream_derive_2()
     MyLogger logger;
     logger << Level{"DEBUG"} << "User login\n"
            << Level{"WARN"} << "something happened";
-    auto str = logger.detach().str();
+    auto [dev, err] = logger.detach();
+    auto str = dev.str();
     VERIFY(str == "[DEBUG] User login\n[WARN] something happened");
 }
 

--- a/test/io/ostream/inserters_arithmetic/test_ostream_inserters_atithmetic_char.cpp
+++ b/test/io/ostream/inserters_arithmetic/test_ostream_inserters_atithmetic_char.cpp
@@ -134,14 +134,16 @@ void test_ostream_inserters_arithmetic_char_1()
                 T os(IOv2::mem_device{""}, loc);
                 apply_formatting<char>(tc, os);
                 os << tc.val;
-                VERIFY(os.detach().str() == tc.result);
+                auto [dev1, err1] = os.detach();
+                VERIFY(dev1.str() == tc.result);
             }
             // test long double with char type
             {
                 T os(IOv2::mem_device{""}, loc);
                 apply_formatting<char>(tc, os);
                 os << (long double)tc.val;
-                VERIFY(os.detach().str() == tc.result);
+                auto [dev2, err2] = os.detach();
+                VERIFY(dev2.str() == tc.result);
             }
         }
     };
@@ -194,11 +196,12 @@ void test_ostream_inserters_arithmetic_char_3()
             expect = "wow, you've got some big numbers here";
 
         o << IOv2::oct << n << ' ' << IOv2::hex << n;
-        
-        auto str = o.detach().str();
+
+        auto [dev3, err3] = o.detach();
+        auto str = dev3.str();
         VERIFY(str == expect);
     };
-    
+
     helper.operator()<IOv2::ostream>(static_cast<short>(-1));
     helper.operator()<IOv2::ostream>(static_cast<int>(-1));
     helper.operator()<IOv2::ostream>(static_cast<long>(-1));
@@ -220,10 +223,12 @@ void test_ostream_inserters_arithmetic_char_4()
         T o2(IOv2::mem_device{""});
 
         o1 << IOv2::hex << IOv2::showbase << IOv2::setw(6) << IOv2::internal << 0xff;
-        VERIFY(o1.detach().str() == "0x  ff");
+        auto [dev4, err4] = o1.detach();
+        VERIFY(dev4.str() == "0x  ff");
 
         o2 << IOv2::hex << IOv2::showbase << IOv2::setw(6) << IOv2::internal << "0xff";
-        VERIFY(o2.detach().str() == "  0xff");
+        auto [dev5, err5] = o2.detach();
+        VERIFY(dev5.str() == "  0xff");
     };
 
     helper.operator()<IOv2::ostream>();
@@ -242,7 +247,8 @@ void test_ostream_inserters_arithmetic_char_5()
         T ostr(IOv2::mem_device{""});
         ostr.precision(20);
         ostr << pi;
-        std::string sval = ostr.detach().str();
+        auto [dev6, err6] = ostr.detach();
+        std::string sval = dev6.str();
         IOv2::istream istr(IOv2::mem_device{sval});
         double d;
         istr >> d;
@@ -267,11 +273,12 @@ void test_ostream_inserters_arithmetic_char_6()
         T ostr(IOv2::mem_device{""});
         ostr.precision(prec);
         ostr << oval;
-        auto sval = ostr.detach().str();
+        auto [dev7, err7] = ostr.detach();
+        auto sval = dev7.str();
         IOv2::istream istr{IOv2::mem_device{sval}};
         double ival;
         istr >> ival;
-        VERIFY( std::abs(oval-ival)/oval < DBL_EPSILON ); 
+        VERIFY( std::abs(oval-ival)/oval < DBL_EPSILON );
     };
 
     helper.operator()<IOv2::ostream>();
@@ -295,28 +302,32 @@ void test_ostream_inserters_arithmetic_char_7()
         ostr1.setf(IOv2::ios_defs::hex);
         short s = -1;
         ostr1 << s;
-        VERIFY(ostr1.detach().str() == "-1");
+        auto [dev8, err8] = ostr1.detach();
+        VERIFY(dev8.str() == "-1");
 
         ostr2.setf(IOv2::ios_defs::oct);
         ostr2.setf(IOv2::ios_defs::hex);
 
         int i = -1;
         ostr2 << i;
-        VERIFY(ostr2.detach().str() == "-1");
+        auto [dev9, err9] = ostr2.detach();
+        VERIFY(dev9.str() == "-1");
 
         ostr3.setf(IOv2::ios_defs::oct);
         ostr3.setf(IOv2::ios_defs::hex);
-    
+
         long l = -1;
         ostr3 << l;
-        VERIFY(ostr3.detach().str() == "-1");
+        auto [dev10, err10] = ostr3.detach();
+        VERIFY(dev10.str() == "-1");
 
         ostr4.setf(IOv2::ios_defs::oct);
         ostr4.setf(IOv2::ios_defs::hex);
 
         long long ll = -1LL;
         ostr4 << ll;
-        VERIFY(ostr4.detach().str() == "-1");
+        auto [dev11, err11] = ostr4.detach();
+        VERIFY(dev11.str() == "-1");
     };
 
     helper.operator()<IOv2::ostream>();
@@ -367,29 +378,31 @@ void test_ostream_inserters_arithmetic_char_9()
         // make sure we can output a very long float
         long double val = std::numeric_limits<long double>::max();
         int prec = std::numeric_limits<long double>::digits10;
-    
+
         T os(IOv2::mem_device{""});
         os.precision(prec);
         os.setf(IOv2::ios_defs::scientific);
         os << val;
-    
+
         char largebuf[512];
         sprintf(largebuf, "%.*Le", prec, val);
         VERIFY(static_cast<bool>(os));
-        VERIFY(os.detach().str() == largebuf);
-    
+        auto [dev12, err12] = os.detach();
+        VERIFY(dev12.str() == largebuf);
+
         // Make sure we can output a long float in fixed format
         // without seg-faulting (libstdc++/4402)
         double val2 = std::numeric_limits<double>::max();
-    
+
         T os2(IOv2::mem_device{""});
         os2.precision(3);
         os2.setf(IOv2::ios_defs::fixed);
         os2 << val2;
-    
+
         sprintf(largebuf, "%.*f", 3, val2);
         VERIFY(static_cast<bool>(os2));
-        VERIFY(os2.detach().str() == largebuf);
+        auto [dev13, err13] = os2.detach();
+        VERIFY(dev13.str() == largebuf);
     };
 
     helper.operator()<IOv2::ostream>();
@@ -411,7 +424,8 @@ void test_ostream_inserters_arithmetic_char_10()
         os << d;
 
         VERIFY(static_cast<bool>(os));
-        auto str = os.detach().str();
+        auto [dev14, err14] = os.detach();
+        auto str = dev14.str();
         VERIFY(std::stod(str) == d);
         VERIFY(str.substr(0, 2) == "0x");
         VERIFY(str.find('p') != std::string::npos);
@@ -423,7 +437,7 @@ void test_ostream_inserters_arithmetic_char_10()
         VERIFY(std::stod(os.device().str()) == d);
         VERIFY(os.device().str().substr(0, 2) == "0X");
         VERIFY(os.device().str().find('P') != std::string::npos);
-    
+
         os << IOv2::nouppercase;
         os.attach(IOv2::mem_device{""});
         os << IOv2::defaultfloat << IOv2::setprecision(6);
@@ -431,26 +445,29 @@ void test_ostream_inserters_arithmetic_char_10()
         os.flush();
         VERIFY(static_cast<bool>(os));
         VERIFY(os.device().str() == "272");
-    
+
         os.attach(IOv2::mem_device{""});
         d = 15.; //0x1.ep+3;
         os << IOv2::hexfloat << IOv2::setprecision(1);
         os << d;
         VERIFY(static_cast<bool>(os));
-        VERIFY(std::stod(os.detach().str()) == d);
-    
+        auto [dev15, err15] = os.detach();
+        VERIFY(std::stod(dev15.str()) == d);
+
         os.attach(IOv2::mem_device{""});
         os << IOv2::uppercase << IOv2::setprecision(1);
         os << d;
         VERIFY(static_cast<bool>(os));
-        VERIFY(std::stod(os.detach().str()) == d);
+        auto [dev16, err16] = os.detach();
+        VERIFY(std::stod(dev16.str()) == d);
 
         os << IOv2::nouppercase;
         os.attach(IOv2::mem_device{""});
         os << IOv2::defaultfloat << IOv2::setprecision(6);
         os << d;
         VERIFY(static_cast<bool>(os));
-        VERIFY(os.detach().str() == "15");
+        auto [dev17, err17] = os.detach();
+        VERIFY(dev17.str() == "15");
     };
   
     helper.template operator()<IOv2::ostream, double>();
@@ -470,7 +487,8 @@ void test_ostream_inserters_arithmetic_char_11()
         float nan = std::numeric_limits<float>::quiet_NaN();
         T os(IOv2::mem_device{""});
         os << -nan;
-        VERIFY(os.detach().str()[0] == '-');
+        auto [dev18, err18] = os.detach();
+        VERIFY(dev18.str()[0] == '-');
     };
 
     helper.template operator()<IOv2::ostream>();

--- a/test/io/ostream/inserters_arithmetic/test_ostream_inserters_atithmetic_wchar_t.cpp
+++ b/test/io/ostream/inserters_arithmetic/test_ostream_inserters_atithmetic_wchar_t.cpp
@@ -132,14 +132,16 @@ void test_ostream_inserters_arithmetic_wchar_t_1()
                 T os(IOv2::mem_device{L""}, loc);
                 apply_formatting<wchar_t>(tc, os);
                 os << tc.val;
-                VERIFY(os.detach().str() == tc.result);
+                auto [dev1, err1] = os.detach();
+                VERIFY(dev1.str() == tc.result);
             }
             // test long double with wchar_t type
             {
                 T os(IOv2::mem_device{L""}, loc);
                 apply_formatting<wchar_t>(tc, os);
                 os << (long double)tc.val;
-                VERIFY(os.detach().str() == tc.result);
+                auto [dev2, err2] = os.detach();
+                VERIFY(dev2.str() == tc.result);
             }
         }
     };
@@ -192,8 +194,9 @@ void test_ostream_inserters_arithmetic_wchar_t_3()
             expect = L"wow, you've got some big numbers here";
 
         o << IOv2::oct << n << ' ' << IOv2::hex << n;
-        
-        auto str = o.detach().str();
+
+        auto [dev3, err3] = o.detach();
+        auto str = dev3.str();
         VERIFY(str == expect);
     };
 
@@ -218,10 +221,12 @@ void test_ostream_inserters_arithmetic_wchar_t_4()
         T o2(IOv2::mem_device{L""});
 
         o1 << IOv2::hex << IOv2::showbase << IOv2::setw(6) << IOv2::internal << 0xff;
-        VERIFY(o1.detach().str() == L"0x  ff");
+        auto [dev4, err4] = o1.detach();
+        VERIFY(dev4.str() == L"0x  ff");
 
         o2 << IOv2::hex << IOv2::showbase << IOv2::setw(6) << IOv2::internal << L"0xff";
-        VERIFY(o2.detach().str() == L"  0xff");
+        auto [dev5, err5] = o2.detach();
+        VERIFY(dev5.str() == L"  0xff");
     };
 
     helper.operator()<IOv2::ostream>();
@@ -240,7 +245,8 @@ void test_ostream_inserters_arithmetic_wchar_t_5()
         T ostr(IOv2::mem_device{L""});
         ostr.precision(20);
         ostr << pi;
-        std::wstring sval = ostr.detach().str();
+        auto [dev6, err6] = ostr.detach();
+        std::wstring sval = dev6.str();
         IOv2::istream istr(IOv2::mem_device{sval});
         double d;
         istr >> d;
@@ -265,11 +271,12 @@ void test_ostream_inserters_arithmetic_wchar_t_6()
         T ostr(IOv2::mem_device{L""});
         ostr.precision(prec);
         ostr << oval;
-        auto sval = ostr.detach().str();
+        auto [dev7, err7] = ostr.detach();
+        auto sval = dev7.str();
         IOv2::istream istr{IOv2::mem_device{sval}};
         double ival;
         istr >> ival;
-        VERIFY( std::abs(oval-ival)/oval < DBL_EPSILON ); 
+        VERIFY( std::abs(oval-ival)/oval < DBL_EPSILON );
     };
 
     helper.operator()<IOv2::ostream>();
@@ -293,28 +300,32 @@ void test_ostream_inserters_arithmetic_wchar_t_7()
         ostr1.setf(IOv2::ios_defs::hex);
         short s = -1;
         ostr1 << s;
-        VERIFY(ostr1.detach().str() == L"-1");
+        auto [dev8, err8] = ostr1.detach();
+        VERIFY(dev8.str() == L"-1");
 
         ostr2.setf(IOv2::ios_defs::oct);
         ostr2.setf(IOv2::ios_defs::hex);
-    
+
         int i = -1;
         ostr2 << i;
-        VERIFY(ostr2.detach().str() == L"-1");
+        auto [dev9, err9] = ostr2.detach();
+        VERIFY(dev9.str() == L"-1");
 
         ostr3.setf(IOv2::ios_defs::oct);
         ostr3.setf(IOv2::ios_defs::hex);
 
         long l = -1;
         ostr3 << l;
-        VERIFY(ostr3.detach().str() == L"-1");
+        auto [dev10, err10] = ostr3.detach();
+        VERIFY(dev10.str() == L"-1");
 
         ostr4.setf(IOv2::ios_defs::oct);
         ostr4.setf(IOv2::ios_defs::hex);
 
         long long ll = -1LL;
         ostr4 << ll;
-        VERIFY(ostr4.detach().str() == L"-1");
+        auto [dev11, err11] = ostr4.detach();
+        VERIFY(dev11.str() == L"-1");
     };
 
     helper.operator()<IOv2::ostream>();
@@ -365,29 +376,31 @@ void test_ostream_inserters_arithmetic_wchar_t_9()
         // make sure we can output a very long float
         long double val = std::numeric_limits<long double>::max();
         int prec = std::numeric_limits<long double>::digits10;
-    
+
         T os(IOv2::mem_device{L""});
         os.precision(prec);
         os.setf(IOv2::ios_defs::scientific);
         os << val;
-    
+
         wchar_t largebuf[512];
         swprintf(largebuf, 512, L"%.*Le", prec, val);
         VERIFY(static_cast<bool>(os));
-        VERIFY(os.detach().str() == largebuf);
+        auto [dev12, err12] = os.detach();
+        VERIFY(dev12.str() == largebuf);
 
         // Make sure we can output a long float in fixed format
         // without seg-faulting (libstdc++/4402)
         double val2 = std::numeric_limits<double>::max();
-    
+
         T os2(IOv2::mem_device{L""});
         os2.precision(3);
         os2.setf(IOv2::ios_defs::fixed);
         os2 << val2;
-    
+
         swprintf(largebuf, 512, L"%.*f", 3, val2);
         VERIFY(static_cast<bool>(os2));
-        VERIFY(os2.detach().str() == largebuf);
+        auto [dev13, err13] = os2.detach();
+        VERIFY(dev13.str() == largebuf);
     };
 
     helper.operator()<IOv2::ostream>();
@@ -409,7 +422,8 @@ void test_ostream_inserters_arithmetic_wchar_t_10()
         os << d;
 
         VERIFY(static_cast<bool>(os));
-        auto str = os.detach().str();
+        auto [dev14, err14] = os.detach();
+        auto str = dev14.str();
         VERIFY(std::stod(str) == d);
         VERIFY(str.substr(0, 2) == L"0x");
         VERIFY(str.find('p') != std::string::npos);
@@ -421,7 +435,7 @@ void test_ostream_inserters_arithmetic_wchar_t_10()
         VERIFY(std::stod(os.device().str()) == d);
         VERIFY(os.device().str().substr(0, 2) == L"0X");
         VERIFY(os.device().str().find('P') != std::string::npos);
-    
+
         os << IOv2::nouppercase;
         os.attach(IOv2::mem_device{L""});
         os << IOv2::defaultfloat << IOv2::setprecision(6);
@@ -429,26 +443,29 @@ void test_ostream_inserters_arithmetic_wchar_t_10()
         os.flush();
         VERIFY(static_cast<bool>(os));
         VERIFY(os.device().str() == L"272");
-    
+
         os.attach(IOv2::mem_device{L""});
         d = 15.; //0x1.ep+3;
         os << IOv2::hexfloat << IOv2::setprecision(1);
         os << d;
         VERIFY(static_cast<bool>(os));
-        VERIFY(std::stod(os.detach().str()) == d);
-    
+        auto [dev15, err15] = os.detach();
+        VERIFY(std::stod(dev15.str()) == d);
+
         os.attach(IOv2::mem_device{L""});
         os << IOv2::uppercase << IOv2::setprecision(1);
         os << d;
         VERIFY(static_cast<bool>(os));
-        VERIFY(std::stod(os.detach().str()) == d);
-    
+        auto [dev16, err16] = os.detach();
+        VERIFY(std::stod(dev16.str()) == d);
+
         os << IOv2::nouppercase;
         os.attach(IOv2::mem_device{L""});
         os << IOv2::defaultfloat << IOv2::setprecision(6);
         os << d;
         VERIFY(static_cast<bool>(os));
-        VERIFY(os.detach().str() == L"15");
+        auto [dev17, err17] = os.detach();
+        VERIFY(dev17.str() == L"15");
     };
     
     helper.template operator()<IOv2::ostream, double>();
@@ -468,7 +485,8 @@ void test_ostream_inserters_arithmetic_wchar_t_11()
         float nan = std::numeric_limits<float>::quiet_NaN();
         T os(IOv2::mem_device{L""});
         os << -nan;
-        VERIFY(os.detach().str()[0] == L'-');
+        auto [dev18, err18] = os.detach();
+        VERIFY(dev18.str()[0] == L'-');
     };
 
     helper.template operator()<IOv2::ostream>();

--- a/test/io/ostream/inserters_character/test_ostream_inserters_character_char.cpp
+++ b/test/io/ostream/inserters_character/test_ostream_inserters_character_char.cpp
@@ -56,7 +56,8 @@ void test_ostream_inserters_character_char_2()
         oss01.fill('0');
         oss01.flags(IOv2::ios_defs::left);
         oss01 << str01;
-        VERIFY(oss01.detach().str() == "00000");
+        auto [dev01, err01] = oss01.detach();
+        VERIFY(dev01.str() == "00000");
 
         std::string str02 = "1";
         T oss02{IOv2::mem_device{""}};
@@ -64,7 +65,8 @@ void test_ostream_inserters_character_char_2()
         oss02.fill('0');
         oss02.flags(std::ios_base::left);
         oss02 << str02;
-        VERIFY(oss02.detach().str() == "10000");
+        auto [dev02, err02] = oss02.detach();
+        VERIFY(dev02.str() == "10000");
 
         std::string str03 = "909909";
         T oss03{IOv2::mem_device{""}};
@@ -72,7 +74,8 @@ void test_ostream_inserters_character_char_2()
         oss03.fill('0');
         oss03.flags(std::ios_base::left);
         oss03 << str03;
-        VERIFY(oss03.detach().str() == "909909");
+        auto [dev03, err03] = oss03.detach();
+        VERIFY(dev03.str() == "909909");
     };
 
     helper.template operator()<IOv2::ostream>();
@@ -93,7 +96,8 @@ void test_ostream_inserters_character_char_3()
         oss01.fill('0');
         oss01.flags(IOv2::ios_defs::right);
         oss01 << str01;
-        VERIFY(oss01.detach().str() == "00000");
+        auto [dev04, err04] = oss01.detach();
+        VERIFY(dev04.str() == "00000");
 
         std::string str02 = "1";
         T oss02{IOv2::mem_device{""}};
@@ -101,7 +105,8 @@ void test_ostream_inserters_character_char_3()
         oss02.fill('0');
         oss02.flags(std::ios_base::right);
         oss02 << str02;
-        VERIFY(oss02.detach().str() == "00001");
+        auto [dev05, err05] = oss02.detach();
+        VERIFY(dev05.str() == "00001");
 
         std::string str03 = "909909";
         T oss03{IOv2::mem_device{""}};
@@ -109,7 +114,8 @@ void test_ostream_inserters_character_char_3()
         oss03.fill('0');
         oss03.flags(std::ios_base::right);
         oss03 << str03;
-        VERIFY(oss03.detach().str() == "909909");
+        auto [dev06, err06] = oss03.detach();
+        VERIFY(dev06.str() == "909909");
     };
 
     helper.operator()<IOv2::ostream>();
@@ -129,11 +135,12 @@ void test_ostream_inserters_character_char_4()
         const int i_max=250;
 
         T oss_02(IOv2::mem_device{str_01});
-        for (int i = 0; i < i_max; ++i) 
+        for (int i = 0; i < i_max; ++i)
             oss_02 << "Test: " << i << IOv2::endl;
         VERIFY((bool)oss_02);
         VERIFY(oss_02.good());
-        str_tmp = oss_02.detach().str();
+        auto [dev07, err07] = oss_02.detach();
+        str_tmp = dev07.str();
         VERIFY(str_tmp.size() == 2390);
     };
 
@@ -177,21 +184,24 @@ void test_ostream_inserters_character_char_6()
             oss.width(-60);
             oss << 'C';
             VERIFY(oss.good());
-            VERIFY(oss.detach().str() == "C");
+            auto [dev08, err08] = oss.detach();
+            VERIFY(dev08.str() == "C");
         }
         {
             T oss{IOv2::mem_device{""}};
             oss.width(-60);
             oss << "Consoli";
             VERIFY(oss.good());
-            VERIFY(oss.detach().str() == "Consoli");
+            auto [dev09, err09] = oss.detach();
+            VERIFY(dev09.str() == "Consoli");
         }
         {
             T oss{IOv2::mem_device{""}};
             oss.width(-60);
             oss << std::string("Consoli");
             VERIFY(oss.good());
-            VERIFY(oss.detach().str() == "Consoli");
+            auto [dev10, err10] = oss.detach();
+            VERIFY(dev10.str() == "Consoli");
         }
     };
 
@@ -214,7 +224,8 @@ void test_ostream_inserters_character_char_7()
             const std::streamsize width = oss_01.width();
             oss_01 << 'a';
             VERIFY(oss_01.good());
-            VERIFY(oss_01.detach().str().size() == std::string::size_type(width));
+            auto [dev11, err11] = oss_01.detach();
+            VERIFY(dev11.str().size() == std::string::size_type(width));
         }
         {
             const std::string str_01(50, 'a');
@@ -223,7 +234,8 @@ void test_ostream_inserters_character_char_7()
             const std::streamsize width = oss_01.width();
             oss_01 << str_01.c_str();
             VERIFY(oss_01.good());
-            VERIFY(oss_01.detach().str().size() == std::string::size_type(width));
+            auto [dev12, err12] = oss_01.detach();
+            VERIFY(dev12.str().size() == std::string::size_type(width));
         }
     };
 

--- a/test/io/ostream/inserters_character/test_ostream_inserters_character_wchar_t.cpp
+++ b/test/io/ostream/inserters_character/test_ostream_inserters_character_wchar_t.cpp
@@ -56,7 +56,8 @@ void test_ostream_inserters_character_wchar_t_2()
         oss01.fill(L'0');
         oss01.flags(IOv2::ios_defs::left);
         oss01 << str01;
-        VERIFY(oss01.detach().str() == L"00000");
+        auto [dev01, err01] = oss01.detach();
+        VERIFY(dev01.str() == L"00000");
 
         std::wstring str02 = L"1";
         T oss02{IOv2::mem_device{L""}};
@@ -64,7 +65,8 @@ void test_ostream_inserters_character_wchar_t_2()
         oss02.fill(L'0');
         oss02.flags(std::ios_base::left);
         oss02 << str02;
-        VERIFY(oss02.detach().str() == L"10000");
+        auto [dev02, err02] = oss02.detach();
+        VERIFY(dev02.str() == L"10000");
 
         std::wstring str03 = L"909909";
         T oss03{IOv2::mem_device{L""}};
@@ -72,7 +74,8 @@ void test_ostream_inserters_character_wchar_t_2()
         oss03.fill(L'0');
         oss03.flags(std::ios_base::left);
         oss03 << str03;
-        VERIFY(oss03.detach().str() == L"909909");
+        auto [dev03, err03] = oss03.detach();
+        VERIFY(dev03.str() == L"909909");
     };
 
     helper.template operator()<IOv2::ostream>();
@@ -93,7 +96,8 @@ void test_ostream_inserters_character_wchar_t_3()
         oss01.fill(L'0');
         oss01.flags(IOv2::ios_defs::right);
         oss01 << str01;
-        VERIFY(oss01.detach().str() == L"00000");
+        auto [dev04, err04] = oss01.detach();
+        VERIFY(dev04.str() == L"00000");
 
         std::wstring str02 = L"1";
         T oss02{IOv2::mem_device{L""}};
@@ -101,7 +105,8 @@ void test_ostream_inserters_character_wchar_t_3()
         oss02.fill(L'0');
         oss02.flags(std::ios_base::right);
         oss02 << str02;
-        VERIFY(oss02.detach().str() == L"00001");
+        auto [dev05, err05] = oss02.detach();
+        VERIFY(dev05.str() == L"00001");
 
         std::wstring str03 = L"909909";
         T oss03{IOv2::mem_device{L""}};
@@ -109,7 +114,8 @@ void test_ostream_inserters_character_wchar_t_3()
         oss03.fill(L'0');
         oss03.flags(std::ios_base::right);
         oss03 << str03;
-        VERIFY(oss03.detach().str() == L"909909");
+        auto [dev06, err06] = oss03.detach();
+        VERIFY(dev06.str() == L"909909");
     };
 
     helper.operator()<IOv2::ostream>();
@@ -129,11 +135,12 @@ void test_ostream_inserters_character_wchar_t_4()
         const int i_max=250;
 
         T oss_02(IOv2::mem_device{str_01});
-        for (int i = 0; i < i_max; ++i) 
+        for (int i = 0; i < i_max; ++i)
             oss_02 << L"Test: " << i << IOv2::endl;
         VERIFY((bool)oss_02);
         VERIFY(oss_02.good());
-        str_tmp = oss_02.detach().str();
+        auto [dev07, err07] = oss_02.detach();
+        str_tmp = dev07.str();
         VERIFY(str_tmp.size() == 2390);
     };
 
@@ -177,21 +184,24 @@ void test_ostream_inserters_character_wchar_t_6()
             oss.width(-60);
             oss << L'C';
             VERIFY(oss.good());
-            VERIFY(oss.detach().str() == L"C");
+            auto [dev08, err08] = oss.detach();
+            VERIFY(dev08.str() == L"C");
         }
         {
             T oss{IOv2::mem_device{L""}};
             oss.width(-60);
             oss << L"Consoli";
             VERIFY(oss.good());
-            VERIFY(oss.detach().str() == L"Consoli");
+            auto [dev09, err09] = oss.detach();
+            VERIFY(dev09.str() == L"Consoli");
         }
         {
             T oss{IOv2::mem_device{L""}};
             oss.width(-60);
             oss << std::wstring(L"Consoli");
             VERIFY(oss.good());
-            VERIFY(oss.detach().str() == L"Consoli");
+            auto [dev10, err10] = oss.detach();
+            VERIFY(dev10.str() == L"Consoli");
         }
     };
 
@@ -214,7 +224,8 @@ void test_ostream_inserters_character_wchar_t_7()
             const std::streamsize width = oss_01.width();
             oss_01 << L'a';
             VERIFY(oss_01.good());
-            VERIFY(oss_01.detach().str().size() == std::string::size_type(width));
+            auto [dev11, err11] = oss_01.detach();
+            VERIFY(dev11.str().size() == std::string::size_type(width));
         }
         {
             const std::wstring str_01(50, L'a');
@@ -223,7 +234,8 @@ void test_ostream_inserters_character_wchar_t_7()
             const std::streamsize width = oss_01.width();
             oss_01 << str_01.c_str();
             VERIFY(oss_01.good());
-            VERIFY(oss_01.detach().str().size() == std::string::size_type(width));
+            auto [dev12, err12] = oss_01.detach();
+            VERIFY(dev12.str().size() == std::string::size_type(width));
         }
     };
 

--- a/test/io/ostream/inserters_time/test_ostream_inserters_time_char.cpp
+++ b/test/io/ostream/inserters_time/test_ostream_inserters_time_char.cpp
@@ -38,7 +38,8 @@ void test_ostream_inserters_time_char_1()
 
         f << tp;
         VERIFY((bool)f);
-        const std::string res = f.detach().str();
+        auto [dev, err] = f.detach();
+        const std::string res = dev.str();
         VERIFY(res == "09/04/24 13:33:18");
     };
 

--- a/test/io/ostream/inserters_time/test_ostream_inserters_time_wchar_t.cpp
+++ b/test/io/ostream/inserters_time/test_ostream_inserters_time_wchar_t.cpp
@@ -38,7 +38,8 @@ void test_ostream_inserters_time_wchar_t_1()
 
         f << tp;
         VERIFY((bool)f);
-        const std::wstring res = f.detach().str();
+        auto [dev, err] = f.detach();
+        const std::wstring res = dev.str();
         VERIFY(res == L"09/04/24 13:33:18");
     };
 

--- a/test/io/ostream/seek/test_ostream_seek_char.cpp
+++ b/test/io/ostream/seek/test_ostream_seek_char.cpp
@@ -39,7 +39,8 @@ void test_ostream_seek_char_1()
             }
             VERIFY(stream.good());
         }(ofstrm);
-        ofstrm.detach().close();
+        auto [odev, oerr] = ofstrm.detach();
+        odev.close();
 
         IOv2::istream ifstrm{IOv2::ifile_device<char>{"istream_seeks-3.txt"}};
 
@@ -61,7 +62,8 @@ void test_ostream_seek_char_1()
             VERIFY( i == times - 1 );
             VERIFY( stream.rdstate() == IOv2::ios_defs::eofbit );
         }(ifstrm);
-        ifstrm.detach().close();
+        auto [idev, ierr] = ifstrm.detach();
+        idev.close();
     };
 
     helper.template operator()<IOv2::ostream>();

--- a/test/io/ostream/seek/test_ostream_seek_wchar_t.cpp
+++ b/test/io/ostream/seek/test_ostream_seek_wchar_t.cpp
@@ -41,7 +41,8 @@ void test_ostream_seek_wchar_t_1()
             }
             VERIFY(stream.good());
         }(ofstrm);
-        ofstrm.detach().close();
+        auto [odev, oerr] = ofstrm.detach();
+        odev.close();
 
         IOv2::istream ifstrm{IOv2::ifile_device<char>{"istream_seeks-3.txt"}};
 
@@ -63,7 +64,8 @@ void test_ostream_seek_wchar_t_1()
             VERIFY( i == times - 1 );
             VERIFY( stream.rdstate() == IOv2::ios_defs::eofbit );
         }(ifstrm);
-        ifstrm.detach().close();
+        auto [idev, ierr] = ifstrm.detach();
+        idev.close();
     };
 
     helper.template operator()<IOv2::ostream>();

--- a/test/io/ostream/sync/test_ostream_sync_char.cpp
+++ b/test/io/ostream/sync/test_ostream_sync_char.cpp
@@ -46,7 +46,8 @@ void test_ostream_sync_char_1()
         for (size_t i = 0; i < loop_num * thread_num; ++i)
             ref += "123 456\n";
 
-        VERIFY(ostr.detach().str() == ref);
+        auto [dev, err] = ostr.detach();
+        VERIFY(dev.str() == ref);
     };
 
     helper.operator()<IOv2::ostream>();

--- a/test/io/ostream/sync/test_ostream_sync_wchar_t.cpp
+++ b/test/io/ostream/sync/test_ostream_sync_wchar_t.cpp
@@ -46,7 +46,8 @@ void test_ostream_sync_wchar_t_1()
         for (size_t i = 0; i < loop_num * thread_num; ++i)
             ref += L"123 456\n";
 
-        VERIFY(ostr.detach().str() == ref);
+        auto [dev, err] = ostr.detach();
+        VERIFY(dev.str() == ref);
     };
 
     helper.operator()<IOv2::ostream>();

--- a/test/io/streambuf_iterator/test_ostreambuf_iterator.cpp
+++ b/test/io/streambuf_iterator/test_ostreambuf_iterator.cpp
@@ -61,16 +61,18 @@ void test_ostreambuf_iterator_put_1()
         int j = str02.size();   // same as str01.size
         for (int i = 0; i < j; ++i)
             ostrb_it27 = str02[i];
-        auto tmp = strbuf01.detach().str();
+        auto [dev1, err1] = strbuf01.detach();
+        auto tmp = dev1.str();
         if (tmp == str01) throw std::runtime_error("ostreambuf_iterator put check fail");
         if (tmp != 'a' + str02) throw std::runtime_error("ostreambuf_iterator put check fail");
-    
+
         T strbuf02 = sb_ori;
         ostreambuf_iterator ostrb_it28(strbuf02);
         j = str01.size();
         for (int i = 0; i < j + 2; ++i)
             ostrb_it28 = 'b';
-        tmp = strbuf01.detach().str();
+        auto [dev2, err2] = strbuf01.detach();
+        tmp = dev2.str();
         if (tmp == str01) throw std::runtime_error("ostreambuf_iterator put check fail");
         if (tmp == str02) throw std::runtime_error("ostreambuf_iterator put check fail");
     };


### PR DESCRIPTION
Refactor detach() in converters and streams to return a pair containing the detached device and any captured exception during cleanup. This allows detach() to be marked noexcept while still providing access to cleanup failures, following the first-failure-wins principle.

Updated all call sites in library and tests to handle the new return type.