### PR TITLE
fix(cvt): tighten attach/bos exception safety and fix vigenere UB

### DIFF
--- a/include/cvt/abs_cvt.h
+++ b/include/cvt/abs_cvt.h
@@ -922,10 +922,18 @@ namespace IOv2
          */
         void attach(device_type&& dev = device_type{})
         {
-            m_kernel.attach(std::move(dev));
-            m_io_status = io_status::neutral;
-            m_is_bos_done = false;
-            m_is_tainted = false;
+            try
+            {
+                m_kernel.attach(std::move(dev));
+                m_io_status = io_status::neutral;
+                m_is_bos_done = false;
+                m_is_tainted = false;
+            }
+            catch (...)
+            {
+                m_is_tainted = true;
+                throw;
+            }
         }
 
         /**

--- a/include/cvt/code_cvt.h
+++ b/include/cvt/code_cvt.h
@@ -837,8 +837,13 @@ public:
      */
     void attach(device_type&& dev = device_type{})
     {
-        close_stream();
+        std::exception_ptr close_err;
+        try { close_stream(); }
+        catch (...) { close_err = std::current_exception(); }
+
         BT::attach(std::move(dev));
+
+        if (close_err) std::rethrow_exception(close_err);
     }
 
     /**

--- a/include/cvt/crypt/chacha20_cvt.h
+++ b/include/cvt/crypt/chacha20_cvt.h
@@ -85,6 +85,8 @@ public:
 public:
     void attach(device_type&& dev = device_type{})
     {
+        BT::attach(std::move(dev));
+
         if (!m_cipher || m_key.empty())
             throw cvt_error("chacha20_cvt::attach fail: cipher or key missing (moved-from object?)");
         else
@@ -99,8 +101,6 @@ public:
                 throw;
             }
         }
-
-        BT::attach(std::move(dev));
     }
 
     std::pair<device_type, std::exception_ptr> detach() noexcept
@@ -117,10 +117,11 @@ public:
 
     io_status bos()
     {
-        if (!m_cipher)
-            throw cvt_error("chacha20_cvt::bos fail: cipher not initialized (moved-from object?)");
-
         BT::bos();
+
+        if (!m_cipher || m_key.empty())
+            throw cvt_error("chacha20_cvt::bos fail: cipher or key missing (moved-from object?)");
+
         const size_t iv_len = m_cipher->default_iv_length();
         if (iv_len == 0)
             throw cvt_error("chacha20_cvt::bos fail: cipher reports zero IV length");
@@ -153,11 +154,11 @@ public:
         {
             if constexpr (cvt_cpt::support_put<KernelType>)
             {
-                Botan::AutoSeeded_RNG rng;
-                rng.randomize(reinterpret_cast<uint8_t*>(iv_buf.data()), iv_len);
-
                 try
                 {
+                    Botan::AutoSeeded_RNG rng;
+                    rng.randomize(reinterpret_cast<uint8_t*>(iv_buf.data()), iv_len);
+
                     m_cipher->set_key(m_key);
                     m_cipher->set_iv(reinterpret_cast<const uint8_t*>(iv_buf.data()), iv_len);
 
@@ -176,11 +177,6 @@ public:
         else
             throw cvt_error("chacha20_cvt::bos fail: neither in input nor output mode");
         return BT::m_io_status;
-    }
-
-    void main_cont_beg()
-    {
-        BT::main_cont_beg();
     }
 
 // optional methods

--- a/include/cvt/crypt/hash_cvt.h
+++ b/include/cvt/crypt/hash_cvt.h
@@ -7,6 +7,7 @@
 #include <exception>
 #include <limits>
 #include <memory>
+#include <optional>
 #include <string>
 #include <type_traits>
 #include <utility>
@@ -39,21 +40,22 @@ struct set_hash_fmt : cvt_behavior
 
 struct dump_hash : cvt_behavior
 {
-    explicit dump_hash(uint8_t delim)
+    explicit dump_hash(std::optional<uint8_t> delim = std::nullopt)
         : m_delim(delim) {}
 
-    uint8_t m_delim;
+    std::optional<uint8_t> m_delim;
 };
 
 template <io_converter KernelType, typename TInt = typename KernelType::internal_type>
     requires (std::is_integral_v<typename KernelType::internal_type> &&
-              sizeof(typename KernelType::internal_type) == sizeof(uint8_t))
+              sizeof(typename KernelType::internal_type) == sizeof(uint8_t) &&
+              std::is_trivially_copyable_v<TInt> &&
+              std::has_unique_object_representations_v<TInt> &&
+              cvt_cpt::support_put<KernelType>)
 class hash_cvt : public abs_cvt<hash_cvt<KernelType, TInt>, KernelType, TInt, false, false>
 {
     using BT = abs_cvt<hash_cvt<KernelType, TInt>, KernelType, TInt, false, false>;
     friend BT;  // for put_main
-
-    static_assert(cvt_cpt::support_put<KernelType>);
 
 public:
     using device_type = typename KernelType::device_type;
@@ -138,33 +140,34 @@ public:
     io_status bos()
     {
         auto res = BT::bos();
-        if (res != io_status::output)
-            throw cvt_error("hash_cvt::bos fail: only output mode is supported");
-        return io_status::output;
-    }
+        try
+        {
+            if (res != io_status::output)
+                throw cvt_error("hash_cvt::bos fail: only output mode is supported");
 
-    void main_cont_beg()
-    {
-        BT::main_cont_beg();
+            if (!m_hash)
+                throw cvt_error("hash_cvt::bos fail: hash not initialized (moved-from object?)");
+            m_hash->clear();
+        }
+        catch (...)
+        {
+            BT::set_tainted();
+            throw;
+        }
+        return io_status::output;
     }
 
     void attach(device_type&& dev = device_type{})
     {
-        // 1. Try to finalize the old session; capture any failure so we can
-        //    still install the new device (zlib_cvt::attach convention:
-        //    propagating here would let `dev`, already moved into our
-        //    parameter, be destroyed during stack unwinding).
         std::exception_ptr dump_err;
         try { if (m_has_main_cont) dump_stream(); }
         catch (...) { dump_err = std::current_exception(); }
 
+        BT::attach(std::move(dev));
+
         m_has_main_cont = false;
         m_out_fmt = hash_fmt::lower_hex;
 
-        // 2. Defense-in-depth: clear any residual hash state. If clear()
-        //    throws, the converter is in an unknown state — mark it tainted
-        //    and propagate immediately; BT::attach() will not be called and
-        //    the incoming device will be lost.
         if (m_hash)
         {
             try { m_hash->clear(); }
@@ -174,8 +177,6 @@ public:
                 throw;
             }
         }
-
-        BT::attach(std::move(dev));
 
         if (dump_err)  std::rethrow_exception(dump_err);
     }
@@ -214,7 +215,10 @@ public:
             {
                 dump_stream();
                 if (dh_ptr->m_delim)
-                    BT::m_kernel.put(reinterpret_cast<const external_type*>(&dh_ptr->m_delim), 1);
+                {
+                    const uint8_t delim = *dh_ptr->m_delim;
+                    BT::m_kernel.put(reinterpret_cast<const external_type*>(&delim), 1);
+                }
             }
         }
 
@@ -258,7 +262,10 @@ private:
         // Use copy_state()->final() to preserve original state until put() succeeds.
         // This provides strong exception safety: if put() fails, state is unchanged
         // and the operation can be retried.
-        auto digest = m_hash->copy_state()->final();
+        auto cp_state = m_hash->copy_state();
+        if (!cp_state)
+            throw cvt_error("hash_cvt::dump_stream fail: cannot copy hash state");
+        auto digest = cp_state->final();
         if (digest.empty())
             throw cvt_error("hash_cvt::dump_stream fail: cannot get hash result");
 

--- a/include/cvt/crypt/vigenere_cvt.h
+++ b/include/cvt/crypt/vigenere_cvt.h
@@ -49,24 +49,37 @@ public:
     vigenere_cvt(KernelType dev, std::basic_string_view<internal_type> s)
         : BT(std::move(dev))
         , m_pos(0)
-        , m_key(s.begin(), s.end())
-    {
-        if (s.empty())
-            throw cvt_error("Cannot create vigenere converter with empty key");
-    }
+        , m_key([s]
+                {
+                    if (s.empty())
+                        throw cvt_error("vigenere_cvt: cannot create vigenere converter with empty key");
+                    return std::vector<internal_type>(s.begin(), s.end());
+                }())
+    {}
 
 // mandatory methods
 public:
     void attach(device_type&& dev = device_type{})
     {
-        m_pos = 0;
         BT::attach(std::move(dev));
+        try
+        {
+            m_pos = 0;
+            if (m_key.empty())
+                throw cvt_error("vigenere_cvt::attach fail: empty key");
+        }
+        catch (...)
+        {
+            BT::set_tainted();
+            throw;
+        }
     }
 
     std::pair<device_type, std::exception_ptr> detach() noexcept
     {
+        auto res = BT::detach();
         m_pos = 0;
-        return BT::detach();
+        return res;
     }
 
     void main_cont_beg()
@@ -77,6 +90,23 @@ public:
 
 // optional methods
 private:
+    // Vigenère arithmetic is performed in the unsigned domain to avoid
+    // signed integer overflow UB when internal_type is a signed multi-byte
+    // type (e.g. int32_t). Unsigned subtraction/addition is well-defined
+    // (modulo 2^N wrap), and the back-cast to internal_type is well-defined
+    // under C++20's two's-complement guarantee. Encryption (add_wrap) and
+    // decryption (sub_wrap) remain exact inverses in the mod-2^N group.
+    static constexpr internal_type sub_wrap(internal_type a, internal_type b) noexcept
+    {
+        using U = std::make_unsigned_t<internal_type>;
+        return static_cast<internal_type>(static_cast<U>(a) - static_cast<U>(b));
+    }
+    static constexpr internal_type add_wrap(internal_type a, internal_type b) noexcept
+    {
+        using U = std::make_unsigned_t<internal_type>;
+        return static_cast<internal_type>(static_cast<U>(a) + static_cast<U>(b));
+    }
+
     size_t get_main(cvt_reader<KernelType>& reader, internal_type* to, size_t to_max)
         requires (cvt_cpt::support_get<KernelType>)
     {
@@ -95,7 +125,8 @@ private:
             for (size_t i = 0; i < cur_size; ++i)
             {
                 size_t pos = (m_pos++) % m_key.size();
-                *to++ = (*ptr++) - m_key[pos];
+                const internal_type src = *ptr++;
+                *to++ = sub_wrap(src, m_key[pos]);
             }
             total_count += cur_size;
         }
@@ -119,7 +150,8 @@ private:
             for (size_t i = 0; i < dest_size; ++i)
             {
                 size_t pos = (m_pos++) % m_key.size();
-                *ptr++ = (*to++) + m_key[pos];
+                const internal_type src = *to++;
+                *ptr++ = add_wrap(src, m_key[pos]);
             }
             total_count += dest_size;
         }


### PR DESCRIPTION
- abs_cvt::attach: mark tainted if kernel attach throws
- code_cvt::attach: capture close_stream error so dev is not lost on stack unwind; rethrow afterwards
- chacha20_cvt: attach now performs BT::attach first to preserve dev, cipher clear failure taints; bos moves RNG construction into try; bos checks both cipher and key; drop trivial main_cont_beg override
- hash_cvt: dump_hash delim becomes std::optional<uint8_t> so 0x00 is a valid delimiter; strengthen TInt requires with trivially_copyable and has_unique_object_representations; bos clears hash state and taints on failure; attach reorders BT::attach before hash clear; dump_stream null-checks copy_state()
- vigenere_cvt: replace signed arithmetic with unsigned wrap helpers to avoid signed integer overflow UB on multi-byte signed internal_type; attach checks for empty key (moved-from guard); detach reorders