### PR TITLE
refactor(cvt): add main_cont_beg_impl hook and extend clang-tidy coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,12 +100,7 @@ jobs:
     - name: Run clang-tidy
       run: |
         # Use default clang-tidy from the image (which will be a recent version)
-        clang-tidy $(find include/common include/device -name '*.h') \
-          include/cvt/root_cvt.h include/cvt/abs_cvt.h \
-          include/cvt/cvt_concepts.h include/cvt/code_cvt.h \
-          include/cvt/code_cvt_stdio.h include/cvt/cvt_facilities.h \
-          include/cvt/cvt_pipe_creator.h include/cvt/runtime_cvt.h \
-          include/cvt/comp/zlib_cvt.h \
+        clang-tidy $(find include/common include/device include/cvt -name '*.h') \
           --checks='bugprone-*,performance-*,modernize-*,cppcoreguidelines-*,-modernize-use-trailing-return-type,-cppcoreguidelines-avoid-magic-numbers,-cppcoreguidelines-pro-bounds-pointer-arithmetic,-cppcoreguidelines-pro-bounds-constant-array-index,-cppcoreguidelines-avoid-non-const-global-variables,-clang-diagnostic-pragma-once-outside-header' \
           --warnings-as-errors='bugprone-*' \
           -- -std=c++23 -x c++ -I include -I /usr/include -I /usr/include/botan-2

--- a/include/cvt/abs_cvt.h
+++ b/include/cvt/abs_cvt.h
@@ -667,6 +667,11 @@ namespace IOv2
      *   kernel 确定的初始方向，派生类可直接读取。可用于依赖初始 IO 方向的派生层初始化
      *   （如按输入/输出方向选择不同的处理路径）。允许抛出异常；调用方会将 `m_io_status`
      *   重置为 `neutral` 并设置污染标志后透传。
+     *
+     * - **`main_cont_beg_impl()`**
+     *   由 `abs_cvt::main_cont_beg` 在 kernel `main_cont_beg()` 返回后调用，执行派生层
+     *   从 BOS 阶段切换到主内容阶段时所需的初始化（如重置编码状态机、清零计数器）。
+     *   允许抛出异常；调用方会将 `m_io_status` 重置为 `neutral` 并设置污染标志后透传。
      * @endif
      *
      * @lang{EN}
@@ -716,6 +721,13 @@ namespace IOv2
      *   derived-layer initialization that depends on the initial IO direction (e.g.,
      *   selecting a decoder vs. encoder path). May throw; the caller resets
      *   `m_io_status` to `neutral` and sets the taint flag before rethrowing.
+     *
+     * - **`main_cont_beg_impl()`**
+     *   Called by `abs_cvt::main_cont_beg` after the kernel's `main_cont_beg()`
+     *   returns, to perform derived-layer initialization needed when transitioning
+     *   from the BOS phase into the main-content phase (e.g., resetting a codec
+     *   state machine, clearing counters). May throw; the caller resets `m_io_status`
+     *   to `neutral` and sets the taint flag before rethrowing.
      * @endif
      *
      * @par Exception Safety / Tainted State
@@ -1193,8 +1205,21 @@ namespace IOv2
          */
         void main_cont_beg()
         {
-            m_kernel.main_cont_beg();
-            m_is_bos_done = true;
+            assert_not_tainted();
+
+            try
+            {
+                m_kernel.main_cont_beg();
+                if constexpr (requires(CurrentType& t) { t.main_cont_beg_impl(); })
+                    static_cast<CurrentType*>(this)->main_cont_beg_impl();
+                m_is_bos_done = true;
+            }
+            catch (...)
+            {
+                m_io_status = io_status::neutral;
+                m_is_tainted = true;
+                throw;
+            }
         }
 
         /**

--- a/include/cvt/code_cvt.h
+++ b/include/cvt/code_cvt.h
@@ -688,7 +688,7 @@ template <io_converter KernelType, typename CharType>
 class code_cvt : public abs_cvt<code_cvt<KernelType, CharType>, KernelType, CharType, false, false>
 {
     using BT = abs_cvt<code_cvt<KernelType, CharType>, KernelType, CharType, false, false>;
-    friend BT; // for put_main, get_main
+    friend BT; // for put_main, get_main, and private CRTP hooks
 
 public:
     using device_type = typename KernelType::device_type;   ///< 底层设备类型 / Underlying device type.
@@ -807,28 +807,6 @@ public:
 
     ~code_cvt() = default;
 
-// 必选方法 / Mandatory methods
-public:
-    /**
-     * @lang{ZH}
-     * 结束 BOS 阶段，进入主内容阶段。
-     * 调用后编码转换状态将被重置，累计字符计数清零。
-     * @endif
-     *
-     * @lang{EN}
-     * End the BOS phase and transition into the main content phase.
-     * After this call, the encoding conversion state is reset and the
-     * accumulated character count is cleared.
-     * @endif
-     */
-    void main_cont_beg()
-    {
-        BT::main_cont_beg();
-        m_cvt_kernel.init_state();
-        m_accu_len = 0;
-    }
-
-// 可选方法（由 abs_cvt 通过 CRTP 调用）/ Optional methods (called by abs_cvt via CRTP)
 private:
     /**
      * @lang{ZH}
@@ -858,6 +836,30 @@ private:
         try { close_stream(); }
         catch (...) { local_err = std::current_exception(); }
         return local_err;
+    }
+
+    /**
+     * @lang{ZH}
+     * `abs_cvt::main_cont_beg()` 的 CRTP 钩子，在 kernel 层 `main_cont_beg()` 之后调用。
+     *
+     * 负责重置编码转换状态并清零累计字符计数，使主内容阶段从干净状态开始。
+     * 允许抛出异常；调用方会将 `m_io_status` 重置为 `neutral` 并设置污染标志后透传。
+     * @endif
+     *
+     * @lang{EN}
+     * CRTP hook for `abs_cvt::main_cont_beg()`, called after the kernel-level
+     * `main_cont_beg()`.
+     *
+     * Resets the codec conversion state and clears the accumulated character count
+     * so the main-content phase begins from a clean state.
+     * May throw; the caller resets `m_io_status` to `neutral` and sets the taint
+     * flag before rethrowing.
+     * @endif
+     */
+    void main_cont_beg_impl()
+    {
+        m_cvt_kernel.init_state();
+        m_accu_len = 0;
     }
 
     /**

--- a/include/cvt/code_cvt.h
+++ b/include/cvt/code_cvt.h
@@ -259,11 +259,11 @@ struct codecvt_kernel<char, TInt>
         if (std::greater<>{}(to, to_end)) [[unlikely]]
             throw cvt_error("codecvt_kernel::out_helper fail: invalid pointer range");
         clocale_user guard(m_inter_locale);
-        if (static_cast<size_t>(to_end - to) < m_epc)
+        if (static_cast<size_t>(to_end - to) < m_epc) // NOLINT(modernize-use-integer-sign-comparison)
             return false;
 
         const size_t conv = std::wcrtomb(to, ch, &m_state);
-        if (conv == static_cast<size_t>(-1))
+        if (conv == static_cast<size_t>(-1)) // NOLINT(modernize-use-integer-sign-comparison)
         {
             init_state();  // Reset to known state per C standard
             return false;
@@ -325,9 +325,9 @@ struct codecvt_kernel<char, TInt>
         {
             auto tmp_state = m_state;
             size_t conv = mbrtowc(&wch, from, from_end - from, &tmp_state);
-            if (conv == static_cast<size_t>(-1))
+            if (conv == static_cast<size_t>(-1)) // NOLINT(modernize-use-integer-sign-comparison)
                 return std::pair{false, i_count};
-            else if (conv == static_cast<size_t>(-2))
+            else if (conv == static_cast<size_t>(-2)) // NOLINT(modernize-use-integer-sign-comparison)
             {
                 from = from_end;
                 m_state = tmp_state;

--- a/include/cvt/comp/zlib_cvt.h
+++ b/include/cvt/comp/zlib_cvt.h
@@ -1135,7 +1135,11 @@ private:
     {
         struct state_guard
         {
-            zlib_cvt& self;
+            zlib_cvt& self; // NOLINT(cppcoreguidelines-avoid-const-or-ref-data-members)
+            state_guard(const state_guard&) = delete;
+            state_guard& operator=(const state_guard&) = delete;
+            state_guard(state_guard&&) = delete;
+            state_guard& operator=(state_guard&&) = delete;
             ~state_guard()
             {
                 self.BT::m_is_bos_done = false;

--- a/include/cvt/comp/zlib_cvt.h
+++ b/include/cvt/comp/zlib_cvt.h
@@ -161,7 +161,7 @@ template <io_converter KernelType, typename TInt = typename KernelType::internal
 class zlib_cvt : public abs_cvt<zlib_cvt<KernelType, TInt>, KernelType, TInt, false, false>
 {
     using BT = abs_cvt<zlib_cvt<KernelType, TInt>, KernelType, TInt, false, false>;
-    friend BT;  // for put_main and get_main
+    friend BT;  // for put_main, get_main, and private CRTP hooks
 
     /**
      * @lang{ZH}
@@ -563,49 +563,6 @@ public:
         return m_stream_ended || BT::is_eof();
     }
 
-    /**
-     * @lang{ZH}
-     * 标记 BOS 阶段结束，进入主内容阶段。
-     * 先调用基类 `BT::main_cont_beg()`，然后：
-     * - 若当前为输出模式，调用 `BT::flush()` 将已在 BOS 阶段写入内核缓冲区的
-     *   zlib 流头刷出到底层设备。此时 `m_strm` 必须为有效的 zlib 流（由 `bos()`
-     *   的不变量保证）。
-     * - 若当前为 `neutral` 模式，说明 `bos()` 未被调用，抛出异常。
-     * @endif
-     *
-     * @lang{EN}
-     * Mark the end of the BOS phase and enter the main-content phase.
-     * Calls the base-class `BT::main_cont_beg()` first, then:
-     * - If currently in output mode, calls `BT::flush()` to flush the zlib stream
-     *   header (written into the kernel buffer during the BOS phase) to the underlying
-     *   device. At this point `m_strm` is guaranteed to be a valid zlib stream by the
-     *   `bos()` invariant.
-     * - If currently in `neutral` mode, `bos()` has not been called and an exception
-     *   is thrown.
-     * @endif
-     *
-     * @throws cvt_error 若 `bos()` 尚未被调用（IO 状态为 `neutral`）。
-     *                   / If `bos()` has not yet been called (IO status is `neutral`).
-     */
-    void main_cont_beg()
-    {
-        BT::main_cont_beg();
-
-        if (BT::m_io_status == io_status::output)
-        {
-            // Invariant: bos() either allocates m_strm and leaves m_io_status as
-            // input/output, or restores neutral and taints the converter on failure.
-            // Reaching here with m_io_status == output therefore implies m_strm is
-            // a fully-initialized zlib stream; if the converter were tainted,
-            // BT::flush() would throw before flush_impl() dereferences m_strm.
-            assert(m_strm);
-            BT::flush();
-        }
-        else if (BT::m_io_status == io_status::neutral)
-            throw cvt_error("zlib_cvt::main_cont_beg fail: bos() has not been called before main_cont_beg");
-    }
-
-// optional methods
 private:
     /**
      * @lang{ZH}
@@ -778,6 +735,50 @@ private:
         }
         else
             throw cvt_error("zlib_cvt::bos fail: invalid response value.");
+    }
+
+    /**
+     * @lang{ZH}
+     * `abs_cvt::main_cont_beg()` 的 CRTP 钩子，在 kernel 层 `main_cont_beg()` 之后调用。
+     *
+     * - 若当前为输出模式，调用 `BT::flush()` 将已在 BOS 阶段写入内核缓冲区的
+     *   zlib 流头刷出到底层设备。此时 `m_strm` 必须为有效的 zlib 流（由 `bos()`
+     *   的不变量保证）。
+     * - 若当前为 `neutral` 模式，说明 `bos()` 未被调用，抛出异常。
+     * 允许抛出异常；调用方会将 `m_io_status` 重置为 `neutral` 并设置污染标志后透传。
+     * @endif
+     *
+     * @lang{EN}
+     * CRTP hook for `abs_cvt::main_cont_beg()`, called after the kernel-level
+     * `main_cont_beg()`.
+     *
+     * - If currently in output mode, calls `BT::flush()` to flush the zlib stream
+     *   header (written into the kernel buffer during the BOS phase) to the underlying
+     *   device. At this point `m_strm` is guaranteed to be a valid zlib stream by the
+     *   `bos()` invariant.
+     * - If currently in `neutral` mode, `bos()` has not been called and an exception
+     *   is thrown.
+     * May throw; the caller resets `m_io_status` to `neutral` and sets the taint
+     * flag before rethrowing.
+     * @endif
+     *
+     * @throws cvt_error 若 `bos()` 尚未被调用（IO 状态为 `neutral`）。
+     *                   / If `bos()` has not yet been called (IO status is `neutral`).
+     */
+    void main_cont_beg_impl()
+    {
+        if (BT::m_io_status == io_status::output)
+        {
+            // Invariant: bos() either allocates m_strm and leaves m_io_status as
+            // input/output, or restores neutral and taints the converter on failure.
+            // Reaching here with m_io_status == output therefore implies m_strm is
+            // a fully-initialized zlib stream; if the converter were tainted,
+            // BT::flush() would throw before flush_impl() dereferences m_strm.
+            assert(m_strm);
+            BT::flush();
+        }
+        else if (BT::m_io_status == io_status::neutral)
+            throw cvt_error("zlib_cvt::main_cont_beg fail: bos() has not been called before main_cont_beg");
     }
 
     /**

--- a/include/cvt/comp/zlib_cvt.h
+++ b/include/cvt/comp/zlib_cvt.h
@@ -1136,6 +1136,7 @@ private:
         struct state_guard
         {
             zlib_cvt& self; // NOLINT(cppcoreguidelines-avoid-const-or-ref-data-members)
+            state_guard(zlib_cvt& p_self) : self(p_self) {}
             state_guard(const state_guard&) = delete;
             state_guard& operator=(const state_guard&) = delete;
             state_guard(state_guard&&) = delete;

--- a/include/cvt/crypt/chacha20_cvt.h
+++ b/include/cvt/crypt/chacha20_cvt.h
@@ -32,7 +32,7 @@ inline Botan::secure_vector<uint8_t> key_gen(std::string_view key)
     if (!hash)
         throw cvt_error("chacha20 key generation fail: cannot create SHA-256 hash");
 
-    hash->update(reinterpret_cast<const uint8_t*>(key.data()), key.size());
+    hash->update(reinterpret_cast<const uint8_t*>(key.data()), key.size()); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
     return hash->final();
 }
 }
@@ -80,6 +80,7 @@ public:
     chacha20_cvt& operator=(const chacha20_cvt&) = delete;
     chacha20_cvt(chacha20_cvt&& val) = default;
     chacha20_cvt& operator=(chacha20_cvt&& val) = default;
+    ~chacha20_cvt() = default;
 
 // optional methods
 private:
@@ -142,7 +143,7 @@ private:
                     throw cvt_error("chacha20_cvt::bos fail: incomplete IV read");
 
                 m_cipher->set_key(m_key);
-                m_cipher->set_iv(reinterpret_cast<const uint8_t*>(iv_buf.data()), iv_len);
+                m_cipher->set_iv(reinterpret_cast<const uint8_t*>(iv_buf.data()), iv_len); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
             }
             else
                 throw cvt_error("chacha20_cvt::bos fail: input mode but kernel does not support get");
@@ -152,10 +153,10 @@ private:
             if constexpr (cvt_cpt::support_put<KernelType>)
             {
                 Botan::AutoSeeded_RNG rng;
-                rng.randomize(reinterpret_cast<uint8_t*>(iv_buf.data()), iv_len);
+                rng.randomize(reinterpret_cast<uint8_t*>(iv_buf.data()), iv_len); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
 
                 m_cipher->set_key(m_key);
-                m_cipher->set_iv(reinterpret_cast<const uint8_t*>(iv_buf.data()), iv_len);
+                m_cipher->set_iv(reinterpret_cast<const uint8_t*>(iv_buf.data()), iv_len); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
 
                 BT::m_kernel.put(iv_buf.data(), iv_len);
             }
@@ -175,7 +176,7 @@ private:
         constexpr size_t max_type_limit = std::numeric_limits<size_t>::max();
         constexpr size_t max_chunk = max_type_limit - (max_type_limit % sizeof(internal_type));
 
-        uint8_t* to = reinterpret_cast<uint8_t*>(_to);
+        auto* to = reinterpret_cast<uint8_t*>(_to); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
 
         reader.reset(block_size);
         size_t total_res = 0;   // total bytes decrypted across all outer iterations
@@ -196,7 +197,7 @@ private:
                 const size_t dest_size = std::min<size_t>(block_size, aim - chunk_res);
                 auto [ptr, cur_len] = reader.get_buf(dest_size);
                 if (cur_len == 0) { eof = true; break; }
-                m_cipher->cipher(reinterpret_cast<const uint8_t*>(ptr), to, cur_len);
+                m_cipher->cipher(reinterpret_cast<const uint8_t*>(ptr), to, cur_len); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
                 to += cur_len;
                 chunk_res += cur_len;
             }
@@ -219,7 +220,7 @@ private:
         constexpr size_t max_type_limit = std::numeric_limits<size_t>::max();
         constexpr size_t max_chunk = max_type_limit - (max_type_limit % sizeof(internal_type));
 
-        const uint8_t* to = reinterpret_cast<const uint8_t*>(_to);
+        const auto* to = reinterpret_cast<const uint8_t*>(_to); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
 
         writer.reset(block_size);
         while (to_size > 0)
@@ -232,7 +233,7 @@ private:
             {
                 size_t dest_size = std::min<size_t>(block_size, aim_output - to_i);
                 auto ptr = writer.put_buf(dest_size);
-                m_cipher->cipher(to + to_i, reinterpret_cast<uint8_t*>(ptr), dest_size);
+                m_cipher->cipher(to + to_i, reinterpret_cast<uint8_t*>(ptr), dest_size); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
                 to_i += dest_size;
             }
             to += aim_output;

--- a/include/cvt/crypt/hash_cvt.h
+++ b/include/cvt/crypt/hash_cvt.h
@@ -17,7 +17,7 @@
 
 namespace IOv2::Crypt
 {
-enum class hash_algo : unsigned short
+enum class hash_algo : uint8_t
 {
     MD5,
     SHA256,
@@ -66,8 +66,6 @@ public:
     hash_cvt(KernelType kernel, hash_algo algo)
         : BT(std::move(kernel))
         , m_hash(Botan::HashFunction::create_or_throw(algo_to_str(algo)))
-        , m_has_main_cont(false)
-        , m_out_fmt(hash_fmt::lower_hex)
     {}
 
     hash_cvt(const hash_cvt& val)
@@ -139,9 +137,9 @@ public:
 public:
     void adjust(const cvt_behavior& acc)
     {
-        if (const set_hash_fmt* shf_ptr = dynamic_cast<const set_hash_fmt*>(&acc); shf_ptr)
+        if (const auto* shf_ptr = dynamic_cast<const set_hash_fmt*>(&acc); shf_ptr)
             m_out_fmt = shf_ptr->m_val;
-        else if (const dump_hash* dh_ptr = dynamic_cast<const dump_hash*>(&acc); dh_ptr)
+        else if (const auto* dh_ptr = dynamic_cast<const dump_hash*>(&acc); dh_ptr)
         {
             if (m_has_main_cont)
             {
@@ -149,7 +147,7 @@ public:
                 if (dh_ptr->m_delim)
                 {
                     const uint8_t delim = *dh_ptr->m_delim;
-                    BT::m_kernel.put(reinterpret_cast<const external_type*>(&delim), 1);
+                    BT::m_kernel.put(reinterpret_cast<const external_type*>(&delim), 1); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
                 }
             }
         }
@@ -243,7 +241,7 @@ private:
             throw cvt_error("hash_cvt::put_main fail: size overflow");
 
         if (to_size == 0) return;
-        m_hash->update(reinterpret_cast<const uint8_t*>(to), to_size * sizeof(internal_type));
+        m_hash->update(reinterpret_cast<const uint8_t*>(to), to_size * sizeof(internal_type)); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
         m_has_main_cont = true;
     }
 
@@ -277,18 +275,18 @@ private:
         switch (m_out_fmt)
         {
         case hash_fmt::binary:
-            BT::m_kernel.put(reinterpret_cast<const external_type*>(digest.data()), digest.size());
+            BT::m_kernel.put(reinterpret_cast<const external_type*>(digest.data()), digest.size()); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
             break;
         case hash_fmt::upper_hex:
             {
                 std::string hex_string = Botan::hex_encode(digest);
-                BT::m_kernel.put(reinterpret_cast<const external_type*>(hex_string.data()), hex_string.size());
+                BT::m_kernel.put(reinterpret_cast<const external_type*>(hex_string.data()), hex_string.size()); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
             }
             break;
         case hash_fmt::lower_hex:
             {
                 std::string hex_string = Botan::hex_encode(digest, false);
-                BT::m_kernel.put(reinterpret_cast<const external_type*>(hex_string.data()), hex_string.size());
+                BT::m_kernel.put(reinterpret_cast<const external_type*>(hex_string.data()), hex_string.size()); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
             }
             break;
         default:
@@ -309,8 +307,8 @@ private:
     }
 private:
     std::unique_ptr<Botan::HashFunction> m_hash;
-    bool         m_has_main_cont;
-    hash_fmt     m_out_fmt;
+    bool         m_has_main_cont{false};
+    hash_fmt     m_out_fmt{hash_fmt::lower_hex};
 };
 
 template <typename TInt>
@@ -329,6 +327,6 @@ public:
     }
 
 private:
-    const hash_algo m_algo;
+    hash_algo m_algo;
 };
 }

--- a/include/cvt/crypt/vigenere_cvt.h
+++ b/include/cvt/crypt/vigenere_cvt.h
@@ -38,7 +38,7 @@ template <io_converter KernelType>
 class vigenere_cvt : public abs_cvt<vigenere_cvt<KernelType>, KernelType, typename KernelType::internal_type, false, true>
 {
     using BT = abs_cvt<vigenere_cvt<KernelType>, KernelType, typename KernelType::internal_type, false, true>;
-    friend BT;  // for put_main and get_main
+    friend BT;  // for put_main, get_main, and private CRTP hooks
     constexpr static size_t s_buf_len = 16;
 public:
     using device_type = typename KernelType::device_type;
@@ -57,15 +57,6 @@ public:
                 }())
     {}
 
-// mandatory methods
-public:
-    void main_cont_beg()
-    {
-        BT::main_cont_beg();
-        m_pos = 0;
-    }
-
-// optional methods
 private:
     /**
      * @lang{ZH}
@@ -99,6 +90,18 @@ private:
     {
         if (m_key.empty())
             throw cvt_error("vigenere_cvt::attach fail: empty key");
+    }
+
+    /**
+     * CRTP hook for `abs_cvt::main_cont_beg()`, called after the kernel-level
+     * `main_cont_beg()`.
+     *
+     * Resets the key-offset position `m_pos` to zero so that main-content
+     * encryption/decryption starts from the beginning of the key.
+     */
+    void main_cont_beg_impl()
+    {
+        m_pos = 0;
     }
 
     // Vigenère arithmetic is performed in the unsigned domain to avoid

--- a/include/cvt/crypt/vigenere_cvt.h
+++ b/include/cvt/crypt/vigenere_cvt.h
@@ -48,7 +48,6 @@ public:
 public:
     vigenere_cvt(KernelType dev, std::basic_string_view<internal_type> s)
         : BT(std::move(dev))
-        , m_pos(0)
         , m_key([s]
                 {
                     if (s.empty())
@@ -174,7 +173,7 @@ private:
 
 public:
     /// positioning
-    size_t tell() const
+    [[nodiscard]] size_t tell() const
         requires (cvt_cpt::support_positioning<KernelType>)
     {
         BT::assert_not_tainted();
@@ -225,7 +224,7 @@ public:
         }
     }
 private:
-    size_t                     m_pos;
+    size_t                     m_pos{0};
     std::vector<internal_type> m_key;
 };
 
@@ -252,5 +251,5 @@ private:
 };
 
 template <typename TChar>
-vigenere_cvt_creator(const TChar []) -> vigenere_cvt_creator<TChar>;
+vigenere_cvt_creator(const TChar*) -> vigenere_cvt_creator<TChar>;
 }


### PR DESCRIPTION
## Summary

  - Lift `main_cont_beg` logic into `abs_cvt` via a CRTP `main_cont_beg_impl`  hook, consistent with the existing `attach_impl`, `bos_impl`, and `detach_impl` pattern; `vigenere_cvt` resets its key-offset position in  `main_cont_beg_impl` instead of inline code
  - Extend CI clang-tidy to cover all headers under `include/cvt/` (including `crypt/`) by replacing the explicit file list with `find include/cvt`
  - Fix all clang-tidy warnings surfaced by the expanded scope across `chacha20_cvt`, `hash_cvt`, `vigenere_cvt`, `zlib_cvt`, and `code_cvt`

  ## Test plan

  - [ ] All existing tests pass under release and sanitizer builds
  - [ ] `clang-tidy` CI job passes with the expanded file set