### PR TITLE
refactor(cvt): unify detach protocol in abs_cvt and rename do_flush to flush_impl

### DIFF
--- a/include/cvt/abs_cvt.h
+++ b/include/cvt/abs_cvt.h
@@ -628,6 +628,65 @@ namespace IOv2
      *         lower layer before the lower layer is torn down — otherwise the
      *         drained data has nowhere to go.
      *
+     * @par CRTP 可选钩子 / CRTP Optional Hooks
+     * @lang{ZH}
+     * 派生类可实现以下零个或多个私有钩子函数。`abs_cvt` 通过
+     * `if constexpr (requires { ... })` 在编译期检测各钩子是否存在，并在对应的
+     * 生命周期节点调用。所有钩子须声明为 `private`，并在派生类中添加
+     * `friend BT` 授权 `abs_cvt` 访问。
+     *
+     * - **`get_main(cvt_reader<KernelType>&, internal_type*, size_t) -> size_t`**
+     *   由 `abs_cvt::get` 在主内容阶段调用，执行解码逻辑。
+     *   返回值为实际解码的 `internal_type` 元素个数。
+     *   允许抛出异常；调用方会正确传播。
+     *
+     * - **`put_main(cvt_writer<KernelType>&, const internal_type*, size_t)`**
+     *   由 `abs_cvt::put` 在主内容阶段调用，执行编码逻辑。
+     *   禁止自行调用 `cvt_writer::commit()`；commit 由 `abs_cvt::put` 在成功路径统一负责。
+     *   允许抛出异常；调用方会设置污染标志并传播。
+     *
+     * - **`flush_impl()`**
+     *   由 `abs_cvt::flush` 在调用 `m_kernel.flush()` 之前调用，执行派生层特有的冲刷逻辑
+     *   （例如 zlib sync flush）。允许抛出异常；调用方会设置污染标志并传播。
+     *
+     * - **`detach_impl() noexcept -> std::exception_ptr`**
+     *   由 `abs_cvt::detach` 在调用 `m_kernel.detach()` 之前调用，执行派生层清理。
+     *   **必须声明为 `noexcept`**（由 `abs_cvt` 内的 `static_assert` 强制）。
+     *   捕获到的异常须以 `std::exception_ptr` 形式返回；调用方按 first-failure-wins
+     *   与 kernel 层异常合并后统一透传。无异常时返回 `nullptr`。
+     * @endif
+     *
+     * @lang{EN}
+     * Derived classes may implement zero or more of the following private hooks.
+     * `abs_cvt` detects each hook at compile time via `if constexpr (requires { ... })`
+     * and invokes it at the documented lifecycle point. All hooks must be declared
+     * `private`; the derived class must add `friend BT` to grant `abs_cvt` access.
+     *
+     * - **`get_main(cvt_reader<KernelType>&, internal_type*, size_t) -> size_t`**
+     *   Called by `abs_cvt::get` during the main-content phase to perform decoding.
+     *   Returns the number of `internal_type` elements actually decoded.
+     *   May throw; the caller propagates the exception normally.
+     *
+     * - **`put_main(cvt_writer<KernelType>&, const internal_type*, size_t)`**
+     *   Called by `abs_cvt::put` during the main-content phase to perform encoding.
+     *   Must NOT call `cvt_writer::commit()` itself; `abs_cvt::put` is the sole
+     *   committer on the success path. May throw; the caller sets the taint flag
+     *   and rethrows.
+     *
+     * - **`flush_impl()`**
+     *   Called by `abs_cvt::flush` before `m_kernel.flush()`, to perform any
+     *   derived-layer flushing (e.g., a zlib sync flush).
+     *   May throw; the caller sets the taint flag and rethrows.
+     *
+     * - **`detach_impl() noexcept -> std::exception_ptr`**
+     *   Called by `abs_cvt::detach` before `m_kernel.detach()`, to perform
+     *   derived-layer cleanup. **Must be declared `noexcept`** (enforced by a
+     *   `static_assert` inside `abs_cvt`). Any captured exception must be returned
+     *   as a `std::exception_ptr`; the caller merges it with the kernel-layer
+     *   exception under first-failure-wins and forwards the combined result.
+     *   Return `nullptr` if none.
+     * @endif
+     *
      * @par Exception Safety / Tainted State
      * Output streaming cannot in general offer the strong exception
      * guarantee: a single `put` may auto-flush several chunks to the kernel
@@ -848,37 +907,53 @@ namespace IOv2
          * @lang{ZH}
          * 分离并返回底层设备，同时将转换器状态重置为初始状态。
          *
-         * 调用后 `m_io_status` 恢复为 `neutral`，`m_is_bos_done` 恢复为 `false`。
+         * 调用后 `m_io_status` 恢复为 `neutral`，`m_is_bos_done` 与 `m_is_tainted`
+         * 恢复为 `false`。
          *
-         * 本函数为 `noexcept`：底层 kernel `detach()` 的清理异常通过其返回值的 `exception_ptr`
-         * 透传，本层不再额外捕获或转换（first-failure-wins）。设备始终通过返回值的 `first`
-         * 无条件交还给调用方。
+         * 本函数为 `noexcept`，清理异常通过返回值的 `exception_ptr` 透传（first-failure-wins）：
+         * - 若派生类实现了 `detach_impl() noexcept`，则先调用之；其异常优先于 kernel 的异常。
+         *   编译器会通过 `static_assert` 强制要求 `detach_impl()` 必须声明为 `noexcept`。
+         * - 随后调用 `m_kernel.detach()` 完成 kernel 层的分离与清理。
+         *
+         * 设备始终通过返回值的 `first` 无条件交还给调用方。
          * @endif
          *
          * @lang{EN}
          * Detach and return the underlying device, resetting the converter state
          * to its initial state.
          *
-         * After the call `m_io_status` is reset to `neutral` and `m_is_bos_done`
-         * is reset to `false`.
+         * After the call `m_io_status` is reset to `neutral`, and both `m_is_bos_done`
+         * and `m_is_tainted` are reset to `false`.
          *
-         * This function is `noexcept`: the kernel's cleanup exception (if any) is
-         * forwarded unchanged via the returned `exception_ptr` (first-failure-wins);
-         * this layer does not capture or rewrap it. The device is always handed back
-         * unconditionally via `first`.
+         * This function is `noexcept`; cleanup exceptions are forwarded via the returned
+         * `exception_ptr` (first-failure-wins):
+         * - If the derived class implements `detach_impl() noexcept`, it is called first;
+         *   its exception (if any) takes priority over the kernel's exception.
+         *   A `static_assert` enforces that `detach_impl()` must be declared `noexcept`.
+         * - `m_kernel.detach()` is then called to complete kernel-level detachment and cleanup.
+         *
+         * The device is always handed back unconditionally via `first`.
          * @endif
          *
          * @return
-         * @lang{ZH} pair：`first` 为已从 kernel 中分离的底层设备对象（右值），`second` 为底层清理捕获的首个异常（`nullptr` 表示无异常）。 @endif
-         * @lang{EN} A pair: `first` is the device detached from the kernel (rvalue); `second` is the first exception captured by the underlying cleanup (`nullptr` if none). @endif
+         * @lang{ZH} pair：`first` 为已从 kernel 中分离的底层设备对象（右值），`second` 为清理过程中捕获的首个异常（`nullptr` 表示无异常）。 @endif
+         * @lang{EN} A pair: `first` is the device detached from the kernel (rvalue); `second` is the first exception captured during cleanup (`nullptr` if none). @endif
          */
         std::pair<device_type, std::exception_ptr> detach() noexcept
         {
-            auto result = m_kernel.detach();
+            std::exception_ptr local_err = nullptr;
+            if constexpr (requires(CurrentType& t) { t.detach_impl(); })
+            {
+                static_assert(noexcept(std::declval<CurrentType&>().detach_impl()),
+                              "detach_impl() must be noexcept");
+                local_err = static_cast<CurrentType*>(this)->detach_impl();
+            }
+
+            auto [dev, inner_err] = m_kernel.detach();
             m_io_status = io_status::neutral;
             m_is_bos_done = false;
             m_is_tainted = false;
-            return result;
+            return { std::move(dev), local_err ? local_err : inner_err };
         }
 
         /**
@@ -1336,9 +1411,9 @@ namespace IOv2
          *
          * 仅在派生类实现了 `put_main` 时可用。若当前不处于输出模式，则为空操作直接返回。
          *
-         * 若派生类实现了 `do_flush()`，则先调用 `do_flush()` 执行派生类特定的刷出逻辑
+         * 若派生类实现了 `flush_impl()`，则先调用 `flush_impl()` 执行派生类特定的刷出逻辑
          * （例如 zlib 的 sync flush），再调用 `m_kernel.flush()` 将数据推送至底层设备。
-         * 若派生类未实现 `do_flush()`，则直接调用 `m_kernel.flush()`。
+         * 若派生类未实现 `flush_impl()`，则直接调用 `m_kernel.flush()`。
          *
          * 若刷出过程中抛出异常，转换器将进入污染状态，后续操作均不可用。
          * @endif
@@ -1349,10 +1424,10 @@ namespace IOv2
          * Only available when the derived class implements `put_main`. If the converter
          * is not currently in output mode, this is a no-op and returns immediately.
          *
-         * If the derived class implements `do_flush()`, it is called first to perform
+         * If the derived class implements `flush_impl()`, it is called first to perform
          * any derived-class-specific flushing (e.g., a zlib sync flush), after which
          * `m_kernel.flush()` is called to push data through to the underlying device.
-         * If no `do_flush()` is provided, `m_kernel.flush()` is called directly.
+         * If no `flush_impl()` is provided, `m_kernel.flush()` is called directly.
          *
          * If an exception is thrown during flushing, the converter enters a tainted
          * state and further operations are unavailable.
@@ -1369,8 +1444,8 @@ namespace IOv2
             assert_not_tainted();
             try
             {
-                if constexpr (requires(CurrentType& t) { t.do_flush(); })
-                    static_cast<CurrentType*>(this)->do_flush();
+                if constexpr (requires(CurrentType& t) { t.flush_impl(); })
+                    static_cast<CurrentType*>(this)->flush_impl();
                 m_kernel.flush();
             }
             catch (...)

--- a/include/cvt/code_cvt.h
+++ b/include/cvt/code_cvt.h
@@ -848,38 +848,6 @@ public:
 
     /**
      * @lang{ZH}
-     * 关闭当前流并移除底层设备，返回该设备的所有权。
-     *
-     * 本函数为 `noexcept`：`close_stream()` 的清理异常被捕获为返回值 `second`
-     * 中的 `exception_ptr`，并按 first-failure-wins 与底层 `BT::detach()` 返回的
-     * 异常合并（本层捕获到的异常优先）。设备始终通过返回值 `first` 无条件交还。
-     *
-     * @return pair：`first` 为底层设备所有权，`second` 为捕获的首个清理异常（`nullptr` 表示无异常）。
-     * @endif
-     *
-     * @lang{EN}
-     * Close the current stream, remove the underlying device, and return
-     * ownership of it.
-     *
-     * This function is `noexcept`: any exception from `close_stream()` is captured
-     * into the returned pair's `second` (`exception_ptr`) and merged under
-     * first-failure-wins with the one returned by `BT::detach()` (local exception
-     * wins). The device is always handed back unconditionally via `first`.
-     *
-     * @return A pair: `first` is ownership of the underlying device; `second` is the first captured cleanup exception (`nullptr` if none).
-     * @endif
-     */
-    std::pair<device_type, std::exception_ptr> detach() noexcept
-    {
-        std::exception_ptr local_err;
-        try { close_stream(); }
-        catch (...) { local_err = std::current_exception(); }
-        auto [dev, inner_err] = BT::detach();
-        return { std::move(dev), local_err ? local_err : inner_err };
-    }
-
-    /**
-     * @lang{ZH}
      * 建立初始 IO 状态（BOS：Beginning-Of-Stream）。
      * 这是使用转换器之前必须首先调用的函数。
      *
@@ -919,6 +887,36 @@ public:
 
 // 可选方法（由 abs_cvt 通过 CRTP 调用）/ Optional methods (called by abs_cvt via CRTP)
 private:
+    /**
+     * @lang{ZH}
+     * `abs_cvt::detach()` 的 CRTP 钩子，在 kernel 层 `detach()` 之前调用。
+     *
+     * 负责执行 `code_cvt` 层面的清理（`close_stream()`），并将捕获到的异常以
+     * `exception_ptr` 形式返回；调用方（`abs_cvt::detach()`）负责按 first-failure-wins
+     * 与 kernel 层异常合并。本函数为 `noexcept`，此约束由 `abs_cvt` 的 `static_assert` 强制。
+     *
+     * @return 捕获到的首个清理异常；无异常时为 `nullptr`。
+     * @endif
+     *
+     * @lang{EN}
+     * CRTP hook for `abs_cvt::detach()`, called before the kernel-level `detach()`.
+     *
+     * Performs `code_cvt`-layer cleanup (`close_stream()`) and returns any captured
+     * exception as an `exception_ptr`; the caller (`abs_cvt::detach()`) merges it
+     * with the kernel-layer exception under first-failure-wins.
+     * Must be `noexcept` — enforced by a `static_assert` in `abs_cvt`.
+     *
+     * @return The first captured cleanup exception, or `nullptr` if none.
+     * @endif
+     */
+    std::exception_ptr detach_impl() noexcept
+    {
+        std::exception_ptr local_err = nullptr;
+        try { close_stream(); }
+        catch (...) { local_err = std::current_exception(); }
+        return local_err;
+    }
+
     /**
      * @lang{ZH}
      * 将内部字符序列编码为外部字节并写入底层缓冲区（由 `abs_cvt::put` 通过 CRTP 调用）。

--- a/include/cvt/comp/zlib_cvt.h
+++ b/include/cvt/comp/zlib_cvt.h
@@ -248,7 +248,7 @@ class zlib_cvt : public abs_cvt<zlib_cvt<KernelType, TInt>, KernelType, TInt, fa
     /**
      * @lang{ZH}
      * 作用域退出时将 `m_strm` 的输入/输出指针和计数清零的 RAII 守卫。
-     * 确保 `get_main`、`put_main`、`do_flush` 抛出异常时，`m_strm` 不会
+     * 确保 `get_main`、`put_main`、`flush_impl` 抛出异常时，`m_strm` 不会
      * 持有指向已离开作用域的读缓冲区、写缓冲区或用户缓冲区的悬空指针。
      * 不触及 `m_strm` 自身——zlib 流对象的清理由 `close_stream`、
      * `inflate_guard` 和 `deflate_guard` 负责。
@@ -256,7 +256,7 @@ class zlib_cvt : public abs_cvt<zlib_cvt<KernelType, TInt>, KernelType, TInt, fa
      *
      * @lang{EN}
      * RAII guard that clears `m_strm`'s input/output pointers and counts on scope exit.
-     * Ensures that when `get_main`, `put_main`, or `do_flush` throw an exception,
+     * Ensures that when `get_main`, `put_main`, or `flush_impl` throw an exception,
      * `m_strm` is not left holding dangling pointers into reader, writer, or user
      * buffers that have since gone out of scope.
      * Does NOT touch `m_strm` itself — cleanup of the zlib stream object is the
@@ -546,32 +546,6 @@ public:
 
     /**
      * @lang{ZH}
-     * 分离底层设备，同时最终化当前 zlib 流（`noexcept`）。
-     * 先调用 `close_stream()`（捕获异常），再调用基类 `BT::detach()` 分离设备。
-     * `close_stream` 的错误优先于内核的错误返回（first-failure-wins）。
-     * @endif
-     *
-     * @lang{EN}
-     * Detach the underlying device while finalizing the current zlib stream (`noexcept`).
-     * Calls `close_stream()` first (capturing any exception), then calls the base-class
-     * `BT::detach()` to detach the device.
-     * The `close_stream` error takes precedence over the kernel's error (first-failure-wins).
-     * @endif
-     *
-     * @return 包含已分离设备和首个捕获异常的 pair（`nullptr` 表示无异常）。
-     *         / A pair containing the detached device and the first captured exception (`nullptr` if none).
-     */
-    std::pair<device_type, std::exception_ptr> detach() noexcept
-    {
-        std::exception_ptr local_err;
-        try { close_stream(); }
-        catch (...) { local_err = std::current_exception(); }
-        auto [dev, inner_err] = BT::detach();
-        return { std::move(dev), local_err ? local_err : inner_err };
-    }
-
-    /**
-     * @lang{ZH}
      * 调整转换器行为参数。
      * 若 `acc` 为 `zlib_sync_flush` 实例，则更新 `m_sync_flush` 标志；
      * 同时将 `acc` 转发给基类 `BT::adjust()`。
@@ -661,7 +635,7 @@ public:
             // input/output, or restores neutral and taints the converter on failure.
             // Reaching here with m_io_status == output therefore implies m_strm is
             // a fully-initialized zlib stream; if the converter were tainted,
-            // BT::flush() would throw before do_flush() dereferences m_strm.
+            // BT::flush() would throw before flush_impl() dereferences m_strm.
             assert(m_strm);
             BT::flush();
         }
@@ -713,7 +687,7 @@ public:
         // After BT::bos() succeeds, m_io_status is no longer neutral. Any failure
         // from here on must restore the invariant "m_io_status != neutral implies
         // m_strm is a fully-initialized zlib stream" before propagating, otherwise
-        // copy/assign, do_flush, and the direction-switch branches in
+        // copy/assign, flush_impl, and the direction-switch branches in
         // abs_cvt::get/put will dereference a null m_strm. Reset the status and
         // taint the converter so subsequent get/put/flush refuse to run until
         // the caller reattaches a device.
@@ -836,6 +810,36 @@ public:
 
 // optional methods
 private:
+    /**
+     * @lang{ZH}
+     * `abs_cvt::detach()` 的 CRTP 钩子，在 kernel 层 `detach()` 之前调用。
+     *
+     * 负责执行 `zlib_cvt` 层的清理（`close_stream()`），并将捕获到的异常以
+     * `exception_ptr` 形式返回；调用方（`abs_cvt::detach()`）负责按 first-failure-wins
+     * 与 kernel 层异常合并。本函数为 `noexcept`，此约束由 `abs_cvt` 的 `static_assert` 强制。
+     *
+     * @return 捕获到的首个清理异常；无异常时为 `nullptr`。
+     * @endif
+     *
+     * @lang{EN}
+     * CRTP hook for `abs_cvt::detach()`, called before the kernel-level `detach()`.
+     *
+     * Performs `zlib_cvt`-layer cleanup (`close_stream()`) and returns any captured
+     * exception as an `exception_ptr`; the caller (`abs_cvt::detach()`) merges it
+     * with the kernel-layer exception under first-failure-wins.
+     * Must be `noexcept` — enforced by a `static_assert` in `abs_cvt`.
+     *
+     * @return The first captured cleanup exception, or `nullptr` if none.
+     * @endif
+     */
+    std::exception_ptr detach_impl() noexcept
+    {
+        std::exception_ptr local_err = nullptr;
+        try { close_stream(); }
+        catch (...) { local_err = std::current_exception(); }
+        return local_err;
+    }
+
     /**
      * @lang{ZH}
      * 主内容阶段的解压实现（由 `abs_cvt::get` 调用）。
@@ -1070,7 +1074,7 @@ private:
      * For the cost trade-off of this option, see the `zlib_sync_flush` documentation.
      * @endif
      */
-    void do_flush()
+    void flush_impl()
         requires (cvt_cpt::support_put<KernelType>)
     {
         if (m_sync_flush)
@@ -1084,7 +1088,7 @@ private:
             {
                 m_strm->next_out = reinterpret_cast<unsigned char*>(local_buf.data()); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
                 m_strm->avail_out = CHUNK;
-                zerr("zlib_cvt::do_flush fail", deflate(m_strm.get(), Z_SYNC_FLUSH));
+                zerr("zlib_cvt::flush_impl fail", deflate(m_strm.get(), Z_SYNC_FLUSH));
                 const size_t written = CHUNK - m_strm->avail_out;
                 if (written > 0)
                     BT::m_kernel.put(local_buf.data(), written);

--- a/include/cvt/crypt/chacha20_cvt.h
+++ b/include/cvt/crypt/chacha20_cvt.h
@@ -103,18 +103,6 @@ public:
         }
     }
 
-    std::pair<device_type, std::exception_ptr> detach() noexcept
-    {
-        std::exception_ptr local_err;
-        if (m_cipher)
-        {
-            try { m_cipher->clear(); }
-            catch (...) { local_err = std::current_exception(); }
-        }
-        auto [dev, inner_err] = BT::detach();
-        return { std::move(dev), local_err ? local_err : inner_err };
-    }
-
     io_status bos()
     {
         BT::bos();
@@ -181,6 +169,39 @@ public:
 
 // optional methods
 private:
+    /**
+     * @lang{ZH}
+     * `abs_cvt::detach()` 的 CRTP 钩子，在 kernel 层 `detach()` 之前调用。
+     *
+     * 若 `m_cipher` 有效（非 moved-from 状态），调用 `m_cipher->clear()` 清除密钥和 IV 状态；
+     * 异常以 `exception_ptr` 形式返回，由调用方（`abs_cvt::detach()`）按 first-failure-wins
+     * 与 kernel 层异常合并。本函数为 `noexcept`，此约束由 `abs_cvt` 的 `static_assert` 强制。
+     *
+     * @return 捕获到的首个清理异常；无异常时为 `nullptr`。
+     * @endif
+     *
+     * @lang{EN}
+     * CRTP hook for `abs_cvt::detach()`, called before the kernel-level `detach()`.
+     *
+     * If `m_cipher` is valid (not a moved-from object), calls `m_cipher->clear()` to
+     * wipe the key and IV state. Any captured exception is returned as an `exception_ptr`;
+     * the caller (`abs_cvt::detach()`) merges it with the kernel-layer exception under
+     * first-failure-wins. Must be `noexcept` — enforced by a `static_assert` in `abs_cvt`.
+     *
+     * @return The first captured cleanup exception, or `nullptr` if none.
+     * @endif
+     */
+    std::exception_ptr detach_impl() noexcept
+    {
+        std::exception_ptr local_err = nullptr;
+        if (m_cipher)
+        {
+            try { m_cipher->clear(); }
+            catch (...) { local_err = std::current_exception(); }
+        }
+        return local_err;
+    }
+
     size_t get_main(cvt_reader<KernelType>& reader, internal_type* _to, size_t to_max)
         requires (cvt_cpt::support_get<KernelType>)
     {

--- a/include/cvt/crypt/hash_cvt.h
+++ b/include/cvt/crypt/hash_cvt.h
@@ -181,30 +181,6 @@ public:
         if (dump_err)  std::rethrow_exception(dump_err);
     }
 
-    std::pair<device_type, std::exception_ptr> detach() noexcept
-    {
-        std::exception_ptr local_err;
-        try { if (m_has_main_cont) dump_stream(); }
-        catch (...)
-        {
-            local_err = std::current_exception();
-            m_has_main_cont = false;
-            // Clear any residual hash state so a subsequent attach()+put()
-            // does not accumulate on top of half-finished data.  If clear()
-            // itself fails, swallow the exception — we are already in error
-            // recovery from a failed dump_stream(), and surfacing a secondary
-            // failure here would only obscure the primary error.
-            if (m_hash)
-            {
-                try { m_hash->clear(); }
-                catch (...) {} // NOLINT(bugprone-empty-catch)
-            }
-        }
-        m_out_fmt = hash_fmt::lower_hex;
-        auto [dev, inner_err] = BT::detach();
-        return { std::move(dev), local_err ? local_err : inner_err };
-    }
-
     void adjust(const cvt_behavior& acc)
     {
         if (const set_hash_fmt* shf_ptr = dynamic_cast<const set_hash_fmt*>(&acc); shf_ptr)
@@ -227,6 +203,62 @@ public:
 
 // optional methods
 private:
+    /**
+     * @lang{ZH}
+     * `abs_cvt::detach()` 的 CRTP 钩子，在 kernel 层 `detach()` 之前调用。
+     *
+     * 若当前处于主内容阶段（`m_has_main_cont`），尝试调用 `dump_stream()` 将哈希结果写出；
+     * 若 `dump_stream()` 抛出异常，则手动将 `m_has_main_cont` 置为 `false` 并尝试
+     * `m_hash->clear()` 清除残余状态（`clear()` 的异常被吞掉，避免掩盖首要错误）。
+     * 成功路径下 `dump_stream()` 自行置 `m_has_main_cont = false`。
+     * 最后将 `m_out_fmt` 重置为默认值。
+     *
+     * 异常以 `exception_ptr` 形式返回，由调用方（`abs_cvt::detach()`）按 first-failure-wins
+     * 与 kernel 层异常合并。本函数为 `noexcept`，此约束由 `abs_cvt` 的 `static_assert` 强制。
+     *
+     * @return 捕获到的首个清理异常；无异常时为 `nullptr`。
+     * @endif
+     *
+     * @lang{EN}
+     * CRTP hook for `abs_cvt::detach()`, called before the kernel-level `detach()`.
+     *
+     * If currently in the main-content phase (`m_has_main_cont`), attempts to call
+     * `dump_stream()` to write out the hash result. If `dump_stream()` throws, resets
+     * `m_has_main_cont` to `false` and attempts `m_hash->clear()` to wipe residual
+     * state (the `clear()` exception is swallowed to avoid obscuring the primary error).
+     * On the success path, `dump_stream()` itself resets `m_has_main_cont`.
+     * Finally, `m_out_fmt` is reset to its default value.
+     *
+     * Any captured exception is returned as an `exception_ptr`; the caller
+     * (`abs_cvt::detach()`) merges it with the kernel-layer exception under
+     * first-failure-wins. Must be `noexcept` — enforced by a `static_assert` in `abs_cvt`.
+     *
+     * @return The first captured cleanup exception, or `nullptr` if none.
+     * @endif
+     */
+    std::exception_ptr detach_impl() noexcept
+    {
+        std::exception_ptr local_err = nullptr;
+        try { if (m_has_main_cont) dump_stream(); }
+        catch (...)
+        {
+            local_err = std::current_exception();
+            m_has_main_cont = false;
+            // Clear any residual hash state so a subsequent attach()+put()
+            // does not accumulate on top of half-finished data.  If clear()
+            // itself fails, swallow the exception — we are already in error
+            // recovery from a failed dump_stream(), and surfacing a secondary
+            // failure here would only obscure the primary error.
+            if (m_hash)
+            {
+                try { m_hash->clear(); }
+                catch (...) {} // NOLINT(bugprone-empty-catch)
+            }
+        }
+        m_out_fmt = hash_fmt::lower_hex;
+        return local_err;
+    }
+
     void put_main(cvt_writer<KernelType>& /*writer*/, const internal_type* to, size_t to_size)
     {
         if (!m_hash)

--- a/include/cvt/crypt/vigenere_cvt.h
+++ b/include/cvt/crypt/vigenere_cvt.h
@@ -75,13 +75,6 @@ public:
         }
     }
 
-    std::pair<device_type, std::exception_ptr> detach() noexcept
-    {
-        auto res = BT::detach();
-        m_pos = 0;
-        return res;
-    }
-
     void main_cont_beg()
     {
         BT::main_cont_beg();
@@ -90,6 +83,34 @@ public:
 
 // optional methods
 private:
+    /**
+     * @lang{ZH}
+     * `abs_cvt::detach()` 的 CRTP 钩子，在 kernel 层 `detach()` 之前调用。
+     *
+     * 将密钥偏移量 `m_pos` 归零，确保后续 `attach()` 后从密钥起始位置开始加解密。
+     * 本操作不会抛出异常，始终返回 `nullptr`。
+     * 本函数为 `noexcept`，此约束由 `abs_cvt` 的 `static_assert` 强制。
+     *
+     * @return 始终为 `nullptr`。
+     * @endif
+     *
+     * @lang{EN}
+     * CRTP hook for `abs_cvt::detach()`, called before the kernel-level `detach()`.
+     *
+     * Resets the key-offset position `m_pos` to zero so that a subsequent `attach()`
+     * starts encryption/decryption from the beginning of the key.
+     * This operation never throws and always returns `nullptr`.
+     * Must be `noexcept` — enforced by a `static_assert` in `abs_cvt`.
+     *
+     * @return Always `nullptr`.
+     * @endif
+     */
+    std::exception_ptr detach_impl() noexcept
+    {
+        m_pos = 0;
+        return nullptr;
+    }
+
     // Vigenère arithmetic is performed in the unsigned domain to avoid
     // signed integer overflow UB when internal_type is a signed multi-byte
     // type (e.g. int32_t). Unsigned subtraction/addition is well-defined


### PR DESCRIPTION


Introduce a two-layer detach design: abs_cvt::detach() now owns the full protocol (call detach_impl(), then m_kernel.detach(), reset state, merge exceptions under first-failure-wins), while each derived class implements a private noexcept detach_impl() CRTP hook for its own cleanup.

Rename do_flush() to flush_impl() for naming consistency with detach_impl().

Also fixes a pre-existing bug in hash_cvt::detach where `inner_err` (an undefined variable) was returned instead of `local_err`.

Add top-level CRTP hook documentation to abs_cvt listing all hooks (get_main, put_main, flush_impl, detach_impl) with their signatures, call sites, and contracts.