### PR TITLE
docs(cvt): add bilingual Doxygen comments to cvt_pipe_creator, runtime_cvt, and zlib_cvt

### DIFF
--- a/include/cvt/comp/zlib_cvt.h
+++ b/include/cvt/comp/zlib_cvt.h
@@ -1,3 +1,24 @@
+/**
+ * @file zlib_cvt.h
+ * @lang{ZH}
+ * zlib 压缩/解压转换器定义文件。
+ * 本文件实现了基于 zlib 的 deflate（压缩）和 inflate（解压）转换器 `zlib_cvt`，
+ * 以及用于流式管道构造的工厂类 `zlib_cvt_creator`。
+ * `zlib_cvt` 继承自 `abs_cvt`（禁用默认定位与 IO 方向切换），BOS 阶段负责读写
+ * 2 字节的 zlib 流头，主内容阶段通过 `get_main`/`put_main` 执行实际的解压/压缩。
+ * @endif
+ *
+ * @lang{EN}
+ * zlib compression/decompression converter definition file.
+ * This file implements `zlib_cvt`, a deflate (compression) and inflate (decompression)
+ * converter based on zlib, together with `zlib_cvt_creator`, a factory class for
+ * constructing it in streaming pipelines.
+ * `zlib_cvt` derives from `abs_cvt` with default positioning and IO-direction switching
+ * both disabled. During the BOS phase it reads or writes the 2-byte zlib stream header;
+ * the main-content phase performs actual decompression/compression through
+ * `get_main`/`put_main`.
+ * @endif
+ */
 #pragma once
 
 #include <cvt/cvt_concepts.h>
@@ -19,27 +40,48 @@
 
 namespace IOv2::Comp
 {
-// adjust() behavior that toggles Z_SYNC_FLUSH semantics on zlib_cvt::flush().
-//
-// Default for zlib_cvt is sync_flush == false, in which case flush() does NOT
-// emit a sync marker - bytes already deflate()'d on previous put() calls are
-// still resident in the downstream kernel buffer chain and will reach the
-// device through subsequent put / close_stream paths, but data still sitting
-// inside zlib's LZ77 window stays buffered until close_stream finalizes the
-// stream with Z_FINISH.
-//
-// This default is deliberate: Z_SYNC_FLUSH is not free.  Each invocation
-// inserts a 5-byte empty stored block (00 00 00 FF FF) as a stream sync point
-// AND forces zlib to abandon partial LZ77 matches it was still trying to
-// optimize - frequent sync-flushing can degrade the compression ratio toward
-// 1:1.  Callers who do not need stream-level synchronization should not pay
-// that cost.
-//
-// Set sync_flush == true via cvt.adjust(zlib_sync_flush{true}) when you do
-// need synchronization points: streaming over a network where the receiver
-// must be able to start decompression at well-defined boundaries, interactive
-// tools that need byte-level latency at the cost of ratio, or any framing
-// where downstream may begin decompression mid-stream.
+/**
+ * @lang{ZH}
+ * 控制 `zlib_cvt::flush()` 是否触发 `Z_SYNC_FLUSH` 语义的行为策略类。
+ *
+ * `zlib_cvt` 的默认行为是 `sync_flush == false`，此时 `flush()` 不向下游写入任何
+ * 同步标记——先前 `put()` 已送入 zlib 但尚未完成 LZ77 窗口匹配的数据仍保留在
+ * zlib 内部缓冲区中，等到 `close_stream` 以 `Z_FINISH` 最终化时才写出。
+ *
+ * 默认采用此语义是有意为之：`Z_SYNC_FLUSH` 并非免费——每次调用会插入一个
+ * 5 字节的空存储块（`00 00 00 FF FF`）作为流同步点，并强制 zlib 放弃尚在
+ * 优化中的 LZ77 部分匹配，频繁同步刷会使压缩率趋近 1:1。不需要流级同步的
+ * 调用方不应承担这一开销。
+ *
+ * 当确实需要同步点时，可通过 `cvt.adjust(zlib_sync_flush{true})` 启用：
+ * - 通过网络流式传输，接收方需要在明确边界处开始解压；
+ * - 需要字节级延迟的交互式工具（以压缩率换取低延迟）；
+ * - 任何下游可能在流中途开始解压的分帧场景。
+ * @endif
+ *
+ * @lang{EN}
+ * Behavior policy class that controls whether `zlib_cvt::flush()` triggers
+ * `Z_SYNC_FLUSH` semantics.
+ *
+ * The default for `zlib_cvt` is `sync_flush == false`, in which case `flush()` does
+ * NOT emit a sync marker — data that has been passed to `deflate()` on previous `put()`
+ * calls but is still inside zlib's LZ77 window stays buffered until `close_stream`
+ * finalizes the stream with `Z_FINISH`.
+ *
+ * This default is deliberate: `Z_SYNC_FLUSH` is not free. Each invocation inserts a
+ * 5-byte empty stored block (`00 00 00 FF FF`) as a stream sync point AND forces zlib
+ * to abandon partial LZ77 matches it was still trying to optimize — frequent
+ * sync-flushing can degrade the compression ratio toward 1:1. Callers who do not need
+ * stream-level synchronization should not pay that cost.
+ *
+ * Enable it via `cvt.adjust(zlib_sync_flush{true})` when synchronization points are
+ * required:
+ * - Streaming over a network where the receiver must start decompression at
+ *   well-defined boundaries;
+ * - Interactive tools that need byte-level latency at the cost of compression ratio;
+ * - Any framing where downstream may begin decompression mid-stream.
+ * @endif
+ */
 struct zlib_sync_flush : cvt_behavior
 {
     explicit zlib_sync_flush(bool sync_flush)
@@ -48,6 +90,71 @@ struct zlib_sync_flush : cvt_behavior
     bool m_sync_flush;
 };
 
+/**
+ * @lang{ZH}
+ * 基于 zlib 的压缩/解压转换器。
+ *
+ * 继承自 `abs_cvt`，将 `default_positioning` 和 `default_io_switch` 均设为 `false`：
+ * 压缩流具有状态性，既不支持随机定位，也不支持在压缩和解压方向之间切换。
+ *
+ * **BOS 阶段**（`bos()` 后、`main_cont_beg()` 前）：
+ * - 输出（压缩）模式：调用 `deflateInit`，立即以 `Z_NO_FLUSH` 触发 zlib 输出
+ *   2 字节流头，并通过内核写出。
+ * - 输入（解压）模式：调用 `inflateInit`，从内核读取 2 字节流头并送入 `inflate`
+ *   以完成头部验证。
+ *
+ * **主内容阶段**（`main_cont_beg()` 后）：
+ * - 压缩：`put_main` 调用 `deflate(Z_NO_FLUSH)` 将用户数据压缩后写入内核。
+ * - 解压：`get_main` 调用 `inflate(Z_NO_FLUSH)` 从内核读取压缩数据并解压给调用方。
+ *
+ * **流的终结**（`close_stream()`）：
+ * - 压缩：调用 `deflate(Z_FINISH)` 循环直到 `Z_STREAM_END`，将所有剩余压缩字节
+ *   写入内核，最后调用 `deflateEnd`。
+ * - 解压：直接调用 `inflateEnd`。
+ *
+ * @tparam KernelType 内核转换器类型，须满足 `io_converter`；其 `internal_type` 的
+ *                   大小须等于 `unsigned char`（即字节级内核）。
+ *                   / The kernel converter type, must satisfy `io_converter`; its
+ *                   `internal_type` must have the same size as `unsigned char` (byte-level kernel).
+ * @tparam TInt       本转换器对外暴露的内部类型（即 `get`/`put` 接口的元素类型）。
+ *                   须满足 `std::is_trivially_copyable`。默认等于内核的 `internal_type`。
+ *                   / The internal type exposed by this converter (the element type of the
+ *                   `get`/`put` interface). Must satisfy `std::is_trivially_copyable`.
+ *                   Defaults to the kernel's `internal_type`.
+ * @endif
+ *
+ * @lang{EN}
+ * zlib-based compression/decompression converter.
+ *
+ * Derives from `abs_cvt` with both `default_positioning` and `default_io_switch` set
+ * to `false`: compressed streams are stateful and support neither random seeking nor
+ * switching between compression and decompression directions.
+ *
+ * **BOS phase** (after `bos()`, before `main_cont_beg()`):
+ * - Output (compression) mode: calls `deflateInit`, immediately triggers a `Z_NO_FLUSH`
+ *   call to make zlib emit the 2-byte stream header, and writes it through the kernel.
+ * - Input (decompression) mode: calls `inflateInit`, reads the 2-byte stream header
+ *   from the kernel, and feeds it to `inflate` for header validation.
+ *
+ * **Main-content phase** (after `main_cont_beg()`):
+ * - Compression: `put_main` calls `deflate(Z_NO_FLUSH)` to compress user data and
+ *   write it through the kernel.
+ * - Decompression: `get_main` calls `inflate(Z_NO_FLUSH)` to read compressed data
+ *   from the kernel and decompress it for the caller.
+ *
+ * **Stream finalization** (`close_stream()`):
+ * - Compression: loops `deflate(Z_FINISH)` until `Z_STREAM_END`, flushing all
+ *   remaining compressed bytes through the kernel, then calls `deflateEnd`.
+ * - Decompression: calls `inflateEnd` directly.
+ *
+ * @tparam KernelType The kernel converter type, must satisfy `io_converter`; its
+ *                   `internal_type` must have the same size as `unsigned char`
+ *                   (byte-level kernel).
+ * @tparam TInt       The internal type exposed by this converter (the element type of
+ *                   the `get`/`put` interface). Must satisfy `std::is_trivially_copyable`.
+ *                   Defaults to the kernel's `internal_type`.
+ * @endif
+ */
 template <io_converter KernelType, typename TInt = typename KernelType::internal_type>
     requires (sizeof(typename KernelType::internal_type) == sizeof(unsigned char) &&
               std::is_trivially_copyable_v<TInt>)
@@ -56,10 +163,25 @@ class zlib_cvt : public abs_cvt<zlib_cvt<KernelType, TInt>, KernelType, TInt, fa
     using BT = abs_cvt<zlib_cvt<KernelType, TInt>, KernelType, TInt, false, false>;
     friend BT;  // for put_main and get_main
 
-    // On the failure path, call inflateEnd/deflateEnd and reset the unique_ptr
-    // so that close_stream() (and the destructor) see a null m_strm and skip
-    // redundant cleanup.  release() prevents the guard from running End on the
-    // success path (the stream remains alive, owned by m_strm).
+    /**
+     * @lang{ZH}
+     * `inflateInit` 失败路径上的 RAII 守卫。
+     * 若在 `inflateInit` 成功后、流被正式接管前发生异常，析构函数自动调用
+     * `inflateEnd` 并将 `m_strm` 重置为 `nullptr`，确保 `close_stream`
+     * 和析构函数在后续调用中看到空指针并跳过重复清理。
+     * 成功路径上调用 `release()` 可阻止守卫执行清理（流转由 `m_strm` 管理）。
+     * @endif
+     *
+     * @lang{EN}
+     * RAII guard for the `inflateInit` failure path.
+     * If an exception occurs after `inflateInit` succeeds but before the stream is
+     * formally taken over, the destructor automatically calls `inflateEnd` and resets
+     * `m_strm` to `nullptr`, ensuring that subsequent calls to `close_stream` and the
+     * destructor see a null pointer and skip redundant cleanup.
+     * Calling `release()` on the success path prevents the guard from running cleanup
+     * (ownership is retained by `m_strm`).
+     * @endif
+     */
     struct inflate_guard
     {
         std::unique_ptr<z_stream>& strm_ref;
@@ -82,6 +204,25 @@ class zlib_cvt : public abs_cvt<zlib_cvt<KernelType, TInt>, KernelType, TInt, fa
         inflate_guard& operator=(inflate_guard&&) = delete;
     };
 
+    /**
+     * @lang{ZH}
+     * `deflateInit` 失败路径上的 RAII 守卫。
+     * 若在 `deflateInit` 成功后、流被正式接管前发生异常，析构函数自动调用
+     * `deflateEnd` 并将 `m_strm` 重置为 `nullptr`，确保 `close_stream`
+     * 和析构函数在后续调用中看到空指针并跳过重复清理。
+     * 成功路径上调用 `release()` 可阻止守卫执行清理（流转由 `m_strm` 管理）。
+     * @endif
+     *
+     * @lang{EN}
+     * RAII guard for the `deflateInit` failure path.
+     * If an exception occurs after `deflateInit` succeeds but before the stream is
+     * formally taken over, the destructor automatically calls `deflateEnd` and resets
+     * `m_strm` to `nullptr`, ensuring that subsequent calls to `close_stream` and the
+     * destructor see a null pointer and skip redundant cleanup.
+     * Calling `release()` on the success path prevents the guard from running cleanup
+     * (ownership is retained by `m_strm`).
+     * @endif
+     */
     struct deflate_guard
     {
         std::unique_ptr<z_stream>& strm_ref;
@@ -104,11 +245,24 @@ class zlib_cvt : public abs_cvt<zlib_cvt<KernelType, TInt>, KernelType, TInt, fa
         deflate_guard& operator=(deflate_guard&&) = delete;
     };
 
-    // Resets next_in / avail_in / next_out / avail_out on scope exit so that
-    // any throw from get_main / put_main / do_flush cannot leave m_strm holding
-    // pointers into reader / writer / user buffers that have since gone out of
-    // scope.  Does NOT touch m_strm itself - cleanup of the zlib stream object
-    // is the job of close_stream / inflate_guard / deflate_guard.
+    /**
+     * @lang{ZH}
+     * 作用域退出时将 `m_strm` 的输入/输出指针和计数清零的 RAII 守卫。
+     * 确保 `get_main`、`put_main`、`do_flush` 抛出异常时，`m_strm` 不会
+     * 持有指向已离开作用域的读缓冲区、写缓冲区或用户缓冲区的悬空指针。
+     * 不触及 `m_strm` 自身——zlib 流对象的清理由 `close_stream`、
+     * `inflate_guard` 和 `deflate_guard` 负责。
+     * @endif
+     *
+     * @lang{EN}
+     * RAII guard that clears `m_strm`'s input/output pointers and counts on scope exit.
+     * Ensures that when `get_main`, `put_main`, or `do_flush` throw an exception,
+     * `m_strm` is not left holding dangling pointers into reader, writer, or user
+     * buffers that have since gone out of scope.
+     * Does NOT touch `m_strm` itself — cleanup of the zlib stream object is the
+     * responsibility of `close_stream`, `inflate_guard`, and `deflate_guard`.
+     * @endif
+     */
     struct io_buf_guard
     {
         z_stream& strm;
@@ -132,10 +286,30 @@ public:
     using external_type = typename KernelType::internal_type;
 
 private:
+    /// @lang{ZH} deflate/inflate 输出缓冲区的最小字节容量，至少为 16 且不小于 sizeof(internal_type)。 @endif
+    /// @lang{EN} Minimum byte capacity of the deflate/inflate output buffer; at least 16 and no less than sizeof(internal_type). @endif
     constexpr static unsigned CHUNK = std::max<unsigned>(16, sizeof(internal_type));
+
+    /// @lang{ZH} zlib 流头的字节长度（固定为 2 字节）。 @endif
+    /// @lang{EN} Byte length of the zlib stream header (fixed at 2 bytes). @endif
     constexpr static size_t zlib_header_size = 2;
 
 public:
+    /**
+     * @lang{ZH}
+     * 从内核和压缩等级构造 zlib 转换器。
+     * 压缩等级超过 9 时自动截断为 9；解压方向忽略此参数（等级仅影响 `deflateInit`）。
+     * @endif
+     *
+     * @lang{EN}
+     * Construct the zlib converter from a kernel and compression level.
+     * A level greater than 9 is silently clamped to 9; the level is ignored on the
+     * decompression path as it only affects `deflateInit`.
+     * @endif
+     *
+     * @param kernel    底层内核转换器（移动接管所有权）。 / The underlying kernel converter (ownership transferred via move).
+     * @param put_level deflate 压缩等级（0–9，默认 6）。 / deflate compression level (0–9, default 6).
+     */
     zlib_cvt(KernelType kernel, unsigned put_level = 6)
         : BT(std::move(kernel))
         , m_put_level(put_level)
@@ -143,6 +317,26 @@ public:
         if (m_put_level > 9) m_put_level = 9;
     }
 
+    /**
+     * @lang{ZH}
+     * 拷贝构造函数。复制内核、压缩等级、`m_sync_flush` 及 `m_stream_ended` 标志。
+     * 若当前处于输出模式，调用 `deflateCopy` 深拷贝 zlib deflate 状态；
+     * 若处于输入模式，调用 `inflateCopy` 深拷贝 inflate 状态。
+     * 若处于 `neutral` 模式，则无需拷贝 zlib 状态（`m_strm` 为空）。
+     * `deflateCopy`/`inflateCopy` 抛出异常时，`m_strm` 被重置、IO 状态恢复为
+     * `neutral`，确保对象处于一致状态。
+     * @endif
+     *
+     * @lang{EN}
+     * Copy constructor. Copies the kernel, compression level, `m_sync_flush`,
+     * and `m_stream_ended` flag.
+     * If currently in output mode, calls `deflateCopy` to deep-copy the deflate state;
+     * if in input mode, calls `inflateCopy` to deep-copy the inflate state.
+     * In `neutral` mode no zlib state needs to be copied (`m_strm` is null).
+     * If `deflateCopy`/`inflateCopy` throws, `m_strm` is reset and IO status is
+     * restored to `neutral`, leaving the object in a consistent state.
+     * @endif
+     */
     zlib_cvt(const zlib_cvt& val)
         requires (std::copy_constructible<KernelType>)
         : BT(val)
@@ -172,11 +366,23 @@ public:
         }
     }
 
-    // Move constructor: transfer the unique_ptr so the z_stream address is
-    // unchanged.  zlib's internal state keeps a back-pointer (state->strm) to
-    // the z_stream struct; a shallow struct copy would leave that pointer
-    // stale, causing deflate/inflate to return Z_STREAM_ERROR.  Moving the
-    // unique_ptr preserves the address and keeps the back-pointer valid.
+    /**
+     * @lang{ZH}
+     * 移动构造函数。转移 `m_strm` 的 `unique_ptr` 所有权，使 `z_stream` 对象的
+     * 地址保持不变。zlib 内部状态通过 `state->strm` 反向引用 `z_stream` 结构体；
+     * 若浅拷贝结构体会使该指针悬空，`deflate`/`inflate` 将返回 `Z_STREAM_ERROR`。
+     * 转移 `unique_ptr` 可保留原地址，使反向指针持续有效。
+     * @endif
+     *
+     * @lang{EN}
+     * Move constructor. Transfers ownership of the `m_strm` `unique_ptr`, keeping
+     * the address of the `z_stream` object unchanged. zlib's internal state holds a
+     * back-pointer (`state->strm`) to the `z_stream` struct; a shallow struct copy
+     * would leave that pointer stale, causing `deflate`/`inflate` to return
+     * `Z_STREAM_ERROR`. Transferring the `unique_ptr` preserves the address and
+     * keeps the back-pointer valid.
+     * @endif
+     */
     zlib_cvt(zlib_cvt&& val) noexcept
         : BT(std::move(val))
         , m_put_level(val.m_put_level)
@@ -185,6 +391,25 @@ public:
         , m_strm(std::move(val.m_strm))
     {}
 
+    /**
+     * @lang{ZH}
+     * 拷贝赋值运算符。
+     * 先关闭旧流（捕获可能的错误），再拷贝新状态（包括 `deflateCopy`/`inflateCopy`）。
+     * 若新状态拷贝失败，将对象标记为 tainted 后重新抛出。若新状态拷贝成功但旧流
+     * 关闭失败，则在返回前重新抛出 `close_stream` 的异常——确保赋值结果始终可用，
+     * 同时不丢失关闭失败的错误信息。
+     * @endif
+     *
+     * @lang{EN}
+     * Copy assignment operator.
+     * Closes the old stream first (capturing any error), then copies the new state
+     * (including `deflateCopy`/`inflateCopy`).
+     * If copying the new state fails, the object is marked tainted before rethrowing.
+     * If copying succeeds but the old stream close failed, the `close_stream` exception
+     * is rethrown before returning — ensuring the assignment result is always usable
+     * while not silently discarding the close failure.
+     * @endif
+     */
     zlib_cvt& operator=(const zlib_cvt& val)
     {
         if (this == &val) return *this;
@@ -228,6 +453,22 @@ public:
         return *this;
     }
 
+    /**
+     * @lang{ZH}
+     * 移动赋值运算符（`noexcept`）。
+     * 先关闭旧流（忽略任何错误），再转移所有成员，包括 `m_strm` 的 `unique_ptr`。
+     * 转移 `unique_ptr` 而非拷贝 `z_stream` 结构体，可保留 zlib 内部反向指针的有效性
+     * （详见移动构造函数的说明）。
+     * @endif
+     *
+     * @lang{EN}
+     * Move assignment operator (`noexcept`).
+     * Closes the old stream first (discarding any error), then transfers all members,
+     * including the `m_strm` `unique_ptr`.
+     * Transferring the `unique_ptr` rather than copying the `z_stream` struct preserves
+     * the validity of zlib's internal back-pointer (see the move constructor for details).
+     * @endif
+     */
     zlib_cvt& operator=(zlib_cvt&& val) noexcept
     {
         if (this == &val) return *this;
@@ -244,6 +485,16 @@ public:
         return *this;
     }
 
+    /**
+     * @lang{ZH}
+     * 析构函数（`noexcept`）。调用 `close_stream()` 最终化输出流；若抛出异常则静默忽略。
+     * @endif
+     *
+     * @lang{EN}
+     * Destructor (`noexcept`). Calls `close_stream()` to finalize the output stream;
+     * any exception thrown is silently discarded.
+     * @endif
+     */
     ~zlib_cvt() noexcept
     {
         try
@@ -255,6 +506,25 @@ public:
 
 // mandatory methods
 public:
+    /**
+     * @lang{ZH}
+     * 将新设备绑定到转换器，同时关闭当前 zlib 流。
+     * 先关闭当前流（捕获可能的错误），再安装新设备；关闭错误在新设备安装完成后才抛出。
+     * 这一顺序是为了防止 `dev`（已移入函数参数）在栈回绕时被析构而悄然丢失。
+     * @endif
+     *
+     * @lang{EN}
+     * Attach a new device to the converter, closing the current zlib stream first.
+     * The current stream is closed before the new device is installed (any close error
+     * is captured); the error is rethrown only after the new device has been installed.
+     * This ordering prevents `dev` (already moved into the parameter) from being
+     * silently destroyed during stack unwinding.
+     * @endif
+     *
+     * @param dev 要绑定的新设备（移动接管所有权），默认为空设备。
+     *            / The new device to attach (ownership transferred via move); defaults to an empty device.
+     * @throws cvt_error 若旧流的 `close_stream()` 失败。 / If `close_stream()` fails for the old stream.
+     */
     void attach(device_type&& dev = device_type{})
     {
         // close_stream failure only means the OLD output stream could not be
@@ -274,6 +544,23 @@ public:
         if (close_err) std::rethrow_exception(close_err);
     }
 
+    /**
+     * @lang{ZH}
+     * 分离底层设备，同时最终化当前 zlib 流（`noexcept`）。
+     * 先调用 `close_stream()`（捕获异常），再调用基类 `BT::detach()` 分离设备。
+     * `close_stream` 的错误优先于内核的错误返回（first-failure-wins）。
+     * @endif
+     *
+     * @lang{EN}
+     * Detach the underlying device while finalizing the current zlib stream (`noexcept`).
+     * Calls `close_stream()` first (capturing any exception), then calls the base-class
+     * `BT::detach()` to detach the device.
+     * The `close_stream` error takes precedence over the kernel's error (first-failure-wins).
+     * @endif
+     *
+     * @return 包含已分离设备和首个捕获异常的 pair（`nullptr` 表示无异常）。
+     *         / A pair containing the detached device and the first captured exception (`nullptr` if none).
+     */
     std::pair<device_type, std::exception_ptr> detach() noexcept
     {
         std::exception_ptr local_err;
@@ -283,6 +570,21 @@ public:
         return { std::move(dev), local_err ? local_err : inner_err };
     }
 
+    /**
+     * @lang{ZH}
+     * 调整转换器行为参数。
+     * 若 `acc` 为 `zlib_sync_flush` 实例，则更新 `m_sync_flush` 标志；
+     * 同时将 `acc` 转发给基类 `BT::adjust()`。
+     * @endif
+     *
+     * @lang{EN}
+     * Adjust converter behavior parameters.
+     * If `acc` is a `zlib_sync_flush` instance, updates the `m_sync_flush` flag;
+     * also forwards `acc` to the base-class `BT::adjust()`.
+     * @endif
+     *
+     * @param acc 行为策略对象。 / The behavior policy object.
+     */
     void adjust(const cvt_behavior& acc)
     {
         if (auto* ptr = dynamic_cast<const zlib_sync_flush*>(&acc); ptr)
@@ -291,6 +593,28 @@ public:
         return BT::adjust(acc);
     }
 
+    /**
+     * @lang{ZH}
+     * 查询是否已到达 zlib 压缩流末尾。
+     * `m_stream_ended` 是 zlib 级别的 EOF 锁存位，在 `get_main` 中 `inflate()` 返回
+     * `Z_STREAM_END` 时置位。`BT::is_eof()` 反映内核的可读字节数视图，可能滞后于
+     * zlib 流结束（zlib 的尾部/校验字段可能仍驻留在内核缓冲区中）。
+     * 两个条件任一为真均代表调用方视角的真实流结束，因此取逻辑或。
+     * @endif
+     *
+     * @lang{EN}
+     * Query whether the end of the zlib compressed stream has been reached.
+     * `m_stream_ended` is the zlib-level EOF latch, set by `get_main` when `inflate()`
+     * reports `Z_STREAM_END`. `BT::is_eof()` reflects the kernel's bytes-available
+     * view, which can lag behind the zlib stream end (zlib's trailer/checksum may still
+     * reside in the kernel buffer after the decompressed payload is exhausted).
+     * Either condition represents a true end-of-stream from the caller's perspective,
+     * so they are OR'd together.
+     * @endif
+     *
+     * @return 若已到达流末尾（zlib 流已结束或内核无更多数据），返回 `true`。
+     *         / `true` if the end of the stream has been reached (zlib stream ended or kernel has no more data).
+     */
     bool is_eof()
         requires (cvt_cpt::support_get<KernelType>)
     {
@@ -303,6 +627,30 @@ public:
         return m_stream_ended || BT::is_eof();
     }
 
+    /**
+     * @lang{ZH}
+     * 标记 BOS 阶段结束，进入主内容阶段。
+     * 先调用基类 `BT::main_cont_beg()`，然后：
+     * - 若当前为输出模式，调用 `BT::flush()` 将已在 BOS 阶段写入内核缓冲区的
+     *   zlib 流头刷出到底层设备。此时 `m_strm` 必须为有效的 zlib 流（由 `bos()`
+     *   的不变量保证）。
+     * - 若当前为 `neutral` 模式，说明 `bos()` 未被调用，抛出异常。
+     * @endif
+     *
+     * @lang{EN}
+     * Mark the end of the BOS phase and enter the main-content phase.
+     * Calls the base-class `BT::main_cont_beg()` first, then:
+     * - If currently in output mode, calls `BT::flush()` to flush the zlib stream
+     *   header (written into the kernel buffer during the BOS phase) to the underlying
+     *   device. At this point `m_strm` is guaranteed to be a valid zlib stream by the
+     *   `bos()` invariant.
+     * - If currently in `neutral` mode, `bos()` has not been called and an exception
+     *   is thrown.
+     * @endif
+     *
+     * @throws cvt_error 若 `bos()` 尚未被调用（IO 状态为 `neutral`）。
+     *                   / If `bos()` has not yet been called (IO status is `neutral`).
+     */
     void main_cont_beg()
     {
         BT::main_cont_beg();
@@ -321,6 +669,44 @@ public:
             throw cvt_error("zlib_cvt::main_cont_beg fail: bos() has not been called before main_cont_beg");
     }
 
+    /**
+     * @lang{ZH}
+     * 启动 zlib 流，初始化 inflate 或 deflate 状态，并处理 2 字节 zlib 流头。
+     *
+     * 调用基类 `BT::bos()` 确定 IO 方向后：
+     * - **输出（压缩）模式**：调用 `deflateInit`，以 `Z_NO_FLUSH` 和零输入触发
+     *   deflate 输出 2 字节流头，验证恰好输出 2 字节且无残余待发字节，
+     *   然后通过内核写出该头部。
+     * - **输入（解压）模式**：调用 `inflateInit`，从内核读取 2 字节流头，
+     *   送入 `inflate` 验证头部格式；不支持预置字典（`Z_NEED_DICT`），遇到时抛出。
+     *
+     * 若任何步骤失败，`m_strm` 已被守卫（`inflate_guard`/`deflate_guard`）或手动
+     * 重置为 `nullptr`，然后将 IO 状态重置为 `neutral` 并标记 tainted 后重新抛出。
+     * @endif
+     *
+     * @lang{EN}
+     * Start the zlib stream by initializing inflate or deflate state and processing
+     * the 2-byte zlib stream header.
+     *
+     * After calling the base-class `BT::bos()` to determine IO direction:
+     * - **Output (compression) mode**: calls `deflateInit`, triggers deflate with
+     *   `Z_NO_FLUSH` and zero input to emit the 2-byte stream header, verifies
+     *   exactly 2 bytes were emitted with no pending bytes remaining, then writes
+     *   the header through the kernel.
+     * - **Input (decompression) mode**: calls `inflateInit`, reads the 2-byte stream
+     *   header from the kernel, and feeds it to `inflate` for header validation.
+     *   Preset dictionaries (`Z_NEED_DICT`) are not supported and cause a throw.
+     *
+     * If any step fails, `m_strm` has already been reset to `nullptr` by the guards
+     * (`inflate_guard`/`deflate_guard`) or manually; the IO status is then reset to
+     * `neutral` and the converter is marked tainted before rethrowing.
+     * @endif
+     *
+     * @return 确定的初始 IO 方向。 / The determined initial IO direction.
+     * @throws cvt_error 若 zlib 初始化失败、流头格式非法或内核不支持所需的读写方向。
+     *                   / If zlib initialization fails, the stream header is invalid, or
+     *                   the kernel does not support the required read/write direction.
+     */
     io_status bos()
     {
         BT::bos();
@@ -450,6 +836,35 @@ public:
 
 // optional methods
 private:
+    /**
+     * @lang{ZH}
+     * 主内容阶段的解压实现（由 `abs_cvt::get` 调用）。
+     * 调用 `inflate(Z_NO_FLUSH)` 将内核提供的压缩数据解压至 `to` 缓冲区。
+     * 若 `m_stream_ended` 已置位（inflate 曾报告 `Z_STREAM_END`），直接返回 0，
+     * 不再向已结束的 z_stream 送入更多数据。
+     * 每次从内核一次读取一字节（有意为之：解压膨胀比不可预测，批量读取可能溢出输出缓冲区；
+     * 内核已有缓冲，单字节读取不会产生额外系统调用）。
+     * @endif
+     *
+     * @lang{EN}
+     * Main-content-phase decompression implementation (called by `abs_cvt::get`).
+     * Calls `inflate(Z_NO_FLUSH)` to decompress data provided by the kernel into the
+     * `to` buffer.
+     * If `m_stream_ended` is already set (inflate previously reported `Z_STREAM_END`),
+     * returns 0 immediately without feeding more data into the finished z_stream.
+     * Reads one byte at a time from the kernel (intentional: the decompression expansion
+     * ratio is unpredictable and bulk reads could overflow the output buffer; the kernel
+     * already buffers, so single-byte reads do not incur extra syscalls).
+     * @endif
+     *
+     * @param reader 封装内核读取的缓冲读取辅助对象。 / Buffered read helper wrapping the kernel.
+     * @param to     解压结果的输出缓冲区。 / Output buffer for the decompressed data.
+     * @param to_max 期望解压的最大元素数量。 / Maximum number of elements to decompress.
+     * @return 实际解压的元素数量。 / Actual number of elements decompressed.
+     * @throws cvt_error 若压缩流被截断，或 zlib 报告致命错误，或输出字节数不是 sizeof(internal_type) 的整数倍。
+     *                   / If the compressed stream is truncated, zlib reports a fatal error,
+     *                   or the output byte count is not a multiple of sizeof(internal_type).
+     */
     size_t get_main(cvt_reader<KernelType>& reader, internal_type* to, size_t to_max)
         requires (cvt_cpt::support_get<KernelType>)
     {
@@ -531,6 +946,32 @@ private:
         return res / sizeof(internal_type);
     }
 
+    /**
+     * @lang{ZH}
+     * 主内容阶段的压缩实现（由 `abs_cvt::put` 调用）。
+     * 调用 `deflate(Z_NO_FLUSH)` 将 `_to` 中的数据压缩后写入内核（通过 `cvt_writer`）。
+     * 按 `CHUNK` 大小申请输出缓冲区槽，若压缩未用完整个槽，调用 `writer.rollback`
+     * 回退未使用的部分，防止未初始化数据被提交到内核。
+     * 发生异常时同样回退未使用的槽位，确保内核缓冲区末尾始终指向最后一个有效压缩字节。
+     * @endif
+     *
+     * @lang{EN}
+     * Main-content-phase compression implementation (called by `abs_cvt::put`).
+     * Calls `deflate(Z_NO_FLUSH)` to compress data from `_to` and writes it into the
+     * kernel through `cvt_writer`.
+     * Allocates output buffer slots in `CHUNK`-sized chunks; if deflate does not fill
+     * an entire slot, calls `writer.rollback` to release the unused portion, preventing
+     * uninitialized data from being committed to the kernel.
+     * On exception, also rolls back any unused slot to ensure the kernel buffer tail
+     * always points to the last valid compressed byte.
+     * @endif
+     *
+     * @param writer  封装内核写入的缓冲写入辅助对象。 / Buffered write helper wrapping the kernel.
+     * @param _to     待压缩的源数据缓冲区。 / Source data buffer to compress.
+     * @param to_size 待压缩的元素数量。 / Number of elements to compress.
+     * @throws cvt_error 若 zlib 报告致命错误或 zlib 未取得进展。
+     *                   / If zlib reports a fatal error or zlib makes no progress.
+     */
     void put_main(cvt_writer<KernelType>& writer, const internal_type* _to, size_t to_size)
         requires (cvt_cpt::support_put<KernelType>)
     {
@@ -608,14 +1049,27 @@ private:
         // m_strm in/out fields are cleared by io_buf_guard on scope exit.
     }
 
-    // flush() entry from abs_cvt.  Honours the m_sync_flush toggle:
-    //   - sync_flush == true  -> emit Z_SYNC_FLUSH so the downstream
-    //     decompressor can resume from a well-defined boundary.
-    //   - sync_flush == false -> no-op for zlib's internal LZ77 state.
-    //     Bytes already deflate()'d on previous put() calls remain in the
-    //     downstream kernel buffer chain and reach the device through
-    //     subsequent put / close_stream paths; no user data is lost.
-    // See the comment on zlib_sync_flush for why this is opt-in.
+    /**
+     * @lang{ZH}
+     * 由 `abs_cvt::flush()` 调用的 zlib 层刷出逻辑。
+     * 依据 `m_sync_flush` 标志决定行为：
+     * - `m_sync_flush == true`：向下游发出 `Z_SYNC_FLUSH` 边界，使接收方能够在
+     *   明确边界处开始解压。
+     * - `m_sync_flush == false`：空操作；zlib 内部待发字节仍保留在缓冲区中，
+     *   等到 `close_stream` 或后续 `put` 时才写出。
+     * 关于此选项的成本权衡，参见 `zlib_sync_flush` 的说明。
+     * @endif
+     *
+     * @lang{EN}
+     * zlib-layer flush logic called by `abs_cvt::flush()`.
+     * Behavior is determined by the `m_sync_flush` flag:
+     * - `m_sync_flush == true`: emits a `Z_SYNC_FLUSH` boundary downstream so that
+     *   the receiver can begin decompression at a well-defined point.
+     * - `m_sync_flush == false`: no-op; zlib's internal pending bytes remain buffered
+     *   until `close_stream` or a subsequent `put` writes them out.
+     * For the cost trade-off of this option, see the `zlib_sync_flush` documentation.
+     * @endif
+     */
     void do_flush()
         requires (cvt_cpt::support_put<KernelType>)
     {
@@ -640,6 +1094,31 @@ private:
         }
     }
 
+    /**
+     * @lang{ZH}
+     * 将 zlib 返回码转换为 `cvt_error` 异常。
+     * 仅对非负返回码（`Z_OK`、`Z_STREAM_END` 等）不抛出。
+     * 模板参数 `IgnoreBufError` 控制 `Z_BUF_ERROR` 的处理：
+     * - `false`（默认）：`Z_BUF_ERROR` 作为错误抛出；
+     * - `true`：`Z_BUF_ERROR` 被静默忽略（用于 `get_main` 中，`Z_BUF_ERROR` 表示
+     *   "当前无可用输入"，这是正常情况而非错误）。
+     * @endif
+     *
+     * @lang{EN}
+     * Translate a zlib return code into a `cvt_error` exception.
+     * Non-negative return codes (`Z_OK`, `Z_STREAM_END`, etc.) do not throw.
+     * The template parameter `IgnoreBufError` controls handling of `Z_BUF_ERROR`:
+     * - `false` (default): `Z_BUF_ERROR` is treated as an error and throws;
+     * - `true`: `Z_BUF_ERROR` is silently ignored (used in `get_main` where
+     *   `Z_BUF_ERROR` means "no input available right now", which is normal).
+     * @endif
+     *
+     * @tparam IgnoreBufError 若为 `true`，`Z_BUF_ERROR` 不抛出异常。 / If `true`, `Z_BUF_ERROR` does not throw.
+     * @param info 异常消息的前缀，用于标识调用位置。 / Prefix for the exception message, identifying the call site.
+     * @param ret  zlib 函数返回的状态码。 / The status code returned by a zlib function.
+     * @throws cvt_error 若 `ret` 为负值（`IgnoreBufError` 控制 `Z_BUF_ERROR` 的处理）。
+     *                   / If `ret` is negative (with `IgnoreBufError` controlling `Z_BUF_ERROR`).
+     */
     template <bool IgnoreBufError = false>
     void zerr(const char* info, int ret)
     {
@@ -670,6 +1149,37 @@ private:
         }
     }
 
+    /**
+     * @lang{ZH}
+     * 最终化并关闭当前 zlib 流。
+     * `state_guard` 在作用域退出时无条件将 `m_is_bos_done`、`m_io_status`、
+     * `m_sync_flush`、`m_stream_ended` 重置为初始值。
+     * - 若 `m_strm` 为空（`bos()` 从未被调用，或已被守卫/手动重置），直接返回。
+     * - **输出模式**（且 BOS 已完成）：循环调用 `deflate(Z_FINISH)` 直到 `Z_STREAM_END`，
+     *   将所有剩余压缩字节写入内核；`deflate_guard` 在作用域退出时调用 `deflateEnd`
+     *   并重置 `m_strm`。
+     * - **输入模式**：先调用 `inflateEnd`（并重置 `m_strm`），再检查返回值——
+     *   确保即使 `inflateEnd` 返回 `Z_STREAM_ERROR`，`m_strm` 已置空，
+     *   防止后续调用重复 `inflateEnd` 已释放的状态。
+     * @endif
+     *
+     * @lang{EN}
+     * Finalize and close the current zlib stream.
+     * A `state_guard` unconditionally resets `m_is_bos_done`, `m_io_status`,
+     * `m_sync_flush`, and `m_stream_ended` to their initial values on scope exit.
+     * - If `m_strm` is null (`bos()` was never called, or it was reset by guards/manually),
+     *   returns immediately.
+     * - **Output mode** (and BOS completed): loops `deflate(Z_FINISH)` until `Z_STREAM_END`,
+     *   writing all remaining compressed bytes to the kernel; `deflate_guard` calls
+     *   `deflateEnd` and resets `m_strm` on scope exit.
+     * - **Input mode**: calls `inflateEnd` first (resetting `m_strm`), then checks the
+     *   return code — ensures that even if `inflateEnd` returns `Z_STREAM_ERROR`,
+     *   `m_strm` is already null, preventing a subsequent call from calling `inflateEnd`
+     *   again on already-freed state.
+     * @endif
+     *
+     * @throws cvt_error 若 deflate/inflate 最终化失败。 / If deflate/inflate finalization fails.
+     */
     void close_stream()
     {
         struct state_guard
@@ -734,37 +1244,106 @@ private:
         }
     }
 private:
-    unsigned    m_put_level;
-    // false (default) -> flush() is a no-op for zlib's internal pending bytes;
-    // true            -> flush() emits Z_SYNC_FLUSH boundary.
-    // Toggled via adjust(zlib_sync_flush{...}).  See zlib_sync_flush doc for
-    // the cost trade-off behind the default.
-    bool        m_sync_flush{false};
-    // Set to true inside get_main when inflate() returns Z_STREAM_END.  Any
-    // subsequent get_main entry short-circuits to 0 instead of feeding more
-    // compressed bytes into a finished stream (which would otherwise produce
-    // Z_DATA_ERROR or be misinterpreted as a new concatenated zlib stream).
-    // Reset by close_stream's state_guard and by copy/move/assignment paths
-    // that install a fresh stream.
-    bool        m_stream_ended{false};
+    unsigned m_put_level; ///< @lang{ZH} deflate 压缩等级（0–9），在构造时截断至 9。 @endif @lang{EN} deflate compression level (0–9), clamped to 9 at construction. @endif
 
+    /**
+     * @lang{ZH}
+     * `flush()` 的同步刷模式标志。
+     * `false`（默认）：`flush()` 是 zlib 内部待发字节的空操作；
+     * `true`：`flush()` 发出 `Z_SYNC_FLUSH` 边界。
+     * 通过 `adjust(zlib_sync_flush{...})` 切换。详见 `zlib_sync_flush` 的成本权衡说明。
+     * @endif
+     *
+     * @lang{EN}
+     * Sync-flush mode flag for `flush()`.
+     * `false` (default): `flush()` is a no-op for zlib's internal pending bytes;
+     * `true`: `flush()` emits a `Z_SYNC_FLUSH` boundary.
+     * Toggled via `adjust(zlib_sync_flush{...})`. See `zlib_sync_flush` for the
+     * cost trade-off rationale.
+     * @endif
+     */
+    bool m_sync_flush{false};
+
+    /**
+     * @lang{ZH}
+     * 流结束锁存位。在 `get_main` 中 `inflate()` 返回 `Z_STREAM_END` 时置 `true`。
+     * 后续 `get_main` 调用直接返回 0，不再向已结束的流送入压缩数据
+     * （否则会产生 `Z_DATA_ERROR` 或被误解为新的拼接 zlib 流）。
+     * 由 `close_stream` 的 `state_guard` 及拷贝/移动/赋值路径安装新流时重置。
+     * @endif
+     *
+     * @lang{EN}
+     * End-of-stream latch. Set to `true` inside `get_main` when `inflate()` returns
+     * `Z_STREAM_END`. Subsequent `get_main` calls short-circuit to 0 instead of
+     * feeding more compressed bytes into the finished stream (which would otherwise
+     * produce `Z_DATA_ERROR` or be misinterpreted as a new concatenated zlib stream).
+     * Reset by `close_stream`'s `state_guard` and by copy/move/assignment paths
+     * that install a fresh stream.
+     * @endif
+     */
+    bool m_stream_ended{false};
+
+    /// @lang{ZH} 当前活跃的 zlib 流对象；在 `bos()` 中初始化，在 `close_stream()` 中释放。 @endif
+    /// @lang{EN} The currently active zlib stream object; initialized in `bos()` and released in `close_stream()`. @endif
     std::unique_ptr<z_stream> m_strm;
 };
 
+/**
+ * @lang{ZH}
+ * `zlib_cvt` 的工厂类，用于在管道中构造压缩/解压转换器。
+ * 持有压缩等级，通过 `create(kernel)` 将任意内核包装为 `zlib_cvt` 实例。
+ * 通常通过 `operator|` 与其他工厂组合使用。
+ * @endif
+ *
+ * @lang{EN}
+ * Factory class for `zlib_cvt`, used to construct compression/decompression converters
+ * in a pipeline. Stores the compression level and wraps any compatible kernel into a
+ * `zlib_cvt` instance via `create(kernel)`.
+ * Typically composed with other factories via `operator|`.
+ * @endif
+ *
+ * @tparam TInt 目标转换器的内部数据类型。 / The internal data type of the target converter.
+ */
 template <typename TInt>
 class zlib_cvt_creator
 {
 public:
     using category = CvtCreatorCategory;
+
+    /**
+     * @lang{ZH}
+     * 以指定压缩等级构造工厂。
+     * @endif
+     *
+     * @lang{EN}
+     * Construct the factory with the specified compression level.
+     * @endif
+     *
+     * @param level deflate 压缩等级（0–9）。 / deflate compression level (0–9).
+     */
     explicit zlib_cvt_creator(unsigned level)
         : m_level(level) {}
 
+    /**
+     * @lang{ZH}
+     * 将内核包装为 `zlib_cvt` 实例。
+     * @endif
+     *
+     * @lang{EN}
+     * Wrap a kernel into a `zlib_cvt` instance.
+     * @endif
+     *
+     * @tparam TKernel 满足 `io_converter` 的内核类型。 / The kernel type satisfying `io_converter`.
+     * @param kernel  待包装的内核（完美转发）。 / The kernel to wrap (perfect-forwarded).
+     * @return 以 `kernel` 和存储的压缩等级构造的 `zlib_cvt` 实例。
+     *         / A `zlib_cvt` instance constructed from `kernel` and the stored compression level.
+     */
     template <io_converter TKernel>
     auto create(TKernel&& kernel) const
     {
         return zlib_cvt<std::remove_cvref_t<TKernel>, TInt>{std::forward<TKernel>(kernel), m_level};
     }
 private:
-    unsigned m_level;
+    unsigned m_level; ///< @lang{ZH} 传递给 `deflateInit` 的压缩等级。 @endif @lang{EN} Compression level passed to `deflateInit`. @endif
 };
 }

--- a/include/cvt/cvt_pipe_creator.h
+++ b/include/cvt/cvt_pipe_creator.h
@@ -1,3 +1,18 @@
+/**
+ * @file cvt_pipe_creator.h
+ * @lang{ZH}
+ * 管道式转换器工厂（Pipe Creator）定义文件。
+ * 本文件提供了将多个转换器工厂链式组合为单一管道工厂的机制，
+ * 以及通过 `operator|` 构造管道工厂时所需的辅助类型工具。
+ * @endif
+ *
+ * @lang{EN}
+ * Pipe-style converter creator definition file.
+ * This file provides the mechanism for chaining multiple converter creators
+ * into a single pipeline creator, along with the auxiliary type utilities
+ * needed to construct pipeline creators via `operator|`.
+ * @endif
+ */
 #pragma once
 
 #include <cvt/cvt_concepts.h>
@@ -10,27 +25,111 @@
 
 namespace IOv2
 {
+/**
+ * @lang{ZH}
+ * 管道式转换器工厂模板的前置声明。
+ * 通过 `operator|` 将多个 `cvt_creator` 类型串联，可得到此类型的实例。
+ * @endif
+ *
+ * @lang{EN}
+ * Forward declaration of the pipe-style converter creator template.
+ * Instances of this type are obtained by chaining multiple `cvt_creator`
+ * types together via `operator|`.
+ * @endif
+ *
+ * @tparam T 组成管道的各转换器工厂类型。
+ *           / The converter creator types that form the pipeline.
+ */
 template <typename... T>
 class cvt_pipe_creator;
 
+/**
+ * @lang{ZH}
+ * `cpt_cvt_pipe_creator` 概念的辅助特征模板（主模板）。
+ * 对于非 `cvt_pipe_creator` 特化的类型，`value` 为 `false`。
+ * @endif
+ *
+ * @lang{EN}
+ * Helper trait template (primary template) for the `cpt_cvt_pipe_creator` concept.
+ * For types that are not specializations of `cvt_pipe_creator`, `value` is `false`.
+ * @endif
+ *
+ * @tparam T 待检测的类型。 / The type to be inspected.
+ */
 template<typename T>
 struct cpt_cvt_pipe_creator_helper
 {
     constexpr static bool value = false;
 };
 
+/**
+ * @lang{ZH}
+ * `cpt_cvt_pipe_creator` 概念的辅助特征模板（`cvt_pipe_creator` 特化）。
+ * 对于 `cvt_pipe_creator<T...>` 特化，`value` 为 `true`。
+ * @endif
+ *
+ * @lang{EN}
+ * Helper trait template specialization for `cvt_pipe_creator<T...>`.
+ * For specializations of `cvt_pipe_creator`, `value` is `true`.
+ * @endif
+ *
+ * @tparam T 组成管道的各转换器工厂类型。
+ *           / The converter creator types that form the pipeline.
+ */
 template<typename... T>
 struct cpt_cvt_pipe_creator_helper<cvt_pipe_creator<T...>>
 {
     constexpr static bool value = true;
 };
 
+/**
+ * @lang{ZH}
+ * 检测类型 T 是否为 `cvt_pipe_creator` 特化实例的概念。
+ * @endif
+ *
+ * @lang{EN}
+ * Concept that detects whether type T is a specialization of `cvt_pipe_creator`.
+ * @endif
+ *
+ * @tparam T 待检测的类型。 / The type to be checked.
+ */
 template<typename T>
 concept cpt_cvt_pipe_creator = cpt_cvt_pipe_creator_helper<T>::value;
 
+/**
+ * @lang{ZH}
+ * 根据两个转换器工厂类型推导合并后管道类型的类型生成器（主模板，故意未定义）。
+ * 此主模板无定义，仅通过各特化提供 `type` 成员；
+ * 若两个操作数的组合不满足任何特化的约束，将产生编译错误。
+ * @endif
+ *
+ * @lang{EN}
+ * Type generator that deduces the resulting pipeline type from two converter creator types
+ * (primary template, intentionally left undefined).
+ * This primary template provides no definition; only specializations expose the `type` member.
+ * A combination of operands that satisfies no specialization results in a compile error.
+ * @endif
+ *
+ * @tparam T1 左操作数的转换器工厂类型。 / Left-hand converter creator type.
+ * @tparam T2 右操作数的转换器工厂类型。 / Right-hand converter creator type.
+ */
 template <typename T1, typename T2>
 struct cvt_creator_type_gen;
 
+/**
+ * @lang{ZH}
+ * `cvt_creator_type_gen` 特化：两个非管道的 `cvt_creator` 类型合并，
+ * 生成 `cvt_pipe_creator<T1, T2>`。
+ * @endif
+ *
+ * @lang{EN}
+ * `cvt_creator_type_gen` specialization: two non-pipe `cvt_creator` types are combined,
+ * yielding `cvt_pipe_creator<T1, T2>`.
+ * @endif
+ *
+ * @tparam T1 左侧非管道转换器工厂类型。 / Left-hand non-pipe converter creator type.
+ * @tparam T2 右侧非管道转换器工厂类型。 / Right-hand non-pipe converter creator type.
+ */
 template <typename T1, typename T2>
     requires (std::is_same_v<typename T1::category, CvtCreatorCategory> &&
               std::is_same_v<typename T2::category, CvtCreatorCategory> &&
@@ -40,6 +139,21 @@ struct cvt_creator_type_gen<T1, T2>
     using type = cvt_pipe_creator<T1, T2>;
 };
 
+/**
+ * @lang{ZH}
+ * `cvt_creator_type_gen` 特化：非管道工厂 T1 前置于管道工厂 `cvt_pipe_creator<T2...>` 之前，
+ * 生成 `cvt_pipe_creator<T1, T2...>`。
+ * @endif
+ *
+ * @lang{EN}
+ * `cvt_creator_type_gen` specialization: a non-pipe creator T1 is prepended to an existing
+ * pipeline `cvt_pipe_creator<T2...>`, yielding `cvt_pipe_creator<T1, T2...>`.
+ * @endif
+ *
+ * @tparam T1 左侧非管道转换器工厂类型。 / Left-hand non-pipe converter creator type.
+ * @tparam T2 右侧管道工厂所含的各转换器工厂类型。
+ *           / The converter creator types contained in the right-hand pipeline.
+ */
 template <typename T1, typename... T2>
     requires (std::is_same_v<typename T1::category, CvtCreatorCategory> &&
               !cpt_cvt_pipe_creator<T1>)
@@ -48,6 +162,21 @@ struct cvt_creator_type_gen<T1, cvt_pipe_creator<T2...>>
     using type = cvt_pipe_creator<T1, T2...>;
 };
 
+/**
+ * @lang{ZH}
+ * `cvt_creator_type_gen` 特化：非管道工厂 T2 追加于管道工厂 `cvt_pipe_creator<T1...>` 之后，
+ * 生成 `cvt_pipe_creator<T1..., T2>`。
+ * @endif
+ *
+ * @lang{EN}
+ * `cvt_creator_type_gen` specialization: a non-pipe creator T2 is appended to an existing
+ * pipeline `cvt_pipe_creator<T1...>`, yielding `cvt_pipe_creator<T1..., T2>`.
+ * @endif
+ *
+ * @tparam T1 左侧管道工厂所含的各转换器工厂类型。
+ *           / The converter creator types contained in the left-hand pipeline.
+ * @tparam T2 右侧非管道转换器工厂类型。 / Right-hand non-pipe converter creator type.
+ */
 template <typename... T1, typename T2>
     requires (std::is_same_v<typename T2::category, CvtCreatorCategory> &&
               !cpt_cvt_pipe_creator<T2>)
@@ -56,12 +185,45 @@ struct cvt_creator_type_gen<cvt_pipe_creator<T1...>, T2>
     using type = cvt_pipe_creator<T1..., T2>;
 };
 
+/**
+ * @lang{ZH}
+ * `cvt_creator_type_gen` 特化：两个管道工厂合并，将各自内部的工厂列表依序拼接，
+ * 生成 `cvt_pipe_creator<T1..., T2...>`。
+ * @endif
+ *
+ * @lang{EN}
+ * `cvt_creator_type_gen` specialization: two pipeline creators are merged by concatenating
+ * their internal creator lists in order, yielding `cvt_pipe_creator<T1..., T2...>`.
+ * @endif
+ *
+ * @tparam T1 左侧管道工厂所含的各转换器工厂类型。
+ *           / The converter creator types in the left-hand pipeline.
+ * @tparam T2 右侧管道工厂所含的各转换器工厂类型。
+ *           / The converter creator types in the right-hand pipeline.
+ */
 template <typename... T1, typename... T2>
 struct cvt_creator_type_gen<cvt_pipe_creator<T1...>, cvt_pipe_creator<T2...>>
 {
     using type = cvt_pipe_creator<T1..., T2...>;
 };
 
+/**
+ * @lang{ZH}
+ * 由两个转换器工厂组成的管道工厂（二元特化）。
+ * 调用 `create(kernel)` 时，先以 T1 包装 `kernel`，再以 T2 包装上一步的结果，
+ * 形成双层转换链路。向最终转换器写入数据时，数据依次流经 T2 和 T1 的处理，最终到达 `kernel`。
+ * @endif
+ *
+ * @lang{EN}
+ * Two-element pipeline creator (binary specialization).
+ * When `create(kernel)` is called, it first wraps `kernel` with T1, then wraps the result
+ * with T2, producing a two-layer conversion chain. When data is written into the resulting
+ * converter, it passes through T2, then T1, and finally reaches `kernel`.
+ * @endif
+ *
+ * @tparam T1 第一个（内层）转换器工厂类型。 / The first (inner) converter creator type.
+ * @tparam T2 第二个（外层）转换器工厂类型。 / The second (outer) converter creator type.
+ */
 template <typename T1, typename T2>
 class cvt_pipe_creator<T1, T2>
 {
@@ -71,9 +233,36 @@ class cvt_pipe_creator<T1, T2>
 public:
     using category = CvtCreatorCategory;
 
+    /**
+     * @lang{ZH}
+     * 构造二元管道工厂，保存两个工厂实例的副本。
+     * @endif
+     *
+     * @lang{EN}
+     * Constructs a binary pipeline creator, storing copies of both creator instances.
+     * @endif
+     *
+     * @param c1 第一个（内层）转换器工厂。 / The first (inner) converter creator.
+     * @param c2 第二个（外层）转换器工厂。 / The second (outer) converter creator.
+     */
     cvt_pipe_creator(const T1& c1, const T2& c2)
         : m_creators(c1, c2) {}
 
+    /**
+     * @lang{ZH}
+     * 以此管道工厂创建转换器，将 `kernel` 依次包装进 T1 和 T2 中。
+     * @endif
+     *
+     * @lang{EN}
+     * Creates a converter using this pipeline creator by successively wrapping
+     * `kernel` inside T1 and then inside T2.
+     * @endif
+     *
+     * @tparam TKernel 满足 `io_converter` 的内核转换器类型。
+     *                / The kernel converter type satisfying `io_converter`.
+     * @param kernel  最内层的转换器内核。 / The innermost converter kernel.
+     * @return 经过两层包装后的转换器。 / The converter after two layers of wrapping.
+     */
     template <io_converter TKernel>
     auto create(TKernel&& kernel) const
     {
@@ -84,6 +273,27 @@ private:
     std::tuple<T1, T2> m_creators;
 };
 
+/**
+ * @lang{ZH}
+ * 由三个或更多转换器工厂组成的管道工厂（多元特化）。
+ * 内部将所有工厂展平存储于单一 `std::tuple` 中。
+ * 调用 `create(kernel)` 时，按索引从小到大依次将 `kernel` 包装进每个工厂，
+ * 最终得到多层嵌套的转换器：最外层为最后一个工厂（索引最大），
+ * 最内层（直接包裹 `kernel`）为第一个工厂（索引 0）。
+ * @endif
+ *
+ * @lang{EN}
+ * Multi-element pipeline creator (variadic specialization, requires more than two elements).
+ * Internally, all creators are stored flattened in a single `std::tuple`.
+ * When `create(kernel)` is called, it wraps `kernel` with each creator in index order,
+ * yielding a multi-layer nested converter. The outermost layer corresponds to the last
+ * creator (highest index), and the innermost layer (directly wrapping `kernel`) corresponds
+ * to the first creator (index 0).
+ * @endif
+ *
+ * @tparam T 组成管道的各转换器工厂类型（至少三个）。
+ *           / The converter creator types forming the pipeline (at least three).
+ */
 template <typename... T>
     requires (sizeof...(T) > 2)
 class cvt_pipe_creator<T...>
@@ -94,20 +304,85 @@ class cvt_pipe_creator<T...>
 public:
     using category = CvtCreatorCategory;
 
+    /**
+     * @lang{ZH}
+     * 从两个管道工厂合并构造，将两者内部的工厂列表拼接为一个扁平列表。
+     * @endif
+     *
+     * @lang{EN}
+     * Constructs by merging two pipeline creators, concatenating their internal
+     * creator lists into a single flat list.
+     * @endif
+     *
+     * @tparam T1 左侧管道工厂类型（须满足 `cpt_cvt_pipe_creator`）。
+     *           / Left-hand pipeline creator type (must satisfy `cpt_cvt_pipe_creator`).
+     * @tparam T2 右侧管道工厂类型（须满足 `cpt_cvt_pipe_creator`）。
+     *           / Right-hand pipeline creator type (must satisfy `cpt_cvt_pipe_creator`).
+     * @param t1 左侧管道工厂实例。 / Left-hand pipeline creator instance.
+     * @param t2 右侧管道工厂实例。 / Right-hand pipeline creator instance.
+     */
     template <cpt_cvt_pipe_creator T1, cpt_cvt_pipe_creator T2>
     cvt_pipe_creator(const T1& t1, const T2& t2)
         : m_creators(std::tuple_cat(t1.m_creators, t2.m_creators)) {}
 
+    /**
+     * @lang{ZH}
+     * 从单个非管道工厂与一个管道工厂合并构造，将非管道工厂前置于管道工厂的工厂列表之前。
+     * @endif
+     *
+     * @lang{EN}
+     * Constructs by prepending a single non-pipe creator to an existing pipeline creator's
+     * internal creator list.
+     * @endif
+     *
+     * @tparam TH 左侧非管道转换器工厂类型。 / Left-hand non-pipe converter creator type.
+     * @tparam TR 右侧管道工厂类型（须满足 `cpt_cvt_pipe_creator`）。
+     *           / Right-hand pipeline creator type (must satisfy `cpt_cvt_pipe_creator`).
+     * @param h  左侧非管道工厂实例。 / Left-hand non-pipe creator instance.
+     * @param hr 右侧管道工厂实例。 / Right-hand pipeline creator instance.
+     */
     template <typename TH, cpt_cvt_pipe_creator TR>
         requires (!cpt_cvt_pipe_creator<TH>)
     cvt_pipe_creator(const TH& h, const TR& hr)
         : m_creators(std::tuple_cat(std::make_tuple(h), hr.m_creators)) {}
 
+    /**
+     * @lang{ZH}
+     * 从一个管道工厂与单个非管道工厂合并构造，将非管道工厂追加于管道工厂的工厂列表之后。
+     * @endif
+     *
+     * @lang{EN}
+     * Constructs by appending a single non-pipe creator to an existing pipeline creator's
+     * internal creator list.
+     * @endif
+     *
+     * @tparam TR 左侧管道工厂类型（须满足 `cpt_cvt_pipe_creator`）。
+     *           / Left-hand pipeline creator type (must satisfy `cpt_cvt_pipe_creator`).
+     * @tparam TT 右侧非管道转换器工厂类型。 / Right-hand non-pipe converter creator type.
+     * @param tr 左侧管道工厂实例。 / Left-hand pipeline creator instance.
+     * @param t  右侧非管道工厂实例。 / Right-hand non-pipe creator instance.
+     */
     template <cpt_cvt_pipe_creator TR, typename TT>
         requires (!cpt_cvt_pipe_creator<TT>)
     cvt_pipe_creator(const TR& tr, const TT& t)
         : m_creators(std::tuple_cat(tr.m_creators, std::make_tuple(t))) {}
 
+    /**
+     * @lang{ZH}
+     * 以此管道工厂创建转换器，将 `kernel` 依次包装进所有工厂中。
+     * @endif
+     *
+     * @lang{EN}
+     * Creates a converter using this pipeline creator by successively wrapping
+     * `kernel` through all contained creators in index order.
+     * @endif
+     *
+     * @tparam TKernel 满足 `io_converter` 的内核转换器类型。
+     *                / The kernel converter type satisfying `io_converter`.
+     * @param kernel  最内层的转换器内核。 / The innermost converter kernel.
+     * @return 经过所有工厂逐层包装后的转换器。
+     *         / The converter after being wrapped by all creators layer by layer.
+     */
     template <io_converter TKernel>
     auto create(TKernel&& kernel) const
     {
@@ -115,6 +390,25 @@ public:
     }
 
 private:
+    /**
+     * @lang{ZH}
+     * 递归辅助函数，将 `kernel` 依次包装进索引 N 及之后的所有工厂中。
+     * 当 N 等于工厂总数时，直接返回 `kernel`，作为递归的终止条件。
+     * @endif
+     *
+     * @lang{EN}
+     * Recursive helper that wraps `kernel` through creators at index N and beyond.
+     * When N equals the total number of creators, the recursion terminates by
+     * returning `kernel` as-is.
+     * @endif
+     *
+     * @tparam N       当前处理的工厂索引。 / Index of the creator currently being applied.
+     * @tparam TKernel 当前内核类型。 / Type of the current kernel.
+     * @param kernel   当前内核（可能已被若干工厂包装）。
+     *                / The current kernel (possibly already wrapped by preceding creators).
+     * @return 经过索引 N 起的所有工厂包装后的转换器。
+     *         / The converter after applying all creators from index N onward.
+     */
     template <size_t N, typename TKernel>
     auto create_helper(TKernel&& kernel) const
     {
@@ -130,6 +424,31 @@ private:
     std::tuple<T...> m_creators;
 };
 
+/**
+ * @lang{ZH}
+ * 管道组合运算符，将两个 `cvt_creator` 类型组合为一个管道工厂。
+ * 若两个操作数均为非管道工厂，则生成 `cvt_pipe_creator<T1, T2>`；
+ * 若其中一个或两个已为 `cvt_pipe_creator`，则通过 `cvt_creator_type_gen`
+ * 将内部工厂列表展平拼接，避免嵌套管道，始终保持线性扁平结构。
+ * @endif
+ *
+ * @lang{EN}
+ * Pipeline composition operator that combines two `cvt_creator` types into a pipeline creator.
+ * If both operands are non-pipe creators, the result is `cvt_pipe_creator<T1, T2>`.
+ * If one or both operands are already `cvt_pipe_creator` instances, `cvt_creator_type_gen`
+ * flattens and concatenates their internal creator lists, preventing nested pipelines and
+ * always maintaining a flat, linear structure.
+ * @endif
+ *
+ * @tparam T1 左操作数类型，须满足 `cvt_creator` 且可拷贝构造。
+ *           / Left operand type, must satisfy `cvt_creator` and be copy-constructible.
+ * @tparam T2 右操作数类型，须满足 `cvt_creator` 且可拷贝构造。
+ *           / Right operand type, must satisfy `cvt_creator` and be copy-constructible.
+ * @param t1 左侧转换器工厂实例。 / Left-hand converter creator instance.
+ * @param t2 右侧转换器工厂实例。 / Right-hand converter creator instance.
+ * @return 由 T1 和 T2 组合而成的管道工厂。
+ *         / A pipeline creator composed of T1 and T2.
+ */
 template <typename T1, typename T2>
     requires (cvt_creator<T1> && cvt_creator<T2> &&
               std::copy_constructible<T1> && std::copy_constructible<T2>)

--- a/include/cvt/runtime_cvt.h
+++ b/include/cvt/runtime_cvt.h
@@ -1,3 +1,26 @@
+/**
+ * @file runtime_cvt.h
+ * @lang{ZH}
+ * 运行时类型擦除转换器定义文件。
+ * 本文件通过经典的虚函数类型擦除模式，将任意满足 `io_converter` 约束的转换器
+ * 包装为统一的 `runtime_cvt<TDevice, TInt>` 类型，使转换器可以在运行时多态地存储与操作。
+ * 主要包含以下三层结构：
+ * - `abs_runtime_cvt_imp`：定义类型擦除接口的抽象基类；
+ * - `runtime_cvt_imp`：持有具体转换器内核的实现类；
+ * - `runtime_cvt`：面向用户的类型擦除转换器包装类。
+ * @endif
+ *
+ * @lang{EN}
+ * Runtime type-erased converter definition file.
+ * This file wraps any converter satisfying the `io_converter` constraint into a uniform
+ * `runtime_cvt<TDevice, TInt>` type using the classic virtual-function type-erasure pattern,
+ * enabling converters to be stored and used polymorphically at runtime.
+ * The implementation consists of three layers:
+ * - `abs_runtime_cvt_imp`: abstract base class defining the type-erased interface;
+ * - `runtime_cvt_imp`: concrete implementation class holding a specific converter kernel;
+ * - `runtime_cvt`: user-facing type-erased converter wrapper.
+ * @endif
+ */
 #pragma once
 
 #include <common/defs.h>
@@ -13,12 +36,51 @@
 
 namespace IOv2
 {
+/**
+ * @lang{ZH}
+ * 内部实现细节命名空间。
+ * @endif
+ *
+ * @lang{EN}
+ * Namespace for internal implementation details.
+ * @endif
+ */
 namespace detail
 {
+/**
+ * @lang{ZH}
+ * 预构造的异常指针，用于在 `runtime_cvt` 持有空实例时抛出。
+ * 预先构造可避免在可能无法分配内存的场景中重复创建异常对象。
+ * @endif
+ *
+ * @lang{EN}
+ * Pre-constructed exception pointer thrown when a `runtime_cvt` holds a null implementation.
+ * Pre-constructing it avoids repeated allocation in contexts where memory may be unavailable.
+ * @endif
+ */
 inline const std::exception_ptr runtime_cvt_null_err =
     std::make_exception_ptr(cvt_error("runtime_cvt: null instance"));
 }
 
+/**
+ * @lang{ZH}
+ * 类型擦除转换器实现的抽象基类。
+ * 声明了转换器所需的完整虚函数接口，使 `runtime_cvt` 可通过基类指针操作任意具体转换器。
+ * 此类禁止拷贝赋值和移动，避免切片问题；多态拷贝应通过 `clone()` 完成。
+ * @endif
+ *
+ * @lang{EN}
+ * Abstract base class for the type-erased converter implementation.
+ * Declares the complete virtual interface required by a converter, allowing `runtime_cvt`
+ * to operate on any concrete converter through a base-class pointer.
+ * Copy assignment and move are disabled to prevent slicing; polymorphic copying is
+ * performed via `clone()`.
+ * @endif
+ *
+ * @tparam TDevice 底层设备类型，须满足 `io_device`。
+ *                / The underlying device type, must satisfy `io_device`.
+ * @tparam TInt    转换器内部数据类型。 / The converter's internal data type.
+ */
 template <io_device TDevice, typename TInt>
 class abs_runtime_cvt_imp
 {
@@ -36,29 +98,84 @@ public:
     virtual ~abs_runtime_cvt_imp() = default;
 
 public:
+    /**
+     * @lang{ZH}
+     * 多态拷贝：克隆当前实现对象，返回指向新实例的 `unique_ptr`。
+     * 若具体内核不支持拷贝构造，实现类应抛出 `cvt_error`。
+     * @endif
+     *
+     * @lang{EN}
+     * Polymorphic copy: clone the current implementation object and return a
+     * `unique_ptr` to the new instance.
+     * If the concrete kernel does not support copy construction, the implementation
+     * should throw `cvt_error`.
+     * @endif
+     *
+     * @return 指向新克隆实例的 `unique_ptr`。
+     *         / A `unique_ptr` to the newly cloned instance.
+     */
     virtual std::unique_ptr<abs_runtime_cvt_imp> clone() const & = 0;
 
+    /// @lang{ZH} 返回底层设备的引用。 @endif @lang{EN} Return a reference to the underlying device. @endif
     virtual device_type& device() = 0;
+    /// @lang{ZH} 分离底层设备，重置 I/O 状态为 `neutral`，不抛出异常。 @endif @lang{EN} Detach the underlying device and reset I/O status to `neutral`, without throwing. @endif
     virtual std::pair<device_type, std::exception_ptr> detach() noexcept = 0;
+    /// @lang{ZH} 将设备绑定到此转换器，同时重置 I/O 状态为 `neutral`。 @endif @lang{EN} Attach a device to this converter and reset I/O status to `neutral`. @endif
     virtual void attach(device_type&& dev = device_type{}) = 0;
+    /// @lang{ZH} 向转换器应用行为策略。 @endif @lang{EN} Apply a behavior policy to the converter. @endif
     virtual void adjust(const cvt_behavior& acc) = 0;
+    /// @lang{ZH} 提取转换器的内部状态。 @endif @lang{EN} Extract the converter's internal status. @endif
     virtual void retrieve(cvt_status& acc) const = 0;
+    /// @lang{ZH} 查询是否已到达数据末尾。 @endif @lang{EN} Query whether the end of data has been reached. @endif
     virtual bool is_eof() = 0;
 
+    /// @lang{ZH} 建立初始 I/O 状态，返回确定的方向。 @endif @lang{EN} Establish the initial I/O state and return the determined direction. @endif
     virtual io_status bos() = 0;
+    /// @lang{ZH} 通知转换器进入主内容阶段。 @endif @lang{EN} Notify the converter to transition into the main content phase. @endif
     virtual void main_cont_beg() = 0;
 
+    /// @lang{ZH} 从转换器读取至多 `to_max` 个元素，返回实际读取数量。 @endif @lang{EN} Read up to `to_max` elements from the converter; return the number actually read. @endif
     virtual size_t get(internal_type* to, size_t to_max) = 0;
+    /// @lang{ZH} 向转换器写入 `to_size` 个元素。 @endif @lang{EN} Write `to_size` elements into the converter. @endif
     virtual void put(const internal_type* to, size_t to_size) = 0;
+    /// @lang{ZH} 将所有缓冲数据刷出转换器。 @endif @lang{EN} Flush all buffered data out of the converter. @endif
     virtual void flush() = 0;
 
+    /// @lang{ZH} 返回当前流位置。 @endif @lang{EN} Return the current stream position. @endif
     [[nodiscard]] virtual size_t tell() const = 0;
+    /// @lang{ZH} 将流定位到指定绝对位置。 @endif @lang{EN} Seek the stream to the specified absolute position. @endif
     virtual void seek(size_t pos) = 0;
+    /// @lang{ZH} 将流定位到指定相对位置。 @endif @lang{EN} Seek the stream to the specified relative position. @endif
     virtual void rseek(size_t pos) = 0;
+    /// @lang{ZH} 切换至输入（读取）模式。 @endif @lang{EN} Switch to input (reading) mode. @endif
     virtual void switch_to_get() = 0;
+    /// @lang{ZH} 切换至输出（写入）模式。 @endif @lang{EN} Switch to output (writing) mode. @endif
     virtual void switch_to_put() = 0;
 };
 
+/**
+ * @lang{ZH}
+ * 持有具体转换器内核的类型擦除实现类。
+ * 继承自 `abs_runtime_cvt_imp`，通过转发调用将所有虚函数接口委托给内部的内核实例。
+ * 对于内核不支持的可选能力（读取、写入、定位、I/O 切换），在编译期通过 `if constexpr`
+ * 检测，若调用到不支持的接口则在运行时抛出 `cvt_error`。
+ * `switch_to_get` 和 `switch_to_put` 通过 `m_io_status` 追踪当前方向，实现幂等调用。
+ * @endif
+ *
+ * @lang{EN}
+ * Type-erased implementation class that holds a concrete converter kernel.
+ * Inherits from `abs_runtime_cvt_imp` and forwards all virtual interface calls to the
+ * internal kernel instance.
+ * Optional capabilities (read, write, positioning, I/O switch) that the kernel may not
+ * support are detected at compile time via `if constexpr`; calling an unsupported interface
+ * throws `cvt_error` at runtime.
+ * `switch_to_get` and `switch_to_put` track the current direction via `m_io_status`
+ * to make repeated calls idempotent.
+ * @endif
+ *
+ * @tparam KernelType 被包装的具体转换器内核类型，须满足 `io_converter`。
+ *                   / The concrete converter kernel type being wrapped, must satisfy `io_converter`.
+ */
 template <io_converter KernelType>
 class runtime_cvt_imp : public abs_runtime_cvt_imp<typename KernelType::device_type, typename KernelType::internal_type>
 {
@@ -69,15 +186,51 @@ public:
     using external_type = typename device_type::char_type;
 
 public:
+    /**
+     * @lang{ZH}
+     * 从内核的 const 引用拷贝构造，I/O 状态初始化为 `neutral`。
+     * @endif
+     *
+     * @lang{EN}
+     * Copy-constructs from a const kernel reference; I/O status is initialized to `neutral`.
+     * @endif
+     *
+     * @param kernel 待包装的转换器内核（拷贝）。 / The converter kernel to wrap (copied).
+     */
     runtime_cvt_imp(const KernelType& kernel)
         : m_kernel(kernel)
         , m_io_status(io_status::neutral) {}
 
+    /**
+     * @lang{ZH}
+     * 从内核的右值引用移动构造，I/O 状态初始化为 `neutral`。
+     * @endif
+     *
+     * @lang{EN}
+     * Move-constructs from a kernel rvalue reference; I/O status is initialized to `neutral`.
+     * @endif
+     *
+     * @param kernel 待包装的转换器内核（移动）。 / The converter kernel to wrap (moved).
+     */
     runtime_cvt_imp(KernelType&& kernel)
         : m_kernel(std::move(kernel))
         , m_io_status(io_status::neutral) {}
 
 public:
+    /**
+     * @lang{ZH}
+     * 多态拷贝实现。若内核类型支持拷贝构造则克隆当前实例，否则抛出 `cvt_error`。
+     * @endif
+     *
+     * @lang{EN}
+     * Polymorphic copy implementation. Clones the current instance if the kernel type
+     * supports copy construction; otherwise throws `cvt_error`.
+     * @endif
+     *
+     * @return 指向新克隆实例的 `unique_ptr`。
+     *         / A `unique_ptr` to the newly cloned instance.
+     * @throws cvt_error 若内核不支持拷贝构造。 / If the kernel does not support copy construction.
+     */
     std::unique_ptr<BT> clone() const & override
     {
         if constexpr (std::copy_constructible<KernelType>)
@@ -114,6 +267,15 @@ public:
         return m_kernel.retrieve(acc);
     }
 
+    /**
+     * @lang{ZH}
+     * 若内核不支持读取操作，抛出 `cvt_error`，否则委托给内核。
+     * @endif
+     *
+     * @lang{EN}
+     * Throws `cvt_error` if the kernel does not support read operations; otherwise delegates to the kernel.
+     * @endif
+     */
     bool is_eof() override
     {
         if constexpr(!cvt_cpt::support_get<KernelType>)
@@ -133,6 +295,15 @@ public:
         return m_kernel.main_cont_beg();
     }
 
+    /**
+     * @lang{ZH}
+     * 若内核不支持读取操作，抛出 `cvt_error`，否则委托给内核。
+     * @endif
+     *
+     * @lang{EN}
+     * Throws `cvt_error` if the kernel does not support read operations; otherwise delegates to the kernel.
+     * @endif
+     */
     size_t get(internal_type* to, size_t to_max) override
     {
         if constexpr(!cvt_cpt::support_get<KernelType>)
@@ -141,6 +312,15 @@ public:
             return m_kernel.get(to, to_max);
     }
 
+    /**
+     * @lang{ZH}
+     * 若内核不支持写入操作，抛出 `cvt_error`，否则委托给内核。
+     * @endif
+     *
+     * @lang{EN}
+     * Throws `cvt_error` if the kernel does not support write operations; otherwise delegates to the kernel.
+     * @endif
+     */
     void put(const internal_type* to, size_t to_size) override
     {
         if constexpr(!cvt_cpt::support_put<KernelType>)
@@ -149,6 +329,15 @@ public:
             return m_kernel.put(to, to_size);
     }
 
+    /**
+     * @lang{ZH}
+     * 若内核不支持写入操作，抛出 `cvt_error`，否则委托给内核。
+     * @endif
+     *
+     * @lang{EN}
+     * Throws `cvt_error` if the kernel does not support write operations; otherwise delegates to the kernel.
+     * @endif
+     */
     void flush() override
     {
         if constexpr(!cvt_cpt::support_put<KernelType>)
@@ -157,6 +346,15 @@ public:
             return m_kernel.flush();
     }
 
+    /**
+     * @lang{ZH}
+     * 若内核不支持流定位操作，抛出 `cvt_error`，否则委托给内核。
+     * @endif
+     *
+     * @lang{EN}
+     * Throws `cvt_error` if the kernel does not support positioning; otherwise delegates to the kernel.
+     * @endif
+     */
     [[nodiscard]] size_t tell() const override
     {
         if constexpr (!cvt_cpt::support_positioning<KernelType>)
@@ -165,6 +363,15 @@ public:
             return m_kernel.tell();
     }
 
+    /**
+     * @lang{ZH}
+     * 若内核不支持流定位操作，抛出 `cvt_error`，否则委托给内核。
+     * @endif
+     *
+     * @lang{EN}
+     * Throws `cvt_error` if the kernel does not support positioning; otherwise delegates to the kernel.
+     * @endif
+     */
     void seek(size_t pos) override
     {
         if constexpr (!cvt_cpt::support_positioning<KernelType>)
@@ -173,6 +380,15 @@ public:
             m_kernel.seek(pos);
     }
 
+    /**
+     * @lang{ZH}
+     * 若内核不支持流定位操作，抛出 `cvt_error`，否则委托给内核。
+     * @endif
+     *
+     * @lang{EN}
+     * Throws `cvt_error` if the kernel does not support positioning; otherwise delegates to the kernel.
+     * @endif
+     */
     void rseek(size_t pos) override
     {
         if constexpr (!cvt_cpt::support_positioning<KernelType>)
@@ -181,6 +397,17 @@ public:
             m_kernel.rseek(pos);
     }
 
+    /**
+     * @lang{ZH}
+     * 切换至输入模式。若已处于输入模式则直接返回（幂等）；
+     * 若内核不支持 I/O 切换，抛出 `cvt_error`。
+     * @endif
+     *
+     * @lang{EN}
+     * Switch to input mode. Returns immediately if already in input mode (idempotent).
+     * Throws `cvt_error` if the kernel does not support I/O switching.
+     * @endif
+     */
     void switch_to_get() override
     {
         if (m_io_status == io_status::input) return;
@@ -193,6 +420,17 @@ public:
         }
     }
 
+    /**
+     * @lang{ZH}
+     * 切换至输出模式。若已处于输出模式则直接返回（幂等）；
+     * 若内核不支持 I/O 切换，抛出 `cvt_error`。
+     * @endif
+     *
+     * @lang{EN}
+     * Switch to output mode. Returns immediately if already in output mode (idempotent).
+     * Throws `cvt_error` if the kernel does not support I/O switching.
+     * @endif
+     */
     void switch_to_put() override
     {
         if (m_io_status == io_status::output) return;
@@ -207,9 +445,33 @@ public:
 
 private:
     KernelType m_kernel;
-    io_status m_io_status;
+    io_status m_io_status; ///< 追踪当前 I/O 方向，用于 switch_to_get/switch_to_put 的幂等检查。
+                           ///< Tracks current I/O direction for idempotent switch_to_get/switch_to_put.
 };
 
+/**
+ * @lang{ZH}
+ * 面向用户的运行时类型擦除转换器。
+ * 通过 `unique_ptr<abs_runtime_cvt_imp>` 持有具体转换器实现，使具体类型对外不可见。
+ * 支持拷贝（通过 `clone()` 实现多态拷贝）与移动语义。
+ * 所有成员函数在转发调用前均检查内部指针是否为空：
+ * 若为空则抛出异常（`noexcept` 函数 `detach` 除外，其在空指针时调用 `std::terminate`）。
+ * @endif
+ *
+ * @lang{EN}
+ * User-facing runtime type-erased converter.
+ * Holds the concrete converter implementation via `unique_ptr<abs_runtime_cvt_imp>`,
+ * keeping the concrete type invisible to callers.
+ * Supports both copy (via polymorphic `clone()`) and move semantics.
+ * All member functions check the internal pointer before forwarding the call:
+ * a null pointer throws an exception, except for the `noexcept` function `detach`,
+ * which calls `std::terminate` on null.
+ * @endif
+ *
+ * @tparam TDevice 底层设备类型，须满足 `io_device`。
+ *                / The underlying device type, must satisfy `io_device`.
+ * @tparam TInt    转换器内部数据类型。 / The converter's internal data type.
+ */
 template <io_device TDevice, typename TInt>
 class runtime_cvt
 {
@@ -219,6 +481,28 @@ public:
     using external_type = typename device_type::char_type;
 
 public:
+    /**
+     * @lang{ZH}
+     * 从任意兼容的转换器内核构造。接受左值（拷贝）和右值（移动）两种形式。
+     * 约束要求：
+     * - `KernelType` 不得为 `runtime_cvt` 自身（防止此构造函数拦截拷贝/移动构造）；
+     * - `KernelType` 须满足 `io_converter`；
+     * - 若传入左值引用，则内核类型须支持拷贝构造（因内核将被存储于堆上）。
+     * @endif
+     *
+     * @lang{EN}
+     * Constructs from any compatible converter kernel, accepting both lvalue (copy)
+     * and rvalue (move) forms.
+     * Constraints:
+     * - `KernelType` must not be `runtime_cvt` itself (prevents hijacking copy/move construction);
+     * - `KernelType` must satisfy `io_converter`;
+     * - If an lvalue reference is passed, the kernel type must be copy-constructible
+     *   (because the kernel will be stored on the heap).
+     * @endif
+     *
+     * @tparam KernelType 转换器内核类型。 / The converter kernel type.
+     * @param kernel 待包装的转换器内核。 / The converter kernel to wrap.
+     */
     template <typename KernelType>
         requires (!std::is_same_v<std::remove_cvref_t<KernelType>, runtime_cvt> &&
                   io_converter<std::remove_cvref_t<KernelType>> &&
@@ -227,9 +511,34 @@ public:
     runtime_cvt(KernelType&& kernel)
         : m_ptr(std::make_unique<runtime_cvt_imp<std::remove_cvref_t<KernelType>>>(std::forward<KernelType>(kernel))) {}
 
+    /**
+     * @lang{ZH}
+     * 拷贝构造：通过 `clone()` 对内部实现进行多态拷贝。若源对象为空则拷贝结果也为空。
+     * @endif
+     *
+     * @lang{EN}
+     * Copy constructor: performs a polymorphic copy of the internal implementation via `clone()`.
+     * If the source is null, the copy is also null.
+     * @endif
+     *
+     * @param val 源 `runtime_cvt` 实例。 / The source `runtime_cvt` instance.
+     */
     runtime_cvt(const runtime_cvt& val)
         : m_ptr(val.m_ptr ? val.m_ptr->clone() : nullptr) {}
 
+    /**
+     * @lang{ZH}
+     * 拷贝赋值：通过 `clone()` 对内部实现进行多态拷贝。若源对象为空则目标也置为空。
+     * @endif
+     *
+     * @lang{EN}
+     * Copy assignment: performs a polymorphic copy of the internal implementation via `clone()`.
+     * If the source is null, the target is set to null.
+     * @endif
+     *
+     * @param val 源 `runtime_cvt` 实例。 / The source `runtime_cvt` instance.
+     * @return 对 `*this` 的引用。 / A reference to `*this`.
+     */
     runtime_cvt& operator=(const runtime_cvt& val)
     {
         if (this != &val)
@@ -242,96 +551,141 @@ public:
     ~runtime_cvt() = default;
 
 public:
+    /// @lang{ZH} 返回底层设备的引用；若内部指针为空则抛出异常。 @endif
+    /// @lang{EN} Return a reference to the underlying device; throws if the internal pointer is null. @endif
     device_type& device()
     {
         if (!m_ptr) std::rethrow_exception(detail::runtime_cvt_null_err);
         return m_ptr->device();
     }
 
+    /**
+     * @lang{ZH}
+     * 分离底层设备，重置 I/O 状态为 `neutral`。
+     * 此函数声明为 `noexcept`：若内部指针为空，调用 `std::terminate` 而非抛出异常。
+     * @endif
+     *
+     * @lang{EN}
+     * Detach the underlying device and reset I/O status to `neutral`.
+     * This function is `noexcept`: if the internal pointer is null, it calls `std::terminate`
+     * rather than throwing.
+     * @endif
+     *
+     * @return 包含设备和任意待传播异常的 pair。
+     *         / A pair containing the device and any pending exception to propagate.
+     */
     std::pair<device_type, std::exception_ptr> detach() noexcept
     {
         if (!m_ptr) std::terminate();
         return m_ptr->detach();
     }
 
+    /// @lang{ZH} 将设备绑定到此转换器；若内部指针为空则抛出异常。 @endif
+    /// @lang{EN} Attach a device to this converter; throws if the internal pointer is null. @endif
     void attach(device_type&& dev = device_type{})
     {
         if (!m_ptr) std::rethrow_exception(detail::runtime_cvt_null_err);
         m_ptr->attach(std::move(dev));
     }
 
+    /// @lang{ZH} 向转换器应用行为策略；若内部指针为空则抛出异常。 @endif
+    /// @lang{EN} Apply a behavior policy to the converter; throws if the internal pointer is null. @endif
     void adjust(const cvt_behavior& acc)
     {
         if (!m_ptr) std::rethrow_exception(detail::runtime_cvt_null_err);
         return m_ptr->adjust(acc);
     }
 
+    /// @lang{ZH} 提取转换器的内部状态；若内部指针为空则抛出异常。 @endif
+    /// @lang{EN} Extract the converter's internal status; throws if the internal pointer is null. @endif
     void retrieve(cvt_status& acc) const
     {
         if (!m_ptr) std::rethrow_exception(detail::runtime_cvt_null_err);
         return m_ptr->retrieve(acc);
     }
 
+    /// @lang{ZH} 查询是否已到达数据末尾；若内部指针为空则抛出异常。 @endif
+    /// @lang{EN} Query whether the end of data has been reached; throws if the internal pointer is null. @endif
     bool is_eof()
     {
         if (!m_ptr) std::rethrow_exception(detail::runtime_cvt_null_err);
         return m_ptr->is_eof();
     }
 
+    /// @lang{ZH} 建立初始 I/O 状态；若内部指针为空则抛出异常。 @endif
+    /// @lang{EN} Establish the initial I/O state; throws if the internal pointer is null. @endif
     io_status bos()
     {
         if (!m_ptr) std::rethrow_exception(detail::runtime_cvt_null_err);
         return m_ptr->bos();
     }
 
+    /// @lang{ZH} 通知转换器进入主内容阶段；若内部指针为空则抛出异常。 @endif
+    /// @lang{EN} Notify the converter to enter the main content phase; throws if the internal pointer is null. @endif
     void main_cont_beg()
     {
         if (!m_ptr) std::rethrow_exception(detail::runtime_cvt_null_err);
         return m_ptr->main_cont_beg();
     }
 
+    /// @lang{ZH} 从转换器读取至多 `to_max` 个元素；若内部指针为空则抛出异常。 @endif
+    /// @lang{EN} Read up to `to_max` elements from the converter; throws if the internal pointer is null. @endif
     size_t get(internal_type* to, size_t to_max)
     {
         if (!m_ptr) std::rethrow_exception(detail::runtime_cvt_null_err);
         return m_ptr->get(to, to_max);
     }
 
+    /// @lang{ZH} 向转换器写入 `to_size` 个元素；若内部指针为空则抛出异常。 @endif
+    /// @lang{EN} Write `to_size` elements into the converter; throws if the internal pointer is null. @endif
     void put(const internal_type* to, size_t to_size)
     {
         if (!m_ptr) std::rethrow_exception(detail::runtime_cvt_null_err);
         return m_ptr->put(to, to_size);
     }
 
+    /// @lang{ZH} 将所有缓冲数据刷出转换器；若内部指针为空则抛出异常。 @endif
+    /// @lang{EN} Flush all buffered data out of the converter; throws if the internal pointer is null. @endif
     void flush()
     {
         if (!m_ptr) std::rethrow_exception(detail::runtime_cvt_null_err);
         return m_ptr->flush();
     }
 
+    /// @lang{ZH} 返回当前流位置；若内部指针为空则抛出异常。 @endif
+    /// @lang{EN} Return the current stream position; throws if the internal pointer is null. @endif
     [[nodiscard]] size_t tell() const
     {
         if (!m_ptr) std::rethrow_exception(detail::runtime_cvt_null_err);
         return m_ptr->tell();
     }
 
+    /// @lang{ZH} 将流定位到指定绝对位置；若内部指针为空则抛出异常。 @endif
+    /// @lang{EN} Seek the stream to the specified absolute position; throws if the internal pointer is null. @endif
     void seek(size_t pos)
     {
         if (!m_ptr) std::rethrow_exception(detail::runtime_cvt_null_err);
         m_ptr->seek(pos);
     }
 
+    /// @lang{ZH} 将流定位到指定相对位置；若内部指针为空则抛出异常。 @endif
+    /// @lang{EN} Seek the stream to the specified relative position; throws if the internal pointer is null. @endif
     void rseek(size_t pos)
     {
         if (!m_ptr) std::rethrow_exception(detail::runtime_cvt_null_err);
         m_ptr->rseek(pos);
     }
 
+    /// @lang{ZH} 切换至输入（读取）模式；若内部指针为空则抛出异常。 @endif
+    /// @lang{EN} Switch to input (reading) mode; throws if the internal pointer is null. @endif
     void switch_to_get()
     {
         if (!m_ptr) std::rethrow_exception(detail::runtime_cvt_null_err);
         return m_ptr->switch_to_get();
     }
 
+    /// @lang{ZH} 切换至输出（写入）模式；若内部指针为空则抛出异常。 @endif
+    /// @lang{EN} Switch to output (writing) mode; throws if the internal pointer is null. @endif
     void switch_to_put()
     {
         if (!m_ptr) std::rethrow_exception(detail::runtime_cvt_null_err);
@@ -341,6 +695,19 @@ private:
     std::unique_ptr<abs_runtime_cvt_imp<TDevice, TInt>> m_ptr;
 };
 
+/**
+ * @lang{ZH}
+ * `runtime_cvt` 的推导指引：从内核类型自动推导 `TDevice` 和 `TInt`。
+ * @endif
+ *
+ * @lang{EN}
+ * Deduction guide for `runtime_cvt`: automatically deduces `TDevice` and `TInt`
+ * from the kernel type.
+ * @endif
+ *
+ * @tparam KernelType 转换器内核类型，须满足 `io_converter`。
+ *                   / The converter kernel type, must satisfy `io_converter`.
+ */
 template <io_converter KernelType>
 runtime_cvt(KernelType&&) -> runtime_cvt<typename std::remove_cvref_t<KernelType>::device_type, typename std::remove_cvref_t<KernelType>::internal_type>;
 }


### PR DESCRIPTION


为 cvt_pipe_creator.h、runtime_cvt.h 和 zlib_cvt.h 添加符合项目规范的双语 Doxygen 注释（@lang{ZH}/@lang{EN}），覆盖所有公开接口及关键私有实现细节。