### PR TITLE
refactor(cvt): lift attach logic into abs_cvt via attach_impl hook

### DIFF
--- a/include/cvt/abs_cvt.h
+++ b/include/cvt/abs_cvt.h
@@ -650,10 +650,17 @@ namespace IOv2
      *   （例如 zlib sync flush）。允许抛出异常；调用方会设置污染标志并传播。
      *
      * - **`detach_impl() noexcept -> std::exception_ptr`**
-     *   由 `abs_cvt::detach` 在调用 `m_kernel.detach()` 之前调用，执行派生层清理。
+     *   由 `abs_cvt::detach` 在调用 `m_kernel.detach()` 之前、以及 `abs_cvt::attach`
+     *   在安装新设备之前调用，执行派生层清理（如关闭旧流、重置内部状态）。
      *   **必须声明为 `noexcept`**（由 `abs_cvt` 内的 `static_assert` 强制）。
      *   捕获到的异常须以 `std::exception_ptr` 形式返回；调用方按 first-failure-wins
      *   与 kernel 层异常合并后统一透传。无异常时返回 `nullptr`。
+     *
+     * - **`attach_impl()`**
+     *   由 `abs_cvt::attach` 在新设备安装并重置状态字段之后调用，执行派生层的
+     *   初始化（如验证配置、重置加密上下文）。允许抛出异常；调用方会设置污染
+     *   标志并传播。`detach_impl()` 捕获到的旧流错误会在 `attach_impl()` 成功
+     *   返回后再抛出。
      * @endif
      *
      * @lang{EN}
@@ -679,12 +686,22 @@ namespace IOv2
      *   May throw; the caller sets the taint flag and rethrows.
      *
      * - **`detach_impl() noexcept -> std::exception_ptr`**
-     *   Called by `abs_cvt::detach` before `m_kernel.detach()`, to perform
-     *   derived-layer cleanup. **Must be declared `noexcept`** (enforced by a
-     *   `static_assert` inside `abs_cvt`). Any captured exception must be returned
-     *   as a `std::exception_ptr`; the caller merges it with the kernel-layer
-     *   exception under first-failure-wins and forwards the combined result.
-     *   Return `nullptr` if none.
+     *   Called by `abs_cvt::detach` before `m_kernel.detach()`, and by
+     *   `abs_cvt::attach` before installing the new device, to perform
+     *   derived-layer cleanup (e.g., closing the old stream, resetting internal
+     *   state). **Must be declared `noexcept`** (enforced by a `static_assert`
+     *   inside `abs_cvt`). Any captured exception must be returned as a
+     *   `std::exception_ptr`; the caller merges it with the kernel-layer exception
+     *   under first-failure-wins and forwards the combined result. Return `nullptr`
+     *   if none.
+     *
+     * - **`attach_impl()`**
+     *   Called by `abs_cvt::attach` after the new device has been installed and
+     *   the state fields reset, to perform derived-layer initialization (e.g.,
+     *   validating configuration, resetting a cipher context). May throw; the
+     *   caller sets the taint flag and rethrows. Any error captured by
+     *   `detach_impl()` for the old stream is rethrown only after `attach_impl()`
+     *   returns successfully.
      * @endif
      *
      * @par Exception Safety / Tainted State
@@ -958,37 +975,41 @@ namespace IOv2
 
         /**
          * @lang{ZH}
-         * 将新设备附加到转换器，并重置转换器状态。
+         * 将新设备附加到转换器，并重置转换器状态。执行顺序如下：
          *
+         * 1. 若派生类实现了 `detach_impl() noexcept`，先调用之，捕获并暂存其异常
+         *    （first-failure-wins）。
+         * 2. 调用 `m_kernel.attach()` 安装新设备，并将 `m_io_status`、`m_is_bos_done`、
+         *    `m_is_tainted` 重置为初始值。若此步抛出，异常直接传播，`m_is_tainted` 被设置。
+         * 3. 若派生类实现了 `attach_impl()`，调用之执行派生层初始化。若此步抛出，
+         *    `m_is_tainted` 被设置并传播。
+         * 4. 若步骤 1 捕获到异常，在步骤 2–3 均成功后重新抛出。
+         *
+         * 原设备在 `m_kernel.attach()` 内部静默析构，不会归还调用方。若需要保留
+         * 原设备，应先单独调用 `detach()` 取得设备，再调用本函数装入新设备。
          * 若 `dev` 为默认构造值（空设备），则等效于清除当前设备。
-         * 调用后 `m_io_status` 恢复为 `neutral`，`m_is_bos_done` 恢复为 `false`，
-         * `m_is_tainted` 恢复为 `false`。
-         *
-         * 原设备在本函数内部由 kernel 在其 `detach()` 阶段静默析构。若需要保留
-         * 原设备，调用方应先单独调用 `detach()` 取得设备，再调用本函数装入新设备。
-         *
-         * 异常：若底层 kernel 的 `detach()` 在清理原设备时捕获到异常，kernel 的
-         * `attach()` 会将其重新抛出，本函数透传该异常；此时本层的状态字段
-         * （`m_io_status`、`m_is_bos_done`、`m_is_tainted`）不会被本层重置。
          * @endif
          *
          * @lang{EN}
          * Attach a new device to the converter and reset the converter state.
+         * The call sequence is:
          *
-         * Passing a default-constructed (empty) `dev` is equivalent to clearing
-         * the current device. After the call `m_io_status` is reset to `neutral`,
-         * `m_is_bos_done` is reset to `false`, and `m_is_tainted` is reset to `false`.
+         * 1. If the derived class implements `detach_impl() noexcept`, call it first
+         *    and stash any returned exception (first-failure-wins).
+         * 2. Call `m_kernel.attach()` to install the new device and reset
+         *    `m_io_status`, `m_is_bos_done`, and `m_is_tainted` to their initial
+         *    values. If this step throws, the exception propagates and
+         *    `m_is_tainted` is set.
+         * 3. If the derived class implements `attach_impl()`, call it to perform
+         *    derived-layer initialization. If this step throws, `m_is_tainted` is
+         *    set and the exception propagates.
+         * 4. If step 1 captured an exception, rethrow it after steps 2–3 succeed.
          *
-         * The previously held device is silently destroyed by the kernel inside
-         * its `detach()` step. Callers who need to preserve the old device must
-         * call `detach()` first to retrieve it, then call this function to install
-         * the new one.
-         *
-         * Exceptions: if the underlying kernel's `detach()` captures an exception
-         * while cleaning up the old device, the kernel's `attach()` rethrows it
-         * and this function propagates it through; in that case this layer's
-         * state fields (`m_io_status`, `m_is_bos_done`, `m_is_tainted`) are not
-         * reset by this layer.
+         * The previously held device is silently destroyed inside `m_kernel.attach()`
+         * and is not returned to the caller. Callers who need to preserve the old
+         * device must call `detach()` first to retrieve it, then call this function
+         * to install the new one. Passing a default-constructed (empty) `dev` is
+         * equivalent to clearing the current device.
          * @endif
          *
          * @param dev

--- a/include/cvt/abs_cvt.h
+++ b/include/cvt/abs_cvt.h
@@ -997,18 +997,31 @@ namespace IOv2
          */
         void attach(device_type&& dev = device_type{})
         {
+            std::exception_ptr local_err = nullptr;
+            if constexpr (requires(CurrentType& t) { t.detach_impl(); })
+            {
+                static_assert(noexcept(std::declval<CurrentType&>().detach_impl()),
+                              "detach_impl() must be noexcept");
+                local_err = static_cast<CurrentType*>(this)->detach_impl();
+            }
+
             try
             {
                 m_kernel.attach(std::move(dev));
                 m_io_status = io_status::neutral;
                 m_is_bos_done = false;
                 m_is_tainted = false;
+
+                if constexpr (requires(CurrentType& t) { t.attach_impl(); })
+                    static_cast<CurrentType*>(this)->attach_impl();
             }
             catch (...)
             {
                 m_is_tainted = true;
                 throw;
             }
+
+            if (local_err) std::rethrow_exception(local_err);
         }
 
         /**

--- a/include/cvt/code_cvt.h
+++ b/include/cvt/code_cvt.h
@@ -811,43 +811,6 @@ public:
 public:
     /**
      * @lang{ZH}
-     * 关闭当前流并替换底层设备为 `dev`。
-     *
-     * 本函数不归还原设备——原设备由 `BT::attach()` 在内部静默析构。如需保留
-     * 原设备，调用方应先调用 `detach()` 取得设备，再调用本函数装入新设备。
-     *
-     * 异常：`close_stream()` 或 `BT::attach()` 抛出的异常会透传给调用方。
-     *
-     * @param dev 新的底层设备（默认构造即为空设备）。
-     * @endif
-     *
-     * @lang{EN}
-     * Close the current stream and replace the underlying device with `dev`.
-     *
-     * This function does NOT hand the old device back to the caller — the old
-     * device is silently destroyed inside `BT::attach()`. Callers who need to
-     * preserve the old device must call `detach()` first to retrieve it, then
-     * call this function to install the new device.
-     *
-     * Exceptions: any exception thrown by `close_stream()` or `BT::attach()`
-     * is propagated to the caller.
-     *
-     * @param dev New underlying device (default-constructed means an empty device).
-     * @endif
-     */
-    void attach(device_type&& dev = device_type{})
-    {
-        std::exception_ptr close_err;
-        try { close_stream(); }
-        catch (...) { close_err = std::current_exception(); }
-
-        BT::attach(std::move(dev));
-
-        if (close_err) std::rethrow_exception(close_err);
-    }
-
-    /**
-     * @lang{ZH}
      * 建立初始 IO 状态（BOS：Beginning-Of-Stream）。
      * 这是使用转换器之前必须首先调用的函数。
      *

--- a/include/cvt/comp/zlib_cvt.h
+++ b/include/cvt/comp/zlib_cvt.h
@@ -508,44 +508,6 @@ public:
 public:
     /**
      * @lang{ZH}
-     * 将新设备绑定到转换器，同时关闭当前 zlib 流。
-     * 先关闭当前流（捕获可能的错误），再安装新设备；关闭错误在新设备安装完成后才抛出。
-     * 这一顺序是为了防止 `dev`（已移入函数参数）在栈回绕时被析构而悄然丢失。
-     * @endif
-     *
-     * @lang{EN}
-     * Attach a new device to the converter, closing the current zlib stream first.
-     * The current stream is closed before the new device is installed (any close error
-     * is captured); the error is rethrown only after the new device has been installed.
-     * This ordering prevents `dev` (already moved into the parameter) from being
-     * silently destroyed during stack unwinding.
-     * @endif
-     *
-     * @param dev 要绑定的新设备（移动接管所有权），默认为空设备。
-     *            / The new device to attach (ownership transferred via move); defaults to an empty device.
-     * @throws cvt_error 若旧流的 `close_stream()` 失败。 / If `close_stream()` fails for the old stream.
-     */
-    void attach(device_type&& dev = device_type{})
-    {
-        // close_stream failure only means the OLD output stream could not be
-        // finalized on its old device.  Its state_guard resets m_io_status /
-        // m_is_bos_done / m_sync_flush, and the inflate_guard / deflate_guard
-        // inside close_stream have already released m_strm.  So the failure
-        // does NOT prevent us from installing the new device.  If we let it
-        // propagate here, the caller's `dev` (already moved into our parameter)
-        // would be destroyed during stack unwinding and silently lost.  Capture
-        // the exception, install the new device first, then rethrow.
-        std::exception_ptr close_err;
-        try { close_stream(); }
-        catch (...) { close_err = std::current_exception(); }
-
-        BT::attach(std::move(dev));
-
-        if (close_err) std::rethrow_exception(close_err);
-    }
-
-    /**
-     * @lang{ZH}
      * 调整转换器行为参数。
      * 若 `acc` 为 `zlib_sync_flush` 实例，则更新 `m_sync_flush` 标志；
      * 同时将 `acc` 转发给基类 `BT::adjust()`。

--- a/include/cvt/crypt/chacha20_cvt.h
+++ b/include/cvt/crypt/chacha20_cvt.h
@@ -83,26 +83,6 @@ public:
 
 // mandatory methods
 public:
-    void attach(device_type&& dev = device_type{})
-    {
-        BT::attach(std::move(dev));
-
-        if (!m_cipher || m_key.empty())
-            throw cvt_error("chacha20_cvt::attach fail: cipher or key missing (moved-from object?)");
-        else
-        {
-            try
-            {
-                m_cipher->clear();
-            }
-            catch (...)
-            {
-                BT::set_tainted();
-                throw;
-            }
-        }
-    }
-
     io_status bos()
     {
         BT::bos();
@@ -200,6 +180,13 @@ private:
             catch (...) { local_err = std::current_exception(); }
         }
         return local_err;
+    }
+
+    void attach_impl()
+    {
+        if (!m_cipher || m_key.empty())
+            throw cvt_error("chacha20_cvt::attach fail: cipher or key missing (moved-from object?)");
+        m_cipher->clear();
     }
 
     size_t get_main(cvt_reader<KernelType>& reader, internal_type* _to, size_t to_max)

--- a/include/cvt/crypt/hash_cvt.h
+++ b/include/cvt/crypt/hash_cvt.h
@@ -157,30 +157,6 @@ public:
         return io_status::output;
     }
 
-    void attach(device_type&& dev = device_type{})
-    {
-        std::exception_ptr dump_err;
-        try { if (m_has_main_cont) dump_stream(); }
-        catch (...) { dump_err = std::current_exception(); }
-
-        BT::attach(std::move(dev));
-
-        m_has_main_cont = false;
-        m_out_fmt = hash_fmt::lower_hex;
-
-        if (m_hash)
-        {
-            try { m_hash->clear(); }
-            catch (...)
-            {
-                BT::set_tainted();
-                throw;
-            }
-        }
-
-        if (dump_err)  std::rethrow_exception(dump_err);
-    }
-
     void adjust(const cvt_behavior& acc)
     {
         if (const set_hash_fmt* shf_ptr = dynamic_cast<const set_hash_fmt*>(&acc); shf_ptr)
@@ -257,6 +233,13 @@ private:
         }
         m_out_fmt = hash_fmt::lower_hex;
         return local_err;
+    }
+
+    void attach_impl()
+    {
+        if (!m_hash)
+            throw cvt_error("hash_cvt::attach fail: hash not initialized (moved-from object?)");
+        m_hash->clear();
     }
 
     void put_main(cvt_writer<KernelType>& /*writer*/, const internal_type* to, size_t to_size)

--- a/include/cvt/crypt/vigenere_cvt.h
+++ b/include/cvt/crypt/vigenere_cvt.h
@@ -59,22 +59,6 @@ public:
 
 // mandatory methods
 public:
-    void attach(device_type&& dev = device_type{})
-    {
-        BT::attach(std::move(dev));
-        try
-        {
-            m_pos = 0;
-            if (m_key.empty())
-                throw cvt_error("vigenere_cvt::attach fail: empty key");
-        }
-        catch (...)
-        {
-            BT::set_tainted();
-            throw;
-        }
-    }
-
     void main_cont_beg()
     {
         BT::main_cont_beg();
@@ -109,6 +93,12 @@ private:
     {
         m_pos = 0;
         return nullptr;
+    }
+
+    void attach_impl()
+    {
+        if (m_key.empty())
+            throw cvt_error("vigenere_cvt::attach fail: empty key");
     }
 
     // Vigenère arithmetic is performed in the unsigned domain to avoid


### PR DESCRIPTION
Introduce attach_impl() as the per-converter attach hook, mirroring the existing detach_impl() protocol. abs_cvt::attach() now calls detach_impl() before installing the new device and attach_impl() after, so derived classes no longer need to override attach() to sequence cleanup and re-initialization.

Remove the standalone attach() overrides from code_cvt, zlib_cvt, chacha20_cvt, hash_cvt, and vigenere_cvt; replace with attach_impl() where per-class post-attach work is needed. Also fix a typo in abs_cvt::attach() where rethrow_exception referenced the non-existent close_err instead of local_err, and move the rethrow outside the try/catch block to avoid incorrectly tainting the stream when only the old device's cleanup failed.