### PR TITLE
fix(cvt): add missing concepts and constraints for zlib_cvt and pipe creator

### DIFF
--- a/include/cvt/comp/zlib_cvt.h
+++ b/include/cvt/comp/zlib_cvt.h
@@ -49,7 +49,8 @@ struct zlib_sync_flush : cvt_behavior
 };
 
 template <io_converter KernelType, typename TInt = typename KernelType::internal_type>
-    requires (sizeof(typename KernelType::internal_type) == sizeof(unsigned char))
+    requires (sizeof(typename KernelType::internal_type) == sizeof(unsigned char) &&
+              std::is_trivially_copyable_v<TInt>)
 class zlib_cvt : public abs_cvt<zlib_cvt<KernelType, TInt>, KernelType, TInt, false, false>
 {
     using BT = abs_cvt<zlib_cvt<KernelType, TInt>, KernelType, TInt, false, false>;

--- a/include/cvt/cvt_pipe_creator.h
+++ b/include/cvt/cvt_pipe_creator.h
@@ -2,6 +2,7 @@
 
 #include <cvt/cvt_concepts.h>
 
+#include <concepts>
 #include <cstddef>
 #include <tuple>
 #include <type_traits>
@@ -130,7 +131,8 @@ private:
 };
 
 template <typename T1, typename T2>
-    requires (cvt_creator<T1> && cvt_creator<T2>)
+    requires (cvt_creator<T1> && cvt_creator<T2> &&
+              std::copy_constructible<T1> && std::copy_constructible<T2>)
 auto operator | (const T1& t1, const T2& t2)
 {
     using type = typename cvt_creator_type_gen<T1, T2>::type;


### PR DESCRIPTION


- include/cvt/comp/zlib_cvt.h: Add std::is_trivially_copyable_v requirement.
- include/cvt/cvt_pipe_creator.h: Add std::copy_constructible requirement for pipe operators and include <concepts>.