### PR TITLE
fix(crypt): add null-ptr guard, moved-from checks, and exception-safe attach/detach

### DIFF
--- a/include/cvt/crypt/chacha20_cvt.h
+++ b/include/cvt/crypt/chacha20_cvt.h
@@ -6,7 +6,6 @@
 #include <exception>
 #include <limits>
 #include <memory>
-#include <string>
 #include <string_view>
 #include <type_traits>
 #include <utility>
@@ -26,7 +25,11 @@ inline Botan::secure_vector<uint8_t> key_gen(std::string_view key)
     if (!hash)
         throw cvt_error("chacha20 key generation fail: cannot create SHA-256 hash");
 
-    hash->update(reinterpret_cast<const uint8_t*>(key.data()), key.size());
+    // Guard against passing a possibly-null pointer to update(): for an empty
+    // string_view, data() is allowed to return nullptr, and feeding (nullptr, 0)
+    // into a C API that may internally use memcpy is UB in the C standard.
+    if (!key.empty())
+        hash->update(reinterpret_cast<const uint8_t*>(key.data()), key.size());
     return hash->final();
 }
 }

--- a/include/cvt/crypt/hash_cvt.h
+++ b/include/cvt/crypt/hash_cvt.h
@@ -150,10 +150,34 @@ public:
 
     void attach(device_type&& dev = device_type{})
     {
-        if (m_has_main_cont)
-            dump_stream();
+        // 1. Try to finalize the old session; capture any failure so we can
+        //    still install the new device (zlib_cvt::attach convention:
+        //    propagating here would let `dev`, already moved into our
+        //    parameter, be destroyed during stack unwinding).
+        std::exception_ptr dump_err;
+        try { if (m_has_main_cont) dump_stream(); }
+        catch (...) { dump_err = std::current_exception(); }
+
+        m_has_main_cont = false;
         m_out_fmt = hash_fmt::lower_hex;
+
+        // 2. Defense-in-depth: clear any residual hash state. If clear()
+        //    throws, the converter is in an unknown state — mark it tainted
+        //    and propagate immediately; BT::attach() will not be called and
+        //    the incoming device will be lost.
+        if (m_hash)
+        {
+            try { m_hash->clear(); }
+            catch (...)
+            {
+                BT::set_tainted();
+                throw;
+            }
+        }
+
         BT::attach(std::move(dev));
+
+        if (dump_err)  std::rethrow_exception(dump_err);
     }
 
     std::pair<device_type, std::exception_ptr> detach() noexcept
@@ -164,6 +188,16 @@ public:
         {
             local_err = std::current_exception();
             m_has_main_cont = false;
+            // Clear any residual hash state so a subsequent attach()+put()
+            // does not accumulate on top of half-finished data.  If clear()
+            // itself fails, swallow the exception — we are already in error
+            // recovery from a failed dump_stream(), and surfacing a secondary
+            // failure here would only obscure the primary error.
+            if (m_hash)
+            {
+                try { m_hash->clear(); }
+                catch (...) {} // NOLINT(bugprone-empty-catch)
+            }
         }
         m_out_fmt = hash_fmt::lower_hex;
         auto [dev, inner_err] = BT::detach();

--- a/include/cvt/crypt/vigenere_cvt.h
+++ b/include/cvt/crypt/vigenere_cvt.h
@@ -80,6 +80,9 @@ private:
     size_t get_main(cvt_reader<KernelType>& reader, internal_type* to, size_t to_max)
         requires (cvt_cpt::support_get<KernelType>)
     {
+        if (m_key.empty())
+            throw cvt_error("vigenere_cvt: key not initialized (moved-from object?)");
+
         size_t total_count = 0;
         reader.reset(s_buf_len);
         while (total_count != to_max)
@@ -102,6 +105,9 @@ private:
     void put_main(cvt_writer<KernelType>& writer, const internal_type* to, size_t to_size)
         requires (cvt_cpt::support_put<KernelType>)
     {
+        if (m_key.empty())
+            throw cvt_error("vigenere_cvt: key not initialized (moved-from object?)");
+
         writer.reset(s_buf_len);
 
         size_t total_count = 0;


### PR DESCRIPTION


- chacha20: skip hash->update() for empty string_view to avoid UB from possible nullptr data() with zero size
- vigenere: guard get_main/put_main against moved-from (empty key) state
- hash_cvt: make attach() preserve the new device even when dump_stream() fails; clear residual hash state in detach() error path