### PR TITLE
fix(crypt): strengthen exception safety and taint propagation

### DIFF
--- a/include/cvt/crypt/chacha20_cvt.h
+++ b/include/cvt/crypt/chacha20_cvt.h
@@ -82,14 +82,21 @@ public:
 public:
     void attach(device_type&& dev = device_type{})
     {
-        if (!m_cipher)
-        {
-            m_cipher = Botan::StreamCipher::create("ChaCha20");
-            if (!m_cipher)
-                throw cvt_error("chacha20_cvt::attach fail: cannot recreate the stream cipher");
-        }
+        if (!m_cipher || m_key.empty())
+            throw cvt_error("chacha20_cvt::attach fail: cipher or key missing (moved-from object?)");
         else
-            m_cipher->clear();
+        {
+            try
+            {
+                m_cipher->clear();
+            }
+            catch (...)
+            {
+                BT::set_tainted();
+                throw;
+            }
+        }
+
         BT::attach(std::move(dev));
     }
 
@@ -122,8 +129,17 @@ public:
                 if (n != iv_len)
                     throw cvt_error("chacha20_cvt::bos fail: incomplete IV read");
 
-                m_cipher->set_key(m_key);
-                m_cipher->set_iv(reinterpret_cast<const uint8_t*>(iv_buf.data()), iv_len);
+                try
+                {
+                    m_cipher->set_key(m_key);
+                    m_cipher->set_iv(reinterpret_cast<const uint8_t*>(iv_buf.data()), iv_len);
+                }
+                catch (...)
+                {
+                    try { m_cipher->clear(); } catch (...) {}
+                    BT::set_tainted();
+                    throw;
+                }
             }
             else
                 throw cvt_error("chacha20_cvt::bos fail: input mode but kernel does not support get");
@@ -135,10 +151,19 @@ public:
                 Botan::AutoSeeded_RNG rng;
                 rng.randomize(reinterpret_cast<uint8_t*>(iv_buf.data()), iv_len);
 
-                m_cipher->set_key(m_key);
-                m_cipher->set_iv(reinterpret_cast<const uint8_t*>(iv_buf.data()), iv_len);
+                try
+                {
+                    m_cipher->set_key(m_key);
+                    m_cipher->set_iv(reinterpret_cast<const uint8_t*>(iv_buf.data()), iv_len);
 
-                BT::m_kernel.put(iv_buf.data(), iv_len);
+                    BT::m_kernel.put(iv_buf.data(), iv_len);
+                }
+                catch (...)
+                {
+                    try { m_cipher->clear(); } catch (...) {}
+                    BT::set_tainted();
+                    throw;
+                }
             }
             else
                 throw cvt_error("chacha20_cvt::bos fail: output mode but kernel does not support put");

--- a/include/cvt/crypt/hash_cvt.h
+++ b/include/cvt/crypt/hash_cvt.h
@@ -230,8 +230,9 @@ private:
         if (to_size > max_safe)
             throw cvt_error("hash_cvt::put_main fail: size overflow");
 
-        m_has_main_cont = true;
+        if (to_size == 0) return;
         m_hash->update((const uint8_t*)to, to_size * sizeof(internal_type));
+        m_has_main_cont = true;
     }
 
 private:
@@ -281,7 +282,15 @@ private:
 
         // Only clear state after successful output
         m_has_main_cont = false;
-        m_hash->clear();
+        try
+        {
+            m_hash->clear();
+        }
+        catch (...)
+        {
+            BT::set_tainted();
+            throw;
+        }
     }
 private:
     std::unique_ptr<Botan::HashFunction> m_hash;


### PR DESCRIPTION
chacha20_cvt:
- attach(): replace dead "recreate cipher" branch with explicit throw on moved-from state (!m_cipher || m_key.empty()); wrap m_cipher->clear() in try/catch that calls set_tainted() before rethrowing
- bos(): wrap set_key/set_iv (and kernel.put in output path) in try/catch; call m_cipher->clear() then set_tainted() on any failure so the converter is not left with a half-initialized cipher state

hash_cvt:
- put_main(): add early return for to_size == 0 to avoid feeding a zero-length update; move m_has_main_cont = true to after update() so the flag is not set when the update itself throws
- dump_stream(): wrap m_hash->clear() in try/catch and call set_tainted() on failure, matching the same pattern used in chacha20_cvt