### PR TITLE
fix(crypt): correctness and safety fixes across vigenere/hash/chacha20

### DIFF
--- a/include/cvt/crypt/chacha20_cvt.h
+++ b/include/cvt/crypt/chacha20_cvt.h
@@ -21,15 +21,18 @@ namespace chacha20_cvt_helpers
 {
 inline Botan::secure_vector<uint8_t> key_gen(std::string_view key)
 {
+    // Reject empty input: hashing an empty string would silently yield the
+    // publicly known constant SHA-256("") and use it as the ChaCha20 key,
+    // providing zero confidentiality. The secure_vector-based constructor
+    // already rejects invalid key lengths; mirror that contract here.
+    if (key.empty())
+        throw cvt_error("chacha20 key generation fail: key must not be empty");
+
     auto hash = Botan::HashFunction::create("SHA-256");
     if (!hash)
         throw cvt_error("chacha20 key generation fail: cannot create SHA-256 hash");
 
-    // Guard against passing a possibly-null pointer to update(): for an empty
-    // string_view, data() is allowed to return nullptr, and feeding (nullptr, 0)
-    // into a C API that may internally use memcpy is UB in the C standard.
-    if (!key.empty())
-        hash->update(reinterpret_cast<const uint8_t*>(key.data()), key.size());
+    hash->update(reinterpret_cast<const uint8_t*>(key.data()), key.size());
     return hash->final();
 }
 }
@@ -119,18 +122,20 @@ public:
 
         BT::bos();
         const size_t iv_len = m_cipher->default_iv_length();
+        if (iv_len == 0)
+            throw cvt_error("chacha20_cvt::bos fail: cipher reports zero IV length");
         std::vector<external_type> iv_buf(iv_len);
 
         if (BT::m_io_status == io_status::input)
         {
             if constexpr (cvt_cpt::support_get<KernelType>)
             {
-                const size_t n = BT::m_kernel.get(iv_buf.data(), iv_len);
-                if (n != iv_len)
-                    throw cvt_error("chacha20_cvt::bos fail: incomplete IV read");
-
                 try
                 {
+                    const size_t n = BT::m_kernel.get(iv_buf.data(), iv_len);
+                    if (n != iv_len)
+                        throw cvt_error("chacha20_cvt::bos fail: incomplete IV read");
+
                     m_cipher->set_key(m_key);
                     m_cipher->set_iv(reinterpret_cast<const uint8_t*>(iv_buf.data()), iv_len);
                 }
@@ -188,27 +193,40 @@ private:
 
         constexpr size_t max_type_limit = std::numeric_limits<size_t>::max();
         constexpr size_t max_chunk = max_type_limit - (max_type_limit % sizeof(internal_type));
-        to_max = (max_chunk / sizeof(internal_type) > to_max)
-               ? (to_max * sizeof(internal_type))
-               : max_chunk;
 
         uint8_t* to = reinterpret_cast<uint8_t*>(_to);
 
         reader.reset(block_size);
-        size_t res = 0;
-        while (res != to_max)
+        size_t total_res = 0;   // total bytes decrypted across all outer iterations
+
+        // Mirrors put_main: the outer loop splits a large request into
+        // max_chunk-sized slices so that (to_max * sizeof) never overflows.
+        // Each inner loop fills one slice or stops on EOF.
+        while (to_max > 0)
         {
-            size_t dest_size = std::min<size_t>(block_size, to_max - res);
-            auto [ptr, cur_len] = reader.get_buf(dest_size);
-            if (cur_len == 0) break;
-            m_cipher->cipher(reinterpret_cast<const uint8_t*>(ptr), to, cur_len);
-            to += cur_len;
-            res += cur_len;
+            const size_t aim = (max_chunk / sizeof(internal_type) > to_max)
+                             ? (to_max * sizeof(internal_type))
+                             : max_chunk;
+
+            size_t chunk_res = 0;   // bytes decrypted in this slice
+            bool eof = false;
+            while (chunk_res != aim)
+            {
+                const size_t dest_size = std::min<size_t>(block_size, aim - chunk_res);
+                auto [ptr, cur_len] = reader.get_buf(dest_size);
+                if (cur_len == 0) { eof = true; break; }
+                m_cipher->cipher(reinterpret_cast<const uint8_t*>(ptr), to, cur_len);
+                to += cur_len;
+                chunk_res += cur_len;
+            }
+            total_res += chunk_res;
+            to_max -= aim / sizeof(internal_type);
+            if (eof) break;
         }
 
-        if (res % sizeof(internal_type))
+        if (total_res % sizeof(internal_type))
             throw cvt_error("chacha20_cvt::get_main fail: partial sequence");
-        return res / sizeof(internal_type);
+        return total_res / sizeof(internal_type);
     }
 
     void put_main(cvt_writer<KernelType>& writer, const internal_type* _to, size_t to_size)

--- a/include/cvt/crypt/hash_cvt.h
+++ b/include/cvt/crypt/hash_cvt.h
@@ -210,9 +210,12 @@ public:
             m_out_fmt = shf_ptr->m_val;
         else if (const dump_hash* dh_ptr = dynamic_cast<const dump_hash*>(&acc); dh_ptr)
         {
-            dump_stream();
-            if (dh_ptr->m_delim)
-                BT::m_kernel.put(reinterpret_cast<const external_type*>(&dh_ptr->m_delim), 1);
+            if (m_has_main_cont)
+            {
+                dump_stream();
+                if (dh_ptr->m_delim)
+                    BT::m_kernel.put(reinterpret_cast<const external_type*>(&dh_ptr->m_delim), 1);
+            }
         }
 
         return BT::adjust(acc);
@@ -231,7 +234,7 @@ private:
             throw cvt_error("hash_cvt::put_main fail: size overflow");
 
         if (to_size == 0) return;
-        m_hash->update((const uint8_t*)to, to_size * sizeof(internal_type));
+        m_hash->update(reinterpret_cast<const uint8_t*>(to), to_size * sizeof(internal_type));
         m_has_main_cont = true;
     }
 
@@ -262,18 +265,18 @@ private:
         switch (m_out_fmt)
         {
         case hash_fmt::binary:
-            BT::m_kernel.put((const external_type*)digest.data(), digest.size());
+            BT::m_kernel.put(reinterpret_cast<const external_type*>(digest.data()), digest.size());
             break;
         case hash_fmt::upper_hex:
             {
                 std::string hex_string = Botan::hex_encode(digest);
-                BT::m_kernel.put((const external_type*)hex_string.data(), hex_string.size());
+                BT::m_kernel.put(reinterpret_cast<const external_type*>(hex_string.data()), hex_string.size());
             }
             break;
         case hash_fmt::lower_hex:
             {
                 std::string hex_string = Botan::hex_encode(digest, false);
-                BT::m_kernel.put((const external_type*)hex_string.data(), hex_string.size());
+                BT::m_kernel.put(reinterpret_cast<const external_type*>(hex_string.data()), hex_string.size());
             }
             break;
         default:

--- a/include/cvt/crypt/vigenere_cvt.h
+++ b/include/cvt/crypt/vigenere_cvt.h
@@ -139,16 +139,44 @@ public:
         requires (cvt_cpt::support_positioning<KernelType>)
     {
         BT::assert_not_tainted();
+        // The kernel is not required to land exactly on `pos` (e.g. clamping,
+        // alignment, internal buffering), so the keystream index must be
+        // resynced via tell() rather than using `pos` directly.
+        //
+        // If seek() itself throws, the kernel position is expected to be
+        // unchanged (strong exception guarantee of positioning kernels), so
+        // m_pos remains valid and we propagate without tainting.
+        //
+        // If seek() succeeds but tell() throws, the kernel has moved while
+        // m_pos has not — that desync would silently corrupt the keystream,
+        // so taint and propagate.
         BT::m_kernel.seek(pos);
-        m_pos = BT::m_kernel.tell();
+        try
+        {
+            m_pos = BT::m_kernel.tell();
+        }
+        catch (...)
+        {
+            BT::set_tainted();
+            throw;
+        }
     }
 
     void rseek(size_t pos)
         requires (cvt_cpt::support_positioning<KernelType>)
     {
         BT::assert_not_tainted();
+        // See seek() above: only taint when rseek() succeeds but tell() fails.
         BT::m_kernel.rseek(pos);
-        m_pos = BT::m_kernel.tell();
+        try
+        {
+            m_pos = BT::m_kernel.tell();
+        }
+        catch (...)
+        {
+            BT::set_tainted();
+            throw;
+        }
     }
 private:
     size_t                     m_pos;


### PR DESCRIPTION
chacha20_cvt:
- key_gen: reject empty key to prevent silent use of SHA-256("") as cipher key
- bos: add iv_len == 0 guard to avoid nullptr being passed to C APIs
- bos: move kernel.get() + short-read check inside the existing try block so an incomplete IV read also triggers cipher clear + set_tainted (previously the short-read path left cipher uncleared and the converter un-tainted, allowing a retry to pick up a corrupted IV from mid-stream)
- get_main: restructure with an outer loop mirroring put_main so that large requests spanning more than max_chunk bytes are fully processed across multiple slices rather than silently truncated to max_chunk bytes

hash_cvt:
- adjust: guard delimiter write with m_has_main_cont so a dump_hash with no preceding data does not emit a bare delimiter without a hash payload
- dump_stream / put_main: replace four C-style casts with reinterpret_cast for consistency with the rest of the codebase

vigenere_cvt:
- seek / rseek: taint only when tell() fails after a successful seek (kernel has moved but m_pos is stale); let seek() failures propagate without tainting so callers can handle expected seek errors and reuse the converter