### PR TITLE
fix(vigenere_cvt): fix header order, missing includes, typo and POSIX newline

### DIFF
--- a/include/cvt/crypt/vigenere_cvt.h
+++ b/include/cvt/crypt/vigenere_cvt.h
@@ -1,12 +1,16 @@
 #pragma once
+#include <cvt/abs_cvt.h>
+#include <cvt/cvt_concepts.h>
+#include <cvt/root_cvt.h>
+
+#include <algorithm>
 #include <exception>
 #include <stdexcept>
+#include <string>
 #include <string_view>
+#include <type_traits>
 #include <utility>
 #include <vector>
-#include <cvt/cvt_concepts.h>
-#include <cvt/abs_cvt.h>
-#include <cvt/root_cvt.h>
 
 namespace IOv2::Crypt::Classic
 {
@@ -50,7 +54,7 @@ public:
         , m_key(s.begin(), s.end())
     {
         if (s.empty())
-            throw cvt_error("Cannot create vigener converter with empty key");
+            throw cvt_error("Cannot create vigenere converter with empty key");
     }
 
 // mandatory methods


### PR DESCRIPTION
- Reorder headers: local headers first (abs_cvt.h, cvt_concepts.h, root_cvt.h, alphabetically), then C++ stdlib headers (alphabetically)
- Add missing <algorithm> for std::min
- Add missing <type_traits> for std::is_integral_v / std::is_same_v
- Add missing <string> for std::basic_string
- Fix typo in error message: "vigener" -> "vigenere"
- Add missing newline at end of file (POSIX compliance)