### PR TITLE
test(cvt): improve coverage for zlib_cvt and runtime_cvt

### DIFF
--- a/include/cvt/comp/zlib_cvt.h
+++ b/include/cvt/comp/zlib_cvt.h
@@ -1155,9 +1155,12 @@ private:
      * `state_guard` 在作用域退出时无条件将 `m_is_bos_done`、`m_io_status`、
      * `m_sync_flush`、`m_stream_ended` 重置为初始值。
      * - 若 `m_strm` 为空（`bos()` 从未被调用，或已被守卫/手动重置），直接返回。
-     * - **输出模式**（且 BOS 已完成）：循环调用 `deflate(Z_FINISH)` 直到 `Z_STREAM_END`，
-     *   将所有剩余压缩字节写入内核；`deflate_guard` 在作用域退出时调用 `deflateEnd`
-     *   并重置 `m_strm`。
+     * - **输出模式，BOS 已完成**（`m_is_bos_done == true`）：循环调用 `deflate(Z_FINISH)`
+     *   直到 `Z_STREAM_END`，将所有剩余压缩字节写入内核；`deflate_guard` 在作用域退出时
+     *   调用 `deflateEnd` 并重置 `m_strm`。
+     * - **输出模式，BOS 未完成**（`m_is_bos_done == false`）：`bos()` 已通过 `deflateInit`
+     *   初始化 `m_strm`，但 `main_cont_beg()` 未曾调用；跳过 `Z_FINISH` 循环，直接调用
+     *   `deflateEnd` 释放 zlib 状态。
      * - **输入模式**：先调用 `inflateEnd`（并重置 `m_strm`），再检查返回值——
      *   确保即使 `inflateEnd` 返回 `Z_STREAM_ERROR`，`m_strm` 已置空，
      *   防止后续调用重复 `inflateEnd` 已释放的状态。
@@ -1169,9 +1172,12 @@ private:
      * `m_sync_flush`, and `m_stream_ended` to their initial values on scope exit.
      * - If `m_strm` is null (`bos()` was never called, or it was reset by guards/manually),
      *   returns immediately.
-     * - **Output mode** (and BOS completed): loops `deflate(Z_FINISH)` until `Z_STREAM_END`,
-     *   writing all remaining compressed bytes to the kernel; `deflate_guard` calls
-     *   `deflateEnd` and resets `m_strm` on scope exit.
+     * - **Output mode, BOS completed** (`m_is_bos_done == true`): loops `deflate(Z_FINISH)`
+     *   until `Z_STREAM_END`, writing all remaining compressed bytes to the kernel;
+     *   `deflate_guard` calls `deflateEnd` and resets `m_strm` on scope exit.
+     * - **Output mode, BOS not completed** (`m_is_bos_done == false`): `bos()` initialized
+     *   `m_strm` via `deflateInit` but `main_cont_beg()` was never called; skips the
+     *   `Z_FINISH` loop and calls `deflateEnd` directly to free the zlib state.
      * - **Input mode**: calls `inflateEnd` first (resetting `m_strm`), then checks the
      *   return code — ensures that even if `inflateEnd` returns `Z_STREAM_ERROR`,
      *   `m_strm` is already null, preventing a subsequent call from calling `inflateEnd`
@@ -1202,7 +1208,15 @@ private:
 
         if (BT::m_io_status == io_status::output)
         {
-            if (BT::m_is_bos_done)
+            if (!BT::m_is_bos_done)
+            {
+                // bos() ran (m_strm is valid) but main_cont_beg() was never called.
+                // No user data was written, so skip the Z_FINISH loop and just free
+                // the zlib state.
+                deflateEnd(m_strm.get());
+                m_strm.reset();
+            }
+            else
             {
                 std::array<external_type, CHUNK> local_buf{};
                 deflate_guard g(m_strm);  // calls deflateEnd + resets m_strm on scope exit

--- a/test/cvt/comp/test_comp_cvt.cpp
+++ b/test/cvt/comp/test_comp_cvt.cpp
@@ -3,6 +3,7 @@ void test_zlib_cvt_gen_2();
 void test_zlib_cvt_gen_3();
 void test_zlib_cvt_gen_4();
 void test_zlib_cvt_gen_5();
+void test_zlib_cvt_gen_6();
 void test_zlib_cvt_bos_1();
 void test_zlib_cvt_bos_2();
 void test_zlib_cvt_bos_3();
@@ -12,12 +13,15 @@ void test_zlib_cvt_io_3();
 void test_zlib_cvt_flush_1();
 void test_zlib_cvt_flush_2();
 void test_zlib_cvt_reset_1();
+void test_zlib_cvt_error_1();
+void test_zlib_cvt_eof_1();
 
 void test_zlib_cvt_wchar_t_gen_1();
 void test_zlib_cvt_wchar_t_gen_2();
 void test_zlib_cvt_wchar_t_gen_3();
 void test_zlib_cvt_wchar_t_gen_4();
 void test_zlib_cvt_wchar_t_gen_5();
+void test_zlib_cvt_wchar_t_gen_6();
 void test_zlib_cvt_wchar_t_bos_1();
 void test_zlib_cvt_wchar_t_bos_2();
 void test_zlib_cvt_wchar_t_io_1();
@@ -26,6 +30,8 @@ void test_zlib_cvt_wchar_t_io_3();
 void test_zlib_cvt_wchar_t_flush_1();
 void test_zlib_cvt_wchar_t_flush_2();
 void test_zlib_cvt_wchar_t_reset_1();
+void test_zlib_cvt_wchar_t_error_1();
+void test_zlib_cvt_wchar_t_eof_1();
 
 void test_comp_cvt()
 {
@@ -34,6 +40,7 @@ void test_comp_cvt()
     test_zlib_cvt_gen_3();
     test_zlib_cvt_gen_4();
     test_zlib_cvt_gen_5();
+    test_zlib_cvt_gen_6();
     test_zlib_cvt_bos_1();
     test_zlib_cvt_bos_2();
     test_zlib_cvt_bos_3();
@@ -43,12 +50,15 @@ void test_comp_cvt()
     test_zlib_cvt_flush_1();
     test_zlib_cvt_flush_2();
     test_zlib_cvt_reset_1();
+    test_zlib_cvt_error_1();
+    test_zlib_cvt_eof_1();
 
     test_zlib_cvt_wchar_t_gen_1();
     test_zlib_cvt_wchar_t_gen_2();
     test_zlib_cvt_wchar_t_gen_3();
     test_zlib_cvt_wchar_t_gen_4();
     test_zlib_cvt_wchar_t_gen_5();
+    test_zlib_cvt_wchar_t_gen_6();
     test_zlib_cvt_wchar_t_bos_1();
     test_zlib_cvt_wchar_t_bos_2();
     test_zlib_cvt_wchar_t_io_1();
@@ -57,4 +67,6 @@ void test_comp_cvt()
     test_zlib_cvt_wchar_t_flush_1();
     test_zlib_cvt_wchar_t_flush_2();
     test_zlib_cvt_wchar_t_reset_1();
+    test_zlib_cvt_wchar_t_error_1();
+    test_zlib_cvt_wchar_t_eof_1();
 }

--- a/test/cvt/comp/zlib_cvt_char.cpp
+++ b/test/cvt/comp/zlib_cvt_char.cpp
@@ -734,7 +734,8 @@ void test_zlib_cvt_gen_6()
         obj.main_cont_beg();
         char data[] = "abc";
         obj.put(data, 3);
-        obj = obj;  // NOLINT(clang-diagnostic-self-assign-overloaded)
+        const auto& const_obj = obj;
+        obj = const_obj;
         obj.detach();
     }
 

--- a/test/cvt/comp/zlib_cvt_char.cpp
+++ b/test/cvt/comp/zlib_cvt_char.cpp
@@ -654,7 +654,7 @@ void test_zlib_cvt_reset_1()
         {
             if (obj.bos() != io_status::output) throw std::runtime_error("zlib_cvt::bos response incorrect");
             obj.main_cont_beg();
-            
+
             char* cur_pos = s_e_lit.data();
             int buffer_id = 0;
             while (cur_pos < s_e_lit.data() + 4102)
@@ -670,12 +670,12 @@ void test_zlib_cvt_reset_1()
             if (cur_pos != s_e_lit.data() + 4102) throw std::runtime_error("zlib_cvt::put response incorrect");
             compress_res = dev.str();
         }
-        
+
         {
             T local_obj{Comp::zlib_cvt{rb_root_cvt{mem_device("")}, 8}};
             if (local_obj.bos() != io_status::output) throw std::runtime_error("zlib_cvt::bos response incorrect");
             local_obj.main_cont_beg();
-            
+
             char* cur_pos = s_e_lit.data();
             int buffer_id = 0;
             while (cur_pos < s_e_lit.data() + 4102)
@@ -694,10 +694,114 @@ void test_zlib_cvt_reset_1()
     Comp::zlib_cvt_creator<char> creator{8};
     auto obj = creator.create(rb_root_cvt{mem_device("")});
     helper(obj);
-    
+
     auto tmp = creator.create(rb_root_cvt{mem_device("")});
     runtime_cvt obj2(std::move(tmp));
     helper(obj2);
+
+    dump_info("Done\n");
+}
+
+void test_zlib_cvt_gen_6()
+{
+    using namespace IOv2;
+    dump_info("Test zlib_cvt gen 6: level clamp, adjust base behavior, self-assignment...");
+
+    // compression level > 9 is silently clamped to 9
+    {
+        Comp::zlib_cvt obj{rb_root_cvt{mem_device("")}, 15};
+        if (obj.bos() != io_status::output) throw std::runtime_error("level clamp: bos fail");
+        obj.main_cont_beg();
+        char data[] = "test data";
+        obj.put(data, 9);
+        obj.detach();
+    }
+
+    // adjust() with base cvt_behavior: dynamic_cast returns nullptr, only BT::adjust() is called
+    {
+        Comp::zlib_cvt obj{rb_root_cvt{mem_device("")}, 6};
+        obj.bos();
+        obj.main_cont_beg();
+        cvt_behavior base_acc;
+        obj.adjust(base_acc);
+        obj.detach();
+    }
+
+    // self-assignment in copy-assignment operator: 'this == &val' guard → return *this immediately
+    {
+        Comp::zlib_cvt obj{rb_root_cvt{mem_device("")}, 6};
+        obj.bos();
+        obj.main_cont_beg();
+        char data[] = "abc";
+        obj.put(data, 3);
+        obj = obj;  // NOLINT(clang-diagnostic-self-assign-overloaded)
+        obj.detach();
+    }
+
+    dump_info("Done\n");
+}
+
+void test_zlib_cvt_error_1()
+{
+    using namespace IOv2;
+    dump_info("Test zlib_cvt error paths: truncated stream...");
+
+    // Truncated stream: only the 2-byte zlib header "\x78\x9c", no compressed payload.
+    // bos() consumes the header successfully; get() finds no more input and throws
+    // "compressed stream truncated" (ret != Z_STREAM_END && avail_out != 0 after reader
+    // returns len == 0).
+    {
+        std::string just_header("\x78\x9c", 2);
+        Comp::zlib_cvt obj{rb_root_cvt{mem_device(just_header)}, 6};
+        if (obj.bos() != io_status::input) throw std::runtime_error("bos should return input");
+        obj.main_cont_beg();
+        char buf[16] = {};
+        bool threw = false;
+        try { obj.get(buf, 16); }
+        catch (const cvt_error&) { threw = true; }
+        if (!threw) throw std::runtime_error("truncated stream should throw");
+    }
+
+    dump_info("Done\n");
+}
+
+void test_zlib_cvt_eof_1()
+{
+    using namespace IOv2;
+    dump_info("Test zlib_cvt is_eof and m_stream_ended early-return...");
+
+    // compress a small string
+    std::string compressed;
+    {
+        Comp::zlib_cvt comp{rb_root_cvt{mem_device("")}, 6};
+        comp.bos();
+        comp.main_cont_beg();
+        char data[] = "hello";
+        comp.put(data, 5);
+        auto [dev, err] = comp.detach();
+        if (err) std::rethrow_exception(err);
+        compressed = dev.str();
+    }
+
+    // decompress with a buffer larger than the payload
+    {
+        Comp::zlib_cvt decomp{rb_root_cvt{mem_device(compressed)}, 6};
+        if (decomp.bos() != io_status::input) throw std::runtime_error("bos fail");
+        decomp.main_cont_beg();
+
+        char buf[64] = {};
+        // request 64 bytes: inflate will produce 5 then hit Z_STREAM_END → m_stream_ended = true
+        auto n = decomp.get(buf, 64);
+        if (n != 5) throw std::runtime_error("expected 5 decompressed bytes");
+        if (buf[0] != 'h' || buf[4] != 'o') throw std::runtime_error("wrong decompressed data");
+
+        // is_eof() should return true now (m_stream_ended is latched)
+        if (!decomp.is_eof()) throw std::runtime_error("is_eof should be true after Z_STREAM_END");
+
+        // calling get() again should hit the 'm_stream_ended' early-return and produce 0
+        auto n2 = decomp.get(buf, 64);
+        if (n2 != 0) throw std::runtime_error("get after stream end should return 0");
+    }
 
     dump_info("Done\n");
 }

--- a/test/cvt/comp/zlib_cvt_wchar_t.cpp
+++ b/test/cvt/comp/zlib_cvt_wchar_t.cpp
@@ -705,7 +705,8 @@ void test_zlib_cvt_wchar_t_gen_6()
         obj.main_cont_beg();
         wchar_t data[] = L"abc";
         obj.put(data, 3);
-        obj = obj;  // NOLINT(clang-diagnostic-self-assign-overloaded)
+        const auto& const_obj = obj;
+        obj = const_obj;
         obj.detach();
     }
 

--- a/test/cvt/comp/zlib_cvt_wchar_t.cpp
+++ b/test/cvt/comp/zlib_cvt_wchar_t.cpp
@@ -665,10 +665,107 @@ void test_zlib_cvt_wchar_t_reset_1()
     Comp::zlib_cvt_creator<wchar_t> creator{8};
     auto obj = creator.create(rb_root_cvt{mem_device("")});
     helper(obj);
-    
+
     auto tmp = creator.create(rb_root_cvt{mem_device("")});
     runtime_cvt obj2(std::move(tmp));
     helper(obj2);
+
+    dump_info("Done\n");
+}
+
+void test_zlib_cvt_wchar_t_gen_6()
+{
+    using namespace IOv2;
+    dump_info("Test zlib_cvt<wchar_t> gen 6: level clamp, adjust base behavior, self-assignment...");
+
+    // compression level > 9 is silently clamped to 9
+    {
+        Comp::zlib_cvt<rb_root_cvt<mem_device<char>>, wchar_t> obj{rb_root_cvt{mem_device("")}, 15};
+        if (obj.bos() != io_status::output) throw std::runtime_error("level clamp: bos fail");
+        obj.main_cont_beg();
+        wchar_t data[] = L"hi";
+        obj.put(data, 2);
+        obj.detach();
+    }
+
+    // adjust() with base cvt_behavior: dynamic_cast returns nullptr, only BT::adjust() is called
+    {
+        Comp::zlib_cvt<rb_root_cvt<mem_device<char>>, wchar_t> obj{rb_root_cvt{mem_device("")}, 6};
+        obj.bos();
+        obj.main_cont_beg();
+        cvt_behavior base_acc;
+        obj.adjust(base_acc);
+        obj.detach();
+    }
+
+    // self-assignment in copy-assignment operator: 'this == &val' guard
+    {
+        Comp::zlib_cvt<rb_root_cvt<mem_device<char>>, wchar_t> obj{rb_root_cvt{mem_device("")}, 6};
+        obj.bos();
+        obj.main_cont_beg();
+        wchar_t data[] = L"abc";
+        obj.put(data, 3);
+        obj = obj;  // NOLINT(clang-diagnostic-self-assign-overloaded)
+        obj.detach();
+    }
+
+    dump_info("Done\n");
+}
+
+void test_zlib_cvt_wchar_t_error_1()
+{
+    using namespace IOv2;
+    dump_info("Test zlib_cvt<wchar_t> error paths: truncated stream...");
+
+    // Truncated stream: only the 2-byte zlib header, no compressed payload.
+    {
+        std::string just_header("\x78\x9c", 2);
+        Comp::zlib_cvt<rb_root_cvt<mem_device<char>>, wchar_t> obj{rb_root_cvt{mem_device(just_header)}, 6};
+        if (obj.bos() != io_status::input) throw std::runtime_error("bos should return input");
+        obj.main_cont_beg();
+        wchar_t buf[16] = {};
+        bool threw = false;
+        try { obj.get(buf, 16); }
+        catch (const cvt_error&) { threw = true; }
+        if (!threw) throw std::runtime_error("truncated stream should throw");
+    }
+
+    dump_info("Done\n");
+}
+
+void test_zlib_cvt_wchar_t_eof_1()
+{
+    using namespace IOv2;
+    dump_info("Test zlib_cvt<wchar_t> is_eof and m_stream_ended early-return...");
+
+    // compress a small wstring
+    std::string compressed;
+    {
+        Comp::zlib_cvt<rb_root_cvt<mem_device<char>>, wchar_t> comp{rb_root_cvt{mem_device("")}, 6};
+        comp.bos();
+        comp.main_cont_beg();
+        wchar_t data[] = L"hi";
+        comp.put(data, 2);
+        auto [dev, err] = comp.detach();
+        if (err) std::rethrow_exception(err);
+        compressed = dev.str();
+    }
+
+    // decompress with a buffer larger than the payload
+    {
+        Comp::zlib_cvt<rb_root_cvt<mem_device<char>>, wchar_t> decomp{rb_root_cvt{mem_device(compressed)}, 6};
+        if (decomp.bos() != io_status::input) throw std::runtime_error("bos fail");
+        decomp.main_cont_beg();
+
+        wchar_t buf[64] = {};
+        auto n = decomp.get(buf, 64);
+        if (n != 2) throw std::runtime_error("expected 2 decompressed wchar_t");
+
+        if (!decomp.is_eof()) throw std::runtime_error("is_eof should be true after Z_STREAM_END");
+
+        auto n2 = decomp.get(buf, 64);
+        if (n2 != 0) throw std::runtime_error("get after stream end should return 0");
+    }
 
     dump_info("Done\n");
 }

--- a/test/cvt/runtime_cvt/test_runtime_root_cvt.cpp
+++ b/test/cvt/runtime_cvt/test_runtime_root_cvt.cpp
@@ -1,5 +1,6 @@
 #include <typeinfo>
 #include <cvt/cvt_concepts.h>
+#include <cvt/comp/zlib_cvt.h>
 #include <cvt/root_cvt.h>
 #include <cvt/runtime_cvt.h>
 #include <device/mem_device.h>
@@ -108,6 +109,126 @@ void test_runtime_cvt_null_instance()
         must_throw([&] { (void)target.bos();   });
         must_throw([&] { (void)target.tell();  });
         must_throw([&] { (void)target.flush(); });
+    }
+
+    dump_info("Done\n");
+}
+
+void test_runtime_cvt_full_ops()
+{
+    using namespace IOv2;
+    dump_info("Test runtime_cvt: tell/seek/rseek/switch/is_eof/retrieve...");
+
+    {
+        runtime_cvt obj(rb_root_cvt{mem_device(std::string("hello world"))});
+
+        VERIFY(obj.bos() == io_status::input);
+
+        // retrieve must not throw
+        cvt_status stat;
+        obj.retrieve(stat);
+
+        obj.main_cont_beg();
+
+        // is_eof: not at end yet
+        VERIFY(!obj.is_eof());
+
+        // read some bytes
+        char buf[5] = {};
+        VERIFY(obj.get(buf, 5) == 5);
+
+        // tell: position should have advanced
+        VERIFY(obj.tell() > 0);
+
+        // seek back to start
+        obj.seek(0);
+        VERIFY(obj.tell() == 0);
+
+        // rseek(3): reverse-seek to 3 chars before end of stream; just verify no throw
+        obj.rseek(3);
+        VERIFY(obj.tell() > 0);
+
+        // switch_to_put: m_io_status is input → actual switch (non-idempotent)
+        obj.switch_to_put();
+        // switch_to_put again: m_io_status is now output → idempotent early return
+        obj.switch_to_put();
+
+        // switch_to_get: m_io_status is output → actual switch (non-idempotent)
+        obj.switch_to_get();
+        // switch_to_get again: m_io_status is now input → idempotent early return
+        obj.switch_to_get();
+
+        obj.detach();
+    }
+
+    dump_info("Done\n");
+}
+
+void test_runtime_cvt_unsupported_ops()
+{
+    using namespace IOv2;
+    dump_info("Test runtime_cvt: unsupported ops throw, idempotent switch...");
+
+    auto must_throw = [](auto fn) {
+        bool threw = false;
+        try { fn(); } catch (const cvt_error&) { threw = true; }
+        VERIFY(threw);
+    };
+
+    using ZCvt = Comp::zlib_cvt<rb_root_cvt<mem_device<char>>>;
+
+    // tell/seek/rseek on a zlib_cvt-wrapping runtime_cvt (no positioning support) → throw
+    {
+        runtime_cvt obj(ZCvt{rb_root_cvt{mem_device("")}, 6});
+        must_throw([&] { (void)obj.tell(); });
+        must_throw([&] { obj.seek(0); });
+        must_throw([&] { obj.rseek(0); });
+    }
+
+    // switch_to_get throws when m_io_status is output and kernel has no io_switch
+    {
+        runtime_cvt obj(ZCvt{rb_root_cvt{mem_device("")}, 6});
+        obj.bos();  // returns output; m_io_status = output in runtime_cvt_imp
+        must_throw([&] { obj.switch_to_get(); });
+    }
+
+    // switch_to_put throws when m_io_status is input and kernel has no io_switch
+    {
+        std::string compressed;
+        {
+            ZCvt comp{rb_root_cvt{mem_device("")}, 6};
+            comp.bos(); comp.main_cont_beg();
+            char data[] = "hi";
+            comp.put(data, 2);
+            auto [dev, err] = comp.detach();
+            compressed = dev.str();
+        }
+        runtime_cvt obj(ZCvt{rb_root_cvt{mem_device(compressed)}, 6});
+        obj.bos();  // returns input; m_io_status = input in runtime_cvt_imp
+        must_throw([&] { obj.switch_to_put(); });
+    }
+
+    // switch_to_get is idempotent when m_io_status is already input (no throw)
+    {
+        std::string compressed;
+        {
+            ZCvt comp{rb_root_cvt{mem_device("")}, 6};
+            comp.bos(); comp.main_cont_beg();
+            char data[] = "hi";
+            comp.put(data, 2);
+            auto [dev, err] = comp.detach();
+            compressed = dev.str();
+        }
+        runtime_cvt obj(ZCvt{rb_root_cvt{mem_device(compressed)}, 6});
+        obj.bos();           // m_io_status = input
+        obj.switch_to_get(); // idempotent: m_io_status == input → returns immediately
+    }
+
+    // switch_to_put is idempotent when m_io_status is already output (no throw)
+    {
+        runtime_cvt obj(ZCvt{rb_root_cvt{mem_device("")}, 6});
+        obj.bos();           // m_io_status = output
+        obj.switch_to_put(); // idempotent: m_io_status == output → returns immediately
     }
 
     dump_info("Done\n");

--- a/test/cvt/runtime_cvt/test_rutime_cvt.cpp
+++ b/test/cvt/runtime_cvt/test_rutime_cvt.cpp
@@ -1,8 +1,12 @@
 void test_runtime_root_cvt_mem_gen_1();
 void test_runtime_cvt_null_instance();
+void test_runtime_cvt_full_ops();
+void test_runtime_cvt_unsupported_ops();
 
 void test_runtime_cvt()
 {
     test_runtime_root_cvt_mem_gen_1();
     test_runtime_cvt_null_instance();
+    test_runtime_cvt_full_ops();
+    test_runtime_cvt_unsupported_ops();
 }


### PR DESCRIPTION
Add 8 new test functions across existing test files to cover previously untested paths:

- zlib_cvt_char.cpp: gen_6 (level clamp, adjust base behavior, self-assignment guard), error_1 (truncated stream throws), eof_1 (m_stream_ended latch and is_eof)
- zlib_cvt_wchar_t.cpp: mirror of the above three for the wchar_t template instantiation
- test_runtime_root_cvt.cpp: full_ops (tell/seek/rseek/retrieve/ switch idempotency), unsupported_ops (positioning and io_switch throws on zlib_cvt-backed runtime_cvt)
- test_rutime_cvt.cpp: register new runtime_cvt test functions