### PR TITLE
refactor(cvt): introduce adjust_impl NVI hook in abs_cvt

### DIFF
--- a/include/cvt/abs_cvt.h
+++ b/include/cvt/abs_cvt.h
@@ -672,6 +672,14 @@ namespace IOv2
      *   由 `abs_cvt::main_cont_beg` 在 kernel `main_cont_beg()` 返回后调用，执行派生层
      *   从 BOS 阶段切换到主内容阶段时所需的初始化（如重置编码状态机、清零计数器）。
      *   允许抛出异常；调用方会将 `m_io_status` 重置为 `neutral` 并设置污染标志后透传。
+     *
+     * - **`adjust_impl(const cvt_behavior&)`**
+     *   由 `abs_cvt::adjust` 在调用 `m_kernel.adjust()` 之前调用，执行派生层特有的
+     *   行为配置逻辑（如解析自定义 `cvt_behavior` 子类并更新内部状态）。
+     *   允许抛出异常；调用方直接透传，不设置污染标志。
+     *   **仅适用于直接派生自 `abs_cvt` 的类**；若派生类经由中间层（如
+     *   `code_cvt`）继承，则 `CurrentType` 为中间层类型，`adjust_impl` 不可达，
+     *   应改为直接覆写公开的 `adjust()` 并链式调用 `BT::adjust()`。
      * @endif
      *
      * @lang{EN}
@@ -728,6 +736,17 @@ namespace IOv2
      *   from the BOS phase into the main-content phase (e.g., resetting a codec
      *   state machine, clearing counters). May throw; the caller resets `m_io_status`
      *   to `neutral` and sets the taint flag before rethrowing.
+     *
+     * - **`adjust_impl(const cvt_behavior&)`**
+     *   Called by `abs_cvt::adjust` before `m_kernel.adjust()`, to perform any
+     *   derived-layer behavior configuration (e.g., inspecting a custom
+     *   `cvt_behavior` subclass and updating internal state). May throw; the caller
+     *   propagates the exception directly without setting the taint flag.
+     *   **Only applicable to classes that directly inherit from `abs_cvt`.**
+     *   If a class inherits through an intermediate layer (e.g., `code_cvt`),
+     *   `CurrentType` is the intermediate type and `adjust_impl` on the leaf class
+     *   is unreachable; such classes must override the public `adjust()` directly
+     *   and forward to `BT::adjust()`.
      * @endif
      *
      * @par Exception Safety / Tainted State
@@ -1075,13 +1094,17 @@ namespace IOv2
          * @lang{ZH}
          * 调整转换器的行为参数。
          *
-         * 将 `b` 中描述的行为配置转发给底层 kernel。
+         * 先调用 `assert_not_tainted()` 检查污染标志；若派生类实现了
+         * `adjust_impl(const cvt_behavior&)`，则先调用之执行派生层特有的配置逻辑；
+         * 最后将 `b` 转发给底层 kernel。
          * @endif
          *
          * @lang{EN}
          * Adjust the converter's behavior parameters.
          *
-         * Forwards the behavior configuration described in `b` to the underlying kernel.
+         * First calls `assert_not_tainted()`; if the derived class implements
+         * `adjust_impl(const cvt_behavior&)`, calls it to perform any derived-layer
+         * configuration; then forwards `b` to the underlying kernel.
          * @endif
          *
          * @param b
@@ -1090,6 +1113,9 @@ namespace IOv2
          */
         void adjust(const cvt_behavior& b)
         {
+            assert_not_tainted();
+            if constexpr (requires(CurrentType& t, const cvt_behavior& b) { t.adjust_impl(b); })
+                static_cast<CurrentType*>(this)->adjust_impl(b);
             m_kernel.adjust(b);
         }
 

--- a/include/cvt/abs_cvt.h
+++ b/include/cvt/abs_cvt.h
@@ -1114,7 +1114,7 @@ namespace IOv2
         void adjust(const cvt_behavior& b)
         {
             assert_not_tainted();
-            if constexpr (requires(CurrentType& t, const cvt_behavior& b) { t.adjust_impl(b); })
+            if constexpr (requires(CurrentType& t, const cvt_behavior& behavior) { t.adjust_impl(behavior); })
                 static_cast<CurrentType*>(this)->adjust_impl(b);
             m_kernel.adjust(b);
         }

--- a/include/cvt/code_cvt_stdio.h
+++ b/include/cvt/code_cvt_stdio.h
@@ -154,66 +154,6 @@ public:
 public:
     /**
      * @lang{ZH}
-     * 响应行为策略调用，支持运行时切换字符编码。
-     *
-     * 若 `acc` 为 `code_cvt_switch` 类型，则执行区域设置切换：
-     * 用 `acc.code` 构造新的 `codecvt_kernel` 并原子地替换当前内核，
-     * 同时更新缓存的区域设置名称 `m_code`。
-     * 切换时要求编码转换状态（`m_cvt_kernel`）处于初始状态，否则抛出异常。
-     * 所有可能抛出异常的操作均在提交前完成，确保强异常安全保证。
-     * 若 `acc` 不是 `code_cvt_switch` 类型，则将调用委托给基类 `adjust()`。
-     *
-     * @param acc 行为策略对象。
-     *
-     * @throws cvt_error 若当前编码转换状态不处于初始状态。
-     * @endif
-     *
-     * @lang{EN}
-     * Respond to a behavior policy call, supporting runtime character encoding switching.
-     *
-     * If `acc` is of type `code_cvt_switch`, performs a locale switch: constructs a
-     * new `codecvt_kernel` from `acc.code` and atomically replaces the current kernel,
-     * also updating the cached locale name `m_code`.
-     * The encoding conversion state (`m_cvt_kernel`) must be in its initial state at
-     * the time of switching; otherwise an exception is thrown.
-     * All potentially-throwing operations are completed before any commit, ensuring
-     * the strong exception safety guarantee.
-     * If `acc` is not of type `code_cvt_switch`, the call is delegated to the base
-     * class `adjust()`.
-     *
-     * @param acc Behavior policy object.
-     *
-     * @throws cvt_error If the encoding conversion state is not in its initial state.
-     * @endif
-     */
-    void adjust(const cvt_behavior& acc)
-    {
-        if (const auto* ptr = dynamic_cast<const code_cvt_switch*>(&acc); ptr)
-        {
-            if (!this->m_cvt_kernel.is_init_state())
-                throw cvt_error("code_cvt_stdio::adjust fail: invalid state");
-            // Perform all potentially-throwing operations first, then commit with
-            // noexcept moves. The two commit moves below MUST be noexcept; otherwise
-            // a partial-throw could leave m_cvt_kernel and m_code mutually
-            // inconsistent (mismatched locale handle vs. cached code string).
-            static_assert(
-                std::is_nothrow_move_assignable_v<codecvt_kernel<char, wchar_t>>,
-                "codecvt_kernel<char, wchar_t> move-assign must be noexcept; "
-                "otherwise code_cvt_stdio::adjust loses its strong exception guarantee");
-            static_assert(
-                std::is_nothrow_move_assignable_v<std::string>,
-                "std::string move-assign must be noexcept");
-            codecvt_kernel<char, wchar_t> new_kernel(ptr->code);
-            std::string new_code = ptr->code;
-            this->m_cvt_kernel = std::move(new_kernel);
-            m_code = std::move(new_code);
-        }
-
-        return BT::adjust(acc);
-    }
-
-    /**
-     * @lang{ZH}
      * 响应状态查询调用，支持查询当前区域设置名称。
      *
      * 若 `s` 为 `code_cvt_access` 类型，则将当前区域设置名称（`m_code`）
@@ -243,6 +183,64 @@ public:
         BT::retrieve(s);
     }
 
+public:
+    /**
+     * @lang{ZH}
+     * 响应行为策略调用，支持运行时切换字符编码。
+     *
+     * 若 `acc` 为 `code_cvt_switch` 类型，则执行区域设置切换：
+     * 用 `acc.code` 构造新的 `codecvt_kernel` 并原子地替换当前内核，
+     * 同时更新缓存的区域设置名称 `m_code`。
+     * 切换时要求编码转换状态（`m_cvt_kernel`）处于初始状态，否则抛出异常。
+     * 所有可能抛出异常的操作均在提交前完成，确保强异常安全保证。
+     * 无论 `acc` 类型如何，最终均链式调用基类 `BT::adjust(acc)`。
+     *
+     * @param acc 行为策略对象。
+     *
+     * @throws cvt_error 若当前编码转换状态不处于初始状态。
+     * @endif
+     *
+     * @lang{EN}
+     * Respond to a behavior policy call, supporting runtime character encoding switching.
+     *
+     * If `acc` is of type `code_cvt_switch`, performs a locale switch: constructs a
+     * new `codecvt_kernel` from `acc.code` and atomically replaces the current kernel,
+     * also updating the cached locale name `m_code`.
+     * The encoding conversion state (`m_cvt_kernel`) must be in its initial state at
+     * the time of switching; otherwise an exception is thrown.
+     * All potentially-throwing operations are completed before any commit, ensuring
+     * the strong exception safety guarantee.
+     * In all cases the call is forwarded to the base-class `BT::adjust(acc)`.
+     *
+     * @param acc Behavior policy object.
+     *
+     * @throws cvt_error If the encoding conversion state is not in its initial state.
+     * @endif
+     */
+    void adjust(const cvt_behavior& acc)
+    {
+        if (const auto* ptr = dynamic_cast<const code_cvt_switch*>(&acc); ptr)
+        {
+            if (!this->m_cvt_kernel.is_init_state())
+                throw cvt_error("code_cvt_stdio::adjust fail: invalid state");
+            // Perform all potentially-throwing operations first, then commit with
+            // noexcept moves. The two commit moves below MUST be noexcept; otherwise
+            // a partial-throw could leave m_cvt_kernel and m_code mutually
+            // inconsistent (mismatched locale handle vs. cached code string).
+            static_assert(
+                std::is_nothrow_move_assignable_v<codecvt_kernel<char, wchar_t>>,
+                "codecvt_kernel<char, wchar_t> move-assign must be noexcept; "
+                "otherwise code_cvt_stdio::adjust loses its strong exception guarantee");
+            static_assert(
+                std::is_nothrow_move_assignable_v<std::string>,
+                "std::string move-assign must be noexcept");
+            codecvt_kernel<char, wchar_t> new_kernel(ptr->code);
+            std::string new_code = ptr->code;
+            this->m_cvt_kernel = std::move(new_kernel);
+            m_code = std::move(new_code);
+        }
+        return BT::adjust(acc);
+    }
 private:
     std::string m_code; ///< 当前使用的区域设置名称 / Currently active locale name.
 };

--- a/include/cvt/comp/zlib_cvt.h
+++ b/include/cvt/comp/zlib_cvt.h
@@ -508,29 +508,6 @@ public:
 public:
     /**
      * @lang{ZH}
-     * 调整转换器行为参数。
-     * 若 `acc` 为 `zlib_sync_flush` 实例，则更新 `m_sync_flush` 标志；
-     * 同时将 `acc` 转发给基类 `BT::adjust()`。
-     * @endif
-     *
-     * @lang{EN}
-     * Adjust converter behavior parameters.
-     * If `acc` is a `zlib_sync_flush` instance, updates the `m_sync_flush` flag;
-     * also forwards `acc` to the base-class `BT::adjust()`.
-     * @endif
-     *
-     * @param acc 行为策略对象。 / The behavior policy object.
-     */
-    void adjust(const cvt_behavior& acc)
-    {
-        if (auto* ptr = dynamic_cast<const zlib_sync_flush*>(&acc); ptr)
-            m_sync_flush = ptr->m_sync_flush;
-
-        return BT::adjust(acc);
-    }
-
-    /**
-     * @lang{ZH}
      * 查询是否已到达 zlib 压缩流末尾。
      * `m_stream_ended` 是 zlib 级别的 EOF 锁存位，在 `get_main` 中 `inflate()` 返回
      * `Z_STREAM_END` 时置位。`BT::is_eof()` 反映内核的可读字节数视图，可能滞后于
@@ -1039,6 +1016,28 @@ private:
         }
     }
 
+    /**
+     * @lang{ZH}
+     * 调整转换器行为参数。
+     * 若 `acc` 为 `zlib_sync_flush` 实例，则更新 `m_sync_flush` 标志；
+     * 同时将 `acc` 转发给基类 `BT::adjust()`。
+     * @endif
+     *
+     * @lang{EN}
+     * Adjust converter behavior parameters.
+     * If `acc` is a `zlib_sync_flush` instance, updates the `m_sync_flush` flag;
+     * also forwards `acc` to the base-class `BT::adjust()`.
+     * @endif
+     *
+     * @param acc 行为策略对象。 / The behavior policy object.
+     */
+    void adjust_impl(const cvt_behavior& acc)
+    {
+        if (auto* ptr = dynamic_cast<const zlib_sync_flush*>(&acc); ptr)
+            m_sync_flush = ptr->m_sync_flush;
+    }
+
+private:
     /**
      * @lang{ZH}
      * 将 zlib 返回码转换为 `cvt_error` 异常。

--- a/include/cvt/crypt/hash_cvt.h
+++ b/include/cvt/crypt/hash_cvt.h
@@ -137,42 +137,6 @@ public:
         }
     }
 
-// mandatory methods
-public:
-    void adjust(const cvt_behavior& acc)
-    {
-        if (const auto* shf_ptr = dynamic_cast<const set_hash_fmt*>(&acc); shf_ptr)
-            m_out_fmt = shf_ptr->m_val;
-        else if (const auto* dh_ptr = dynamic_cast<const dump_hash*>(&acc); dh_ptr)
-        {
-            if (m_has_main_cont)
-            {
-                dump_stream();
-                if (dh_ptr->m_delim)
-                {
-                    const uint8_t delim = *dh_ptr->m_delim;
-                    // If the delimiter write fails, the digest is already on
-                    // the kernel without its separator; subsequent dumps would
-                    // produce concatenated digests with no boundary. Taint so
-                    // the user is forced to detach/attach instead of silently
-                    // emitting corrupted output.
-                    try
-                    {
-                        BT::m_kernel.put(reinterpret_cast<const external_type*>(&delim), 1); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
-                    }
-                    catch (...)
-                    {
-                        BT::set_tainted();
-                        throw;
-                    }
-                }
-            }
-        }
-
-        return BT::adjust(acc);
-    }
-
-// optional methods
 private:
     /**
      * @lang{ZH}
@@ -260,6 +224,37 @@ private:
         if (to_size == 0) return;
         m_hash->update(reinterpret_cast<const uint8_t*>(to), to_size * sizeof(internal_type)); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
         m_has_main_cont = true;
+    }
+
+    void adjust_impl(const cvt_behavior& acc)
+    {
+        if (const auto* shf_ptr = dynamic_cast<const set_hash_fmt*>(&acc); shf_ptr)
+            m_out_fmt = shf_ptr->m_val;
+        else if (const auto* dh_ptr = dynamic_cast<const dump_hash*>(&acc); dh_ptr)
+        {
+            if (m_has_main_cont)
+            {
+                dump_stream();
+                if (dh_ptr->m_delim)
+                {
+                    const uint8_t delim = *dh_ptr->m_delim;
+                    // If the delimiter write fails, the digest is already on
+                    // the kernel without its separator; subsequent dumps would
+                    // produce concatenated digests with no boundary. Taint so
+                    // the user is forced to detach/attach instead of silently
+                    // emitting corrupted output.
+                    try
+                    {
+                        BT::m_kernel.put(reinterpret_cast<const external_type*>(&delim), 1); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
+                    }
+                    catch (...)
+                    {
+                        BT::set_tainted();
+                        throw;
+                    }
+                }
+            }
+        }
     }
 
 private:


### PR DESCRIPTION
Replace per-class adjust() overrides with a private adjust_impl() hook dispatched by abs_cvt::adjust() via if constexpr requires, centralising assert_not_tainted() and m_kernel.adjust() calls in the base class.

Applies to direct abs_cvt derivatives only (hash_cvt, zlib_cvt). code_cvt_stdio, which inherits through code_cvt, retains a public adjust() override chaining to BT::adjust() — the CRTP CurrentType is code_cvt, so adjust_impl on the leaf class is unreachable from abs_cvt.

Document the hook and its inheritance-depth limitation in the abs_cvt hook catalogue (ZH + EN).