### PR TITLE
refactor: change attach() return type to void and update tests

### DIFF
--- a/include/cvt/abs_cvt.h
+++ b/include/cvt/abs_cvt.h
@@ -883,36 +883,49 @@ namespace IOv2
 
         /**
          * @lang{ZH}
-         * 将新设备附加到转换器，返回先前持有的设备，并重置转换器状态。
+         * 将新设备附加到转换器，并重置转换器状态。
          *
          * 若 `dev` 为默认构造值（空设备），则等效于清除当前设备。
-         * 调用后 `m_io_status` 恢复为 `neutral`，`m_is_bos_done` 恢复为 `false`。
+         * 调用后 `m_io_status` 恢复为 `neutral`，`m_is_bos_done` 恢复为 `false`，
+         * `m_is_tainted` 恢复为 `false`。
+         *
+         * 原设备在本函数内部由 kernel 在其 `detach()` 阶段静默析构。若需要保留
+         * 原设备，调用方应先单独调用 `detach()` 取得设备，再调用本函数装入新设备。
+         *
+         * 异常：若底层 kernel 的 `detach()` 在清理原设备时捕获到异常，kernel 的
+         * `attach()` 会将其重新抛出，本函数透传该异常；此时本层的状态字段
+         * （`m_io_status`、`m_is_bos_done`、`m_is_tainted`）不会被本层重置。
          * @endif
          *
          * @lang{EN}
-         * Attach a new device to the converter, returning the previously held
-         * device and resetting the converter state.
+         * Attach a new device to the converter and reset the converter state.
          *
          * Passing a default-constructed (empty) `dev` is equivalent to clearing
-         * the current device. After the call `m_io_status` is reset to `neutral`
-         * and `m_is_bos_done` is reset to `false`.
+         * the current device. After the call `m_io_status` is reset to `neutral`,
+         * `m_is_bos_done` is reset to `false`, and `m_is_tainted` is reset to `false`.
+         *
+         * The previously held device is silently destroyed by the kernel inside
+         * its `detach()` step. Callers who need to preserve the old device must
+         * call `detach()` first to retrieve it, then call this function to install
+         * the new one.
+         *
+         * Exceptions: if the underlying kernel's `detach()` captures an exception
+         * while cleaning up the old device, the kernel's `attach()` rethrows it
+         * and this function propagates it through; in that case this layer's
+         * state fields (`m_io_status`, `m_is_bos_done`, `m_is_tainted`) are not
+         * reset by this layer.
          * @endif
          *
          * @param dev
          * @lang{ZH} 要附加的新设备（以移动方式转交所有权），默认为空设备。 @endif
          * @lang{EN} The new device to attach (ownership transferred via move); defaults to an empty device. @endif
-         *
-         * @return
-         * @lang{ZH} 先前持有的底层设备对象（右值）。 @endif
-         * @lang{EN} The previously held underlying device object (returned by value). @endif
          */
-        device_type attach(device_type&& dev = device_type{})
+        void attach(device_type&& dev = device_type{})
         {
-            auto result = m_kernel.attach(std::move(dev));
+            m_kernel.attach(std::move(dev));
             m_io_status = io_status::neutral;
             m_is_bos_done = false;
             m_is_tainted = false;
-            return result;
         }
 
         /**

--- a/include/cvt/code_cvt.h
+++ b/include/cvt/code_cvt.h
@@ -811,26 +811,34 @@ public:
 public:
     /**
      * @lang{ZH}
-     * 关闭当前流并替换底层设备为 `dev`，返回被替换的旧设备。
+     * 关闭当前流并替换底层设备为 `dev`。
+     *
+     * 本函数不归还原设备——原设备由 `BT::attach()` 在内部静默析构。如需保留
+     * 原设备，调用方应先调用 `detach()` 取得设备，再调用本函数装入新设备。
+     *
+     * 异常：`close_stream()` 或 `BT::attach()` 抛出的异常会透传给调用方。
      *
      * @param dev 新的底层设备（默认构造即为空设备）。
-     *
-     * @return 被替换的旧底层设备。
      * @endif
      *
      * @lang{EN}
-     * Close the current stream, replace the underlying device with `dev`,
-     * and return the previously held device.
+     * Close the current stream and replace the underlying device with `dev`.
+     *
+     * This function does NOT hand the old device back to the caller — the old
+     * device is silently destroyed inside `BT::attach()`. Callers who need to
+     * preserve the old device must call `detach()` first to retrieve it, then
+     * call this function to install the new device.
+     *
+     * Exceptions: any exception thrown by `close_stream()` or `BT::attach()`
+     * is propagated to the caller.
      *
      * @param dev New underlying device (default-constructed means an empty device).
-     *
-     * @return The previously held underlying device.
      * @endif
      */
-    device_type attach(device_type&& dev = device_type{})
+    void attach(device_type&& dev = device_type{})
     {
         close_stream();
-        return BT::attach(std::move(dev));
+        BT::attach(std::move(dev));
     }
 
     /**

--- a/include/cvt/comp/zlib_cvt.h
+++ b/include/cvt/comp/zlib_cvt.h
@@ -193,10 +193,10 @@ public:
 
 // mandatory methods
 public:
-    device_type attach(device_type&& dev = device_type{})
+    void attach(device_type&& dev = device_type{})
     {
         close_stream();
-        return BT::attach(std::move(dev));
+        BT::attach(std::move(dev));
     }
 
     std::pair<device_type, std::exception_ptr> detach() noexcept

--- a/include/cvt/crypt/chacha20_cvt.h
+++ b/include/cvt/crypt/chacha20_cvt.h
@@ -68,10 +68,10 @@ public:
 
 // mandatory methods
 public:
-    device_type attach(device_type&& dev = device_type{})
+    void attach(device_type&& dev = device_type{})
     {
         m_cipher->clear();
-        return BT::attach(std::move(dev));
+        BT::attach(std::move(dev));
     }
     
     std::pair<device_type, std::exception_ptr> detach() noexcept

--- a/include/cvt/crypt/hash_cvt.h
+++ b/include/cvt/crypt/hash_cvt.h
@@ -140,13 +140,13 @@ public:
         BT::main_cont_beg();
     }
     
-    device_type attach(device_type&& dev = device_type{})
+    void attach(device_type&& dev = device_type{})
     {
         if (m_has_main_cont)
             dump_stream();
         m_has_main_cont = false;
         m_out_fmt = hash_fmt::lower_hex;
-        return BT::attach(std::move(dev));
+        BT::attach(std::move(dev));
     }
 
     std::pair<device_type, std::exception_ptr> detach() noexcept

--- a/include/cvt/crypt/vigenere_cvt.h
+++ b/include/cvt/crypt/vigenere_cvt.h
@@ -55,10 +55,10 @@ public:
 
 // mandatory methods
 public:
-    device_type attach(device_type&& dev = device_type{})
+    void attach(device_type&& dev = device_type{})
     {
         m_pos = 0;
-        return BT::attach(std::move(dev));
+        BT::attach(std::move(dev));
     }
 
     std::pair<device_type, std::exception_ptr> detach() noexcept

--- a/include/cvt/cvt_concepts.h
+++ b/include/cvt/cvt_concepts.h
@@ -226,7 +226,7 @@ namespace IOv2
             {
                 { a.device() } -> std::same_as<typename T::device_type&>;
                 { a.detach() } noexcept -> std::same_as<std::pair<typename T::device_type, std::exception_ptr>>;
-                { a.attach(std::declval<typename T::device_type>()) } -> std::same_as<typename T::device_type>;
+                { a.attach(std::declval<typename T::device_type>()) } -> std::same_as<void>;
 
                 { a.bos() } -> std::same_as<io_status>;
                 { a.main_cont_beg() } -> std::same_as<void>;

--- a/include/cvt/root_cvt.h
+++ b/include/cvt/root_cvt.h
@@ -428,23 +428,41 @@ public:
     /**
      * @lang{ZH}
      * 分离当前设备，将新设备附加到 root_cvt，并将内部状态重置为初始状态。
-     * 等价于先调用 detach()，再接管新设备。
+     * 等价于先调用 `detach()` 清理原设备，再接管新设备。
+     *
+     * 与 `detach()` 不同的是，本函数**不**将原设备归还给调用方——原设备在
+     * 函数内部被静默析构。如需保留原设备，调用方应先单独调用 `detach()` 取得
+     * 设备，再调用本函数装入新设备。
+     *
+     * 异常：若 `detach()` 在清理原设备时捕获到异常（详见 `detach()` 文档），
+     * 本函数会在新设备装入并完成所有状态重置之后将该异常重新抛出。换言之，
+     * 即使抛出异常，root_cvt 也已切换到新设备并处于可用的 `neutral` 状态——
+     * 不提供强异常安全保证（不会回滚到调用前状态）。
      * @endif
      *
      * @lang{EN}
      * Detaches the current device, attaches a new device to root_cvt, and resets
-     * internal state to its initial values. Equivalent to calling detach() followed
-     * by taking ownership of the new device.
+     * internal state to its initial values. Equivalent to calling `detach()` to
+     * clean up the old device, followed by taking ownership of the new device.
+     *
+     * Unlike `detach()`, this function does NOT hand the old device back to the
+     * caller — the old device is silently destroyed inside this function. Callers
+     * who need to preserve the old device must call `detach()` first to retrieve
+     * it, then call this function to install the new device.
+     *
+     * Exceptions: if `detach()` captures an exception while cleaning up the old
+     * device (see `detach()` for details), this function rethrows that exception
+     * after the new device has been installed and all state has been reset. In
+     * other words, even when the function throws, root_cvt has already switched
+     * to the new device and is in a usable `neutral` state — this provides no
+     * strong exception safety guarantee (no rollback to pre-call state).
      * @endif
      *
      * @param dev
      * @lang{ZH} 要附加的新设备，默认为默认构造的空设备。 @endif
      * @lang{EN} The new device to attach; defaults to a default-constructed empty device. @endif
-     * @return
-     * @lang{ZH} 先前持有的设备对象（通过移动语义返回）。 @endif
-     * @lang{EN} The previously held device object, returned via move semantics. @endif
      */
-    device_type attach(device_type&& dev = device_type{})
+    void attach(device_type&& dev = device_type{})
     {
         auto detach_res = detach();
         m_device = std::move(dev);
@@ -455,7 +473,6 @@ public:
         m_buf_end = m_buffer.data();
         m_io_status = io_status::neutral;
         if (detach_res.second) std::rethrow_exception(detach_res.second);
-        return std::move(detach_res.first);
     }
 
     /**
@@ -1253,28 +1270,38 @@ public:
     /**
      * @lang{ZH}
      * 分离当前 mem_device，附加新设备，并将内部状态重置为初始值。
+     *
+     * 与 `detach()` 不同的是，本函数**不**将原 mem_device 归还给调用方——
+     * 原 mem_device 通过移动赋值被新设备覆盖（即静默析构）。如需保留原
+     * mem_device（例如取出其缓冲区内容），调用方应先单独调用 `detach()`
+     * 取得设备，再调用本函数装入新设备。
+     *
+     * mem_device 无清理动作，本函数不会抛出异常。
      * @endif
      *
      * @lang{EN}
      * Detaches the current mem_device, attaches a new device, and resets
      * internal state to initial values.
+     *
+     * Unlike `detach()`, this function does NOT hand the old mem_device back
+     * to the caller — the old mem_device is overwritten by move-assignment
+     * with the new device (i.e. silently destroyed). Callers who need to
+     * preserve the old mem_device (e.g. to extract its buffered contents) must
+     * call `detach()` first to retrieve it, then call this function to install
+     * the new device.
+     *
+     * mem_device has no cleanup step, so this function never throws.
      * @endif
      *
      * @param dev
      * @lang{ZH} 要附加的新设备，默认为默认构造的空设备。 @endif
      * @lang{EN} The new device to attach; defaults to a default-constructed empty device. @endif
-     * @return
-     * @lang{ZH} 先前持有的设备对象（通过移动语义返回）。 @endif
-     * @lang{EN} The previously held device object, returned via move semantics. @endif
      */
-    device_type attach(device_type&& dev = device_type{})
+    void attach(device_type&& dev = device_type{})
     {
-        auto detach_res = detach();  // detach_res.second is always nullptr for mem_device
         m_device = std::move(dev);
         m_bos_len = 0;
-
         m_io_status = io_status::neutral;
-        return std::move(detach_res.first);
     }
 
     /**

--- a/include/cvt/runtime_cvt.h
+++ b/include/cvt/runtime_cvt.h
@@ -33,7 +33,7 @@ public:
 
     virtual device_type& device() = 0;
     virtual std::pair<device_type, std::exception_ptr> detach() noexcept = 0;
-    virtual device_type attach(device_type&& dev = device_type{}) = 0;
+    virtual void attach(device_type&& dev = device_type{}) = 0;
     virtual void adjust(const cvt_behavior& acc) = 0;
     virtual void retrieve(cvt_status& acc) const = 0;
     virtual bool is_eof() = 0;
@@ -91,11 +91,10 @@ public:
         return result;
     }
 
-    device_type attach(device_type&& dev = device_type{}) override
+    void attach(device_type&& dev = device_type{}) override
     {
-        auto result = m_kernel.attach(std::move(dev));
+        m_kernel.attach(std::move(dev));
         m_io_status = io_status::neutral;
-        return result;
     }
 
     void adjust(const cvt_behavior& acc) override
@@ -250,10 +249,10 @@ public:
         return m_ptr->detach();
     }
 
-    device_type attach(device_type&& dev = device_type{})
+    void attach(device_type&& dev = device_type{})
     {
         if (!m_ptr) throw cvt_error("runtime_cvt: null instance");
-        return m_ptr->attach(std::move(dev));
+        m_ptr->attach(std::move(dev));
     }
 
     void adjust(const cvt_behavior& acc)

--- a/include/facet/messages_details.h
+++ b/include/facet/messages_details.h
@@ -369,11 +369,17 @@ private:
 
                     cvt.bos(); cvt.main_cont_beg();
                     cvt.put(wk.data(), wk.size());
-                    std::string ck = cvt.attach(mem_device{""}).str();
+                    auto [dev_k, err_k] = cvt.detach();
+                    cvt.attach(mem_device{""});
+                    if (err_k) std::rethrow_exception(err_k);
+                    std::string ck = dev_k.str();
 
                     cvt.bos(); cvt.main_cont_beg();
                     cvt.put(wv.data(), wv.size());
-                    std::string cv = cvt.attach(mem_device{""}).str();
+                    auto [dev_v, err_v] = cvt.detach();
+                    cvt.attach(mem_device{""});
+                    if (err_v) std::rethrow_exception(err_v);
+                    std::string cv = dev_v.str();
 
                     res.insert({std::move(ck), std::move(cv)});
                 }

--- a/include/io/objects/in_impl.h
+++ b/include/io/objects/in_impl.h
@@ -58,7 +58,7 @@ public:
     }
 
     std::pair<device_type, std::exception_ptr> detach() = delete;
-    device_type attach(device_type&&) = delete;
+    void attach(device_type&&) = delete;
 
     void reset() // mainly used for unit-test
     {

--- a/include/io/objects/out_impl.h
+++ b/include/io/objects/out_impl.h
@@ -70,7 +70,7 @@ public:
     }
 
     std::pair<device_type, std::exception_ptr> detach() = delete;
-    device_type attach(device_type&& dev = device_type{}) = delete;
+    void attach(device_type&& dev = device_type{}) = delete;
 
     void reset() // mainly used for unit-test
     {

--- a/include/io/streambuf.h
+++ b/include/io/streambuf.h
@@ -205,13 +205,12 @@ public:
         return m_cvt.detach();
     }
 
-    device_type attach(device_type&& dev = device_type{})
+    void attach(device_type&& dev = device_type{})
     {
         if constexpr (IsIn)
             m_read_buf.clear();
-        auto res = m_cvt.attach(std::move(dev));
+        m_cvt.attach(std::move(dev));
         init_cvt();
-        return res;
     }
 
     void adjust(const cvt_behavior& acc)

--- a/include/io/utilities/stream_common_operators.h
+++ b/include/io/utilities/stream_common_operators.h
@@ -72,10 +72,10 @@ struct stream_common_operators
         return obj.m_streambuf.detach();
     }
 
-    TDevice attach(TDevice&& dev = TDevice{})
+    void attach(TDevice&& dev = TDevice{})
     {
         T& obj = static_cast<T&>(*this);
-        return obj.m_streambuf.attach(std::move(dev));
+        obj.m_streambuf.attach(std::move(dev));
     }
 
     void adjust(const cvt_behavior& acc)

--- a/test/cvt/code_cvt/code_cvt_mem_char8_t.cpp
+++ b/test/cvt/code_cvt/code_cvt_mem_char8_t.cpp
@@ -1293,7 +1293,8 @@ void test_code_cvt_attach_1()
     VERIFY(obj.tell() == 1);
 
     // attach() resets to neutral (lines 833-836, close_stream)
-    auto old_dev = obj.attach(mem_device(std::u8string{}));
+    auto [old_dev, old_err] = obj.detach();
+    obj.attach(mem_device(std::u8string{}));
     VERIFY(old_dev.str().size() >= 1);
 
     // switch_to_put from neutral (lines 1164-1167); skip bos() since

--- a/test/cvt/comp/zlib_cvt_char.cpp
+++ b/test/cvt/comp/zlib_cvt_char.cpp
@@ -664,8 +664,9 @@ void test_zlib_cvt_reset_1()
                 buffer_id %= std::size(buffer_size);
                 cur_pos += dest_size;
             }
-            auto dev = obj.attach(mem_device(""));
-    
+            auto [dev, err] = obj.detach();
+            obj.attach(mem_device(""));
+
             if (cur_pos != s_e_lit.data() + 4102) throw std::runtime_error("zlib_cvt::put response incorrect");
             compress_res = dev.str();
         }

--- a/test/cvt/comp/zlib_cvt_wchar_t.cpp
+++ b/test/cvt/comp/zlib_cvt_wchar_t.cpp
@@ -634,8 +634,9 @@ void test_zlib_cvt_wchar_t_reset_1()
                 buffer_id %= std::size(buffer_size);
                 cur_pos += dest_size;
             }
-            auto dev = obj.attach(mem_device(""));
-    
+            auto [dev, err] = obj.detach();
+            obj.attach(mem_device(""));
+
             if (cur_pos != s_e_lit.data() + 4102) throw std::runtime_error("zlib_cvt::put response incorrect");
             compress_res = dev.str();
         }

--- a/test/cvt/crypt/md5_cvt.cpp
+++ b/test/cvt/crypt/md5_cvt.cpp
@@ -197,7 +197,8 @@ void test_md5_cvt_put_2()
             if (obj.bos() != io_status::output) throw std::runtime_error("md5_cvt<mem_device>::bos response incorrect");
             obj.main_cont_beg();
             obj.put("hello", 5);
-            auto dev = obj.attach();
+            auto [dev, err] = obj.detach();
+            obj.attach();
             if (dev.str() != hello_md5_hex_low) throw std::runtime_error("md5_cvt<mem_device>::put response incorrect");
         }
         
@@ -206,7 +207,8 @@ void test_md5_cvt_put_2()
             obj.main_cont_beg();
             obj.adjust(Crypt::set_hash_fmt(Crypt::hash_fmt::lower_hex));
             obj.put("hello", 5);
-            auto dev = obj.attach();
+            auto [dev, err] = obj.detach();
+            obj.attach();
             if (dev.str() != hello_md5_hex_low) throw std::runtime_error("md5_cvt<mem_device>::put response incorrect");
         }
         
@@ -215,7 +217,8 @@ void test_md5_cvt_put_2()
             obj.main_cont_beg();
             obj.adjust(Crypt::set_hash_fmt(Crypt::hash_fmt::upper_hex));
             obj.put("hello", 5);
-            auto dev = obj.attach();
+            auto [dev, err] = obj.detach();
+            obj.attach();
             if (dev.str() != hello_md5_hex_up) throw std::runtime_error("md5_cvt<mem_device>::put response incorrect");
         }
         
@@ -224,7 +227,8 @@ void test_md5_cvt_put_2()
             obj.main_cont_beg();
             obj.adjust(Crypt::set_hash_fmt(Crypt::hash_fmt::binary));
             obj.put("hello", 5);
-            auto dev = obj.attach();
+            auto [dev, err] = obj.detach();
+            obj.attach();
             if (dev.str() != hello_md5_binary) throw std::runtime_error("md5_cvt<mem_device>::put response incorrect");
         }
     };
@@ -253,7 +257,8 @@ void test_md5_cvt_put_3()
             obj.put("hello", 5);
             obj.adjust(Crypt::dump_hash('\n'));
             obj.put("hello", 5);
-            auto dev = obj.attach();
+            auto [dev, err] = obj.detach();
+            obj.attach();
             if (dev.str() != hello_md5_hex_low + '\n' + hello_md5_hex_low) throw std::runtime_error("md5_cvt<mem_device>::put response incorrect");
         }
 
@@ -317,7 +322,8 @@ void test_md5_cvt_put_5()
             if (obj.bos() != io_status::output) throw std::runtime_error("md5_cvt<mem_device>::bos response incorrect");
             obj.main_cont_beg();
             obj.put(u8"李伟", 6);
-            auto dev = obj.attach();
+            auto [dev, err] = obj.detach();
+            obj.attach();
             if (dev.str() != liwei_md5_hex_low) throw std::runtime_error("md5_cvt<mem_device>::put response incorrect");
         }
 
@@ -326,7 +332,8 @@ void test_md5_cvt_put_5()
             obj.main_cont_beg();
             obj.adjust(Crypt::set_hash_fmt(Crypt::hash_fmt::lower_hex));
             obj.put(u8"李伟", 6);
-            auto dev = obj.attach();
+            auto [dev, err] = obj.detach();
+            obj.attach();
             if (dev.str() != liwei_md5_hex_low) throw std::runtime_error("md5_cvt<mem_device>::put response incorrect");
         }
 
@@ -335,7 +342,8 @@ void test_md5_cvt_put_5()
             obj.main_cont_beg();
             obj.adjust(Crypt::set_hash_fmt(Crypt::hash_fmt::upper_hex));
             obj.put(u8"李伟", 6);
-            auto dev = obj.attach();
+            auto [dev, err] = obj.detach();
+            obj.attach();
             if (dev.str() != liwei_md5_hex_up) throw std::runtime_error("md5_cvt<mem_device>::put response incorrect");
         }
     
@@ -344,7 +352,8 @@ void test_md5_cvt_put_5()
             obj.main_cont_beg();
             obj.adjust(Crypt::set_hash_fmt(Crypt::hash_fmt::binary));
             obj.put(u8"李伟", 6);
-            auto dev = obj.attach();
+            auto [dev, err] = obj.detach();
+            obj.attach();
             if (dev.str() != liwei_md5_binary) throw std::runtime_error("md5_cvt<mem_device>::put response incorrect");
         }
     };

--- a/test/cvt/crypt/sha256_cvt.cpp
+++ b/test/cvt/crypt/sha256_cvt.cpp
@@ -166,7 +166,8 @@ void test_sha256_cvt_put_2()
             if (obj.bos() != io_status::output) throw std::runtime_error("sha256_cvt<mem_device>::bos response incorrect");
             obj.main_cont_beg();
             obj.put("hello", 5);
-            auto dev = obj.attach();
+            auto [dev, err] = obj.detach();
+            obj.attach();
             if (dev.str() != hello_hex_low) throw std::runtime_error("sha256_cvt<mem_device>::put response incorrect");
         }
         
@@ -175,7 +176,8 @@ void test_sha256_cvt_put_2()
             obj.main_cont_beg();
             obj.adjust(Crypt::set_hash_fmt(Crypt::hash_fmt::lower_hex));
             obj.put("hello", 5);
-            auto dev = obj.attach();
+            auto [dev, err] = obj.detach();
+            obj.attach();
             if (dev.str() != hello_hex_low) throw std::runtime_error("sha256_cvt<mem_device>::put response incorrect");
         }
         
@@ -184,7 +186,8 @@ void test_sha256_cvt_put_2()
             obj.main_cont_beg();
             obj.adjust(Crypt::set_hash_fmt(Crypt::hash_fmt::upper_hex));
             obj.put("hello", 5);
-            auto dev = obj.attach();
+            auto [dev, err] = obj.detach();
+            obj.attach();
             if (dev.str() != hello_hex_up) throw std::runtime_error("sha256_cvt<mem_device>::put response incorrect");
         }
         
@@ -193,7 +196,8 @@ void test_sha256_cvt_put_2()
             obj.main_cont_beg();
             obj.adjust(Crypt::set_hash_fmt(Crypt::hash_fmt::binary));
             obj.put("hello", 5);
-            auto dev = obj.attach();
+            auto [dev, err] = obj.detach();
+            obj.attach();
             if (dev.str() != hello_binary) throw std::runtime_error("sha256_cvt<mem_device>::put response incorrect");
         }
     };
@@ -222,7 +226,8 @@ void test_sha256_cvt_put_3()
             obj.put("hello", 5);
             obj.adjust(Crypt::dump_hash('\n'));
             obj.put("hello", 5);
-            auto dev = obj.attach();
+            auto [dev, err] = obj.detach();
+            obj.attach();
             if (dev.str() != hello_hex_low + '\n' + hello_hex_low) throw std::runtime_error("sha256_cvt<mem_device>::put response incorrect");
         }
 
@@ -233,7 +238,8 @@ void test_sha256_cvt_put_3()
             obj.adjust(Crypt::dump_hash('*'));
             obj.adjust(Crypt::set_hash_fmt(Crypt::hash_fmt::upper_hex));
             obj.put("hello", 5);
-            auto dev = obj.attach();
+            auto [dev, err] = obj.detach();
+            obj.attach();
             if (dev.str() != hello_hex_low + '*' + hello_hex_up) throw std::runtime_error("sha256_cvt<mem_device>::put response incorrect");
         }
     };
@@ -286,7 +292,8 @@ void test_sha256_cvt_put_5()
             if (obj.bos() != io_status::output) throw std::runtime_error("sha256_cvt<mem_device>::bos response incorrect");
             obj.main_cont_beg();
             obj.put(u8"李伟", 6);
-            auto dev = obj.attach();
+            auto [dev, err] = obj.detach();
+            obj.attach();
             if (dev.str() != liwei_hex_low) throw std::runtime_error("sha256_cvt<mem_device>::put response incorrect");
         }
 
@@ -295,7 +302,8 @@ void test_sha256_cvt_put_5()
             obj.main_cont_beg();
             obj.adjust(Crypt::set_hash_fmt(Crypt::hash_fmt::lower_hex));
             obj.put(u8"李伟", 6);
-            auto dev = obj.attach();
+            auto [dev, err] = obj.detach();
+            obj.attach();
             if (dev.str() != liwei_hex_low) throw std::runtime_error("sha256_cvt<mem_device>::put response incorrect");
         }
     
@@ -304,7 +312,8 @@ void test_sha256_cvt_put_5()
             obj.main_cont_beg();
             obj.adjust(Crypt::set_hash_fmt(Crypt::hash_fmt::upper_hex));
             obj.put(u8"李伟", 6);
-            auto dev = obj.attach();
+            auto [dev, err] = obj.detach();
+            obj.attach();
             if (dev.str() != liwei_hex_up) throw std::runtime_error("sha256_cvt<mem_device>::put response incorrect");
         }
     
@@ -313,7 +322,8 @@ void test_sha256_cvt_put_5()
             obj.main_cont_beg();
             obj.adjust(Crypt::set_hash_fmt(Crypt::hash_fmt::binary));
             obj.put(u8"李伟", 6);
-            auto dev = obj.attach();
+            auto [dev, err] = obj.detach();
+            obj.attach();
             if (dev.str() != liwei_binary) throw std::runtime_error("sha256_cvt<mem_device>::put response incorrect");
         }
     };

--- a/test/cvt/root_cvt/root_cvt_file.cpp
+++ b/test/cvt/root_cvt/root_cvt_file.cpp
@@ -817,7 +817,8 @@ void test_root_cvt_file_attach_1()
         VERIFY(obj.device().dtell() == 8);
 
         file_guard g("test_file2", "abcde");
-        auto dev = obj.attach(ifile_device<char>("test_file2"));
+        auto [dev, err] = obj.detach();
+        obj.attach(ifile_device<char>("test_file2"));
         VERIFY(dev.dtell() == 1);
     };
 
@@ -846,7 +847,8 @@ void test_root_cvt_file_attach_2()
         VERIFY(obj.device().dtell() == 0);
 
         file_guard g("test_file2", "");
-        auto dev = obj.attach(ofile_device<char>("test_file2"));
+        auto [dev, err] = obj.detach();
+        obj.attach(ofile_device<char>("test_file2"));
         VERIFY(dev.dtell() == 3);
     };
 

--- a/test/cvt/root_cvt/root_cvt_mem.cpp
+++ b/test/cvt/root_cvt/root_cvt_mem.cpp
@@ -432,7 +432,8 @@ void test_root_cvt_mem_reset_1()
         obj.put(" world", 6);
         if (obj.tell() != 6) throw std::runtime_error("root_cvt<mem_device>::tell incorrect");
 
-        mem_device<char> ori = obj.attach(mem_device(""));
+        auto [ori, ori_err] = obj.detach();
+        obj.attach(mem_device(""));
         if (ori.str() != "hello world") throw std::runtime_error("root_cvt<mem_device>::reset incorrect");
         
         obj.bos();
@@ -475,7 +476,8 @@ void test_root_cvt_mem_device_1()
         obj.bos(); obj.main_cont_beg();
         obj.put("123", 3);
 
-        device_type f2 = obj.attach(std::move(f1));
+        auto [f2, f2_err] = obj.detach();
+        obj.attach(std::move(f1));
         obj.bos(); obj.main_cont_beg();
         obj.put("def", 3);
 
@@ -561,7 +563,8 @@ void test_root_cvt_mem_attach_1()
         VERIFY(ch == '1');
         VERIFY(obj.device().dtell() == 1);
         
-        auto dev = obj.attach(mem_device{""});
+        auto [dev, err] = obj.detach();
+        obj.attach(mem_device{""});
         VERIFY(dev.dtell() == 1);
     };
     {
@@ -586,7 +589,8 @@ void test_root_cvt_mem_attach_2()
         obj.put("123", 3);
         VERIFY(obj.device().dtell() == 3);
         
-        auto dev = obj.attach(mem_device{""});
+        auto [dev, err] = obj.detach();
+        obj.attach(mem_device{""});
         VERIFY(dev.dtell() == 3);
     };
     {


### PR DESCRIPTION
- Modified attach() in various converter classes to return void instead of the old device.
- Updated cvt_concepts.h to reflect this change.
- Updated tests to use detach() before attach() when the old device is needed.
- This change avoids ambiguity and ensures that the old device is properly handled via detach().