### PR TITLE
refactor(crypt): improve safety and exception handling in crypto converters

### DIFF
--- a/include/cvt/crypt/chacha20_cvt.h
+++ b/include/cvt/crypt/chacha20_cvt.h
@@ -1,7 +1,6 @@
 #pragma once
 #include <cvt/abs_cvt.h>
 #include <cvt/cvt_concepts.h>
-#include <cvt/root_cvt.h>
 
 #include <cstdint>
 #include <exception>
@@ -43,6 +42,9 @@ public:
     using internal_type = TInt;
     using external_type = typename KernelType::internal_type;
 
+    static_assert(sizeof(external_type) == 1,
+        "chacha20_cvt requires external_type (kernel's internal_type) to be 1 byte");
+
     static constexpr size_t block_size = 64;
 
 public:
@@ -63,6 +65,8 @@ public:
     {
         if (!m_cipher)
             throw cvt_error("chacha20_cvt constructor fail: cannot create the stream cipher");
+        if (!m_cipher->valid_keylength(key.size()))
+            throw cvt_error("chacha20_cvt constructor fail: invalid key length");
     }
 
     chacha20_cvt(const chacha20_cvt&) = delete;
@@ -99,6 +103,9 @@ public:
 
     io_status bos()
     {
+        if (!m_cipher)
+            throw cvt_error("chacha20_cvt::bos fail: cipher not initialized (moved-from object?)");
+
         BT::bos();
         const size_t iv_len = m_cipher->default_iv_length();
         std::vector<external_type> iv_buf(iv_len);
@@ -143,6 +150,9 @@ private:
     size_t get_main(cvt_reader<KernelType>& reader, internal_type* _to, size_t to_max)
         requires (cvt_cpt::support_get<KernelType>)
     {
+        if (!m_cipher)
+            throw cvt_error("chacha20_cvt::get_main fail: cipher not initialized (moved-from object?)");
+
         constexpr size_t max_type_limit = std::numeric_limits<size_t>::max();
         constexpr size_t max_chunk = max_type_limit - (max_type_limit % sizeof(internal_type));
         to_max = (max_chunk / sizeof(internal_type) > to_max)
@@ -164,13 +174,16 @@ private:
         }
 
         if (res % sizeof(internal_type))
-            throw cvt_error("chacha20_cvt::get fails: partial sequence");
+            throw cvt_error("chacha20_cvt::get_main fail: partial sequence");
         return res / sizeof(internal_type);
     }
 
     void put_main(cvt_writer<KernelType>& writer, const internal_type* _to, size_t to_size)
         requires (cvt_cpt::support_put<KernelType>)
     {
+        if (!m_cipher)
+            throw cvt_error("chacha20_cvt::put_main fail: cipher not initialized (moved-from object?)");
+
         constexpr size_t max_type_limit = std::numeric_limits<size_t>::max();
         constexpr size_t max_chunk = max_type_limit - (max_type_limit % sizeof(internal_type));
 

--- a/include/cvt/crypt/hash_cvt.h
+++ b/include/cvt/crypt/hash_cvt.h
@@ -69,8 +69,8 @@ public:
     hash_cvt(const hash_cvt& val)
         requires (std::copy_constructible<KernelType>)
         : BT(val)
-        , m_hash(val.m_hash->copy_state())
-        , m_has_main_cont(val.m_has_main_cont)
+        , m_hash(val.m_hash ? val.m_hash->copy_state() : nullptr)
+        , m_has_main_cont(val.m_hash ? val.m_has_main_cont : false)
         , m_out_fmt(val.m_out_fmt)
     {}
 
@@ -87,18 +87,16 @@ public:
     {
         if (this != &val)
         {
-            // Copy new state first (may throw) before modifying *this
-            auto new_hash = val.m_hash->copy_state();
+            // Copy-and-move idiom for strong exception safety:
+            // 1. Construct full copy (may throw, *this unchanged)
+            hash_cvt temp(val);
 
-            // New state prepared successfully, now safe to modify *this
+            // 2. Flush current data (may throw, but strong exception safe)
             if (m_has_main_cont)
                 dump_stream();
 
-            m_hash = std::move(new_hash);
-            m_has_main_cont = val.m_has_main_cont;
-            m_out_fmt = val.m_out_fmt;
-
-            BT::operator=(val);
+            // 3. Move-assign from temp (noexcept, per io_converter concept)
+            *this = std::move(temp);
         }
         return *this;
     }
@@ -139,7 +137,7 @@ public:
     {
         auto res = BT::bos();
         if (res != io_status::output)
-            throw cvt_error("hash_cvt::bos fail: only output mode is supported.");
+            throw cvt_error("hash_cvt::bos fail: only output mode is supported");
         return io_status::output;
     }
 
@@ -186,6 +184,9 @@ public:
 private:
     void put_main(cvt_writer<KernelType>& /*writer*/, const internal_type* to, size_t to_size)
     {
+        if (!m_hash)
+            throw cvt_error("hash_cvt::put_main fail: hash not initialized (moved-from object?)");
+
         m_has_main_cont = true;
         m_hash->update((const uint8_t*)to, to_size * sizeof(internal_type));
     }
@@ -207,12 +208,12 @@ private:
         if (!m_has_main_cont) return;
         if (!m_hash) return;
 
-        auto digest = m_hash->final();
+        // Use copy_state()->final() to preserve original state until put() succeeds.
+        // This provides strong exception safety: if put() fails, state is unchanged
+        // and the operation can be retried.
+        auto digest = m_hash->copy_state()->final();
         if (digest.empty())
-            throw cvt_error("hash_cvt::dump_stream fail: cannot get hash result.");
-
-        m_has_main_cont = false;
-        m_hash->clear();
+            throw cvt_error("hash_cvt::dump_stream fail: cannot get hash result");
 
         switch (m_out_fmt)
         {
@@ -232,8 +233,12 @@ private:
             }
             break;
         default:
-            throw cvt_error("hash_cvt::dump_stream fail: invalid output format.");
+            throw cvt_error("hash_cvt::dump_stream fail: invalid output format");
         }
+
+        // Only clear state after successful output
+        m_has_main_cont = false;
+        m_hash->clear();
     }
 private:
     std::unique_ptr<Botan::HashFunction> m_hash;

--- a/include/cvt/crypt/vigenere_cvt.h
+++ b/include/cvt/crypt/vigenere_cvt.h
@@ -1,7 +1,6 @@
 #pragma once
 #include <cvt/abs_cvt.h>
 #include <cvt/cvt_concepts.h>
-#include <cvt/root_cvt.h>
 
 #include <algorithm>
 #include <exception>


### PR DESCRIPTION
- Add static_assert and key length validation to chacha20_cvt
- Add safety checks for null cipher/hash pointers (moved-from state)
- Implement strong exception safety in hash_cvt assignment and dump_stream
- Remove unused root_cvt.h includes