### PR TITLE
refactor(cvt): introduce tell_impl/seek_impl/rseek_impl/is_eof_impl NVI hooks in abs_cvt

### DIFF
--- a/include/cvt/abs_cvt.h
+++ b/include/cvt/abs_cvt.h
@@ -839,7 +839,7 @@ namespace IOv2
      * @lang{ZH} 派生类对外暴露的字符类型（即 `get`/`put` 接口所使用的元素类型）。 @endif
      * @lang{EN} The character type exposed by the derived class (the element type used by the `get`/`put` interface). @endif
      *
-     * @tparam default_positioning
+     * @tparam enable_positioning
      * @lang{ZH}
      * 若为 `true`（默认），且 kernel 支持定位，则 `tell()`/`seek()`/`rseek()` 方法可用。
      * @endif
@@ -858,7 +858,7 @@ namespace IOv2
     template <typename CurrentType,
               io_converter KernelType,
               typename InternalType,
-              bool default_positioning = true,
+              bool enable_positioning = true,
               bool enable_io_switch = true>
     class abs_cvt
     {
@@ -1304,22 +1304,28 @@ namespace IOv2
          * 检查是否已到达流末尾（EOF）。
          *
          * 仅在 `KernelType` 支持 get 操作时可用。
+         * 若派生类实现了 `is_eof_impl()`，则调用它；否则直接调用 `m_kernel.is_eof()`。
          * @endif
          *
          * @lang{EN}
          * Check whether the end of the stream (EOF) has been reached.
          *
          * Only available when `KernelType` supports the get operation.
+         * Dispatches to `is_eof_impl()` if the derived class implements it;
+         * otherwise calls `m_kernel.is_eof()` directly.
          * @endif
          *
          * @return
          * @lang{ZH} 若已到达流末尾则返回 `true`，否则返回 `false`。 @endif
          * @lang{EN} `true` if the end of the stream has been reached; `false` otherwise. @endif
          */
-        bool is_eof()
+        [[nodiscard]] bool is_eof()
             requires (cvt_cpt::support_get<KernelType>)
         {
-            return m_kernel.is_eof();
+            if constexpr (requires(CurrentType& t) { { t.is_eof_impl() } -> std::same_as<bool>; })
+                return static_cast<CurrentType*>(this)->is_eof_impl();
+            else
+                return m_kernel.is_eof();
         }
 
     // optional methods
@@ -1623,14 +1629,17 @@ namespace IOv2
          * @lang{ZH}
          * 返回当前流位置（以 `external_type` 元素为单位）。
          *
-         * 仅在 `default_positioning` 为 `true` 且 kernel 支持定位时可用。
+         * 仅在 `enable_positioning` 为 `true` 且 kernel 支持定位时可用。
+         * 若派生类实现了 `tell_impl()`，则调用它；否则直接调用 `m_kernel.tell()`。
          * @endif
          *
          * @lang{EN}
          * Return the current stream position in units of `external_type` elements.
          *
-         * Only available when `default_positioning` is `true` and the kernel
+         * Only available when `enable_positioning` is `true` and the kernel
          * supports positioning.
+         * Dispatches to `tell_impl()` if the derived class implements it;
+         * otherwise calls `m_kernel.tell()` directly.
          * @endif
          *
          * @return
@@ -1638,24 +1647,32 @@ namespace IOv2
          * @lang{EN} The current stream position as an offset in `external_type` elements from the start of the stream. @endif
          */
         [[nodiscard]] size_t tell() const
-            requires (default_positioning && cvt_cpt::support_positioning<KernelType>)
+            requires (enable_positioning && cvt_cpt::support_positioning<KernelType>)
         {
-            return m_kernel.tell();
+            if constexpr (requires(const CurrentType& t) { { t.tell_impl() } -> std::same_as<size_t>; })
+                return static_cast<const CurrentType*>(this)->tell_impl();
+            else
+                return m_kernel.tell();
         }
 
         /**
          * @lang{ZH}
          * 将流位置移动到绝对位置 `pos`（从流起始处计算，以 `external_type` 元素为单位）。
          *
-         * 仅在 `default_positioning` 为 `true` 且 kernel 支持定位时可用。
+         * 仅在 `enable_positioning` 为 `true` 且 kernel 支持定位时可用。
+         * 若 `pos` 已等于当前位置则立即返回（快速路径）；否则调用 `assert_not_tainted()`，
+         * 再分发到 `seek_impl()`（若派生类实现了该 hook），或直接调用 `m_kernel.seek()`。
          * @endif
          *
          * @lang{EN}
          * Seek to absolute position `pos` measured from the start of the stream in
          * units of `external_type` elements.
          *
-         * Only available when `default_positioning` is `true` and the kernel
+         * Only available when `enable_positioning` is `true` and the kernel
          * supports positioning.
+         * Returns immediately if `pos` already equals the current position (fast path).
+         * Otherwise calls `assert_not_tainted()`, then dispatches to `seek_impl()` if
+         * the derived class implements it, or calls `m_kernel.seek()` directly.
          * @endif
          *
          * @param pos
@@ -1663,24 +1680,39 @@ namespace IOv2
          * @lang{EN} Target absolute position as an offset in `external_type` elements from the start of the stream. @endif
          */
         void seek(size_t pos)
-            requires (default_positioning && cvt_cpt::support_positioning<KernelType>)
+            requires (enable_positioning && cvt_cpt::support_positioning<KernelType>)
         {
-            m_kernel.seek(pos);
+            // Fast path for no-op self-seek: skip validation and kernel work when
+            // pos already equals the current position. Intentional even in modes
+            // where the validation below would otherwise reject — callers using
+            // seek(saved_pos) for position-restore must not be rejected when
+            // saved_pos happens to equal tell().
+            if (this->tell() == pos) return;
+
+            assert_not_tainted();
+
+            if constexpr (requires(CurrentType& t, size_t p) { t.seek_impl(p); })
+                static_cast<CurrentType*>(this)->seek_impl(pos);
+            else m_kernel.seek(pos);
         }
 
         /**
          * @lang{ZH}
          * 将流位置移动到反向绝对位置 `pos`（从流末尾处向前计算，以 `external_type` 元素为单位）。
          *
-         * 仅在 `default_positioning` 为 `true` 且 kernel 支持定位时可用。
+         * 仅在 `enable_positioning` 为 `true` 且 kernel 支持定位时可用。
+         * 调用 `assert_not_tainted()`，再分发到 `rseek_impl()`（若派生类实现了该 hook），
+         * 或直接调用 `m_kernel.rseek()`。
          * @endif
          *
          * @lang{EN}
          * Seek to reverse absolute position `pos` measured backwards from the end
          * of the stream in units of `external_type` elements.
          *
-         * Only available when `default_positioning` is `true` and the kernel
+         * Only available when `enable_positioning` is `true` and the kernel
          * supports positioning.
+         * Calls `assert_not_tainted()`, then dispatches to `rseek_impl()` if the
+         * derived class implements it, or calls `m_kernel.rseek()` directly.
          * @endif
          *
          * @param pos
@@ -1688,9 +1720,13 @@ namespace IOv2
          * @lang{EN} Target reverse position as an offset in `external_type` elements measured backwards from the end of the stream. @endif
          */
         void rseek(size_t pos)
-            requires (default_positioning && cvt_cpt::support_positioning<KernelType>)
+            requires (enable_positioning && cvt_cpt::support_positioning<KernelType>)
         {
-            m_kernel.rseek(pos);
+            assert_not_tainted();
+
+            if constexpr (requires(CurrentType& t, size_t p) { t.rseek_impl(p); })
+                static_cast<CurrentType*>(this)->rseek_impl(pos);
+            else m_kernel.rseek(pos);
         }
 
         /**

--- a/include/cvt/code_cvt.h
+++ b/include/cvt/code_cvt.h
@@ -685,9 +685,9 @@ struct codecvt_kernel<char8_t, TInt>
  * @endif
  */
 template <io_converter KernelType, typename CharType>
-class code_cvt : public abs_cvt<code_cvt<KernelType, CharType>, KernelType, CharType, false, true>
+class code_cvt : public abs_cvt<code_cvt<KernelType, CharType>, KernelType, CharType, true, true>
 {
-    using BT = abs_cvt<code_cvt<KernelType, CharType>, KernelType, CharType, false, true>;
+    using BT = abs_cvt<code_cvt<KernelType, CharType>, KernelType, CharType, true, true>;
     friend BT; // for put_main, get_main, and private CRTP hooks
 
 public:
@@ -1021,7 +1021,6 @@ private:
         }
     }
 
-public:
     /**
      * @lang{ZH}
      * 返回当前流中已处理的内部字符总数（即逻辑位置）。
@@ -1036,10 +1035,9 @@ public:
      * @return Number of internal characters processed.
      * @endif
      */
-    [[nodiscard]] size_t tell() const
+    [[nodiscard]] size_t tell_impl() const
         requires (cvt_cpt::support_positioning<KernelType>)
     {
-        BT::assert_not_tainted();
         return m_accu_len;
     }
 
@@ -1047,7 +1045,6 @@ public:
      * @lang{ZH}
      * 将流定位至指定的绝对内部字符位置。
      * 对于变长或状态依赖编码，仅允许 `seek(0)`（定位至流起始）且须处于输入模式。
-     * 当目标位置等于当前位置时，直接返回（快速路径）。
      *
      * @param pos 目标内部字符位置。
      *
@@ -1059,7 +1056,6 @@ public:
      * Position the stream to the specified absolute internal character position.
      * For variable-length or state-dependent encodings, only `seek(0)` (repositioning
      * to the beginning of the stream) in input mode is permitted.
-     * Returns immediately when the target position equals the current position (fast path).
      *
      * @param pos Target internal character position.
      *
@@ -1068,17 +1064,9 @@ public:
      *                   a byte-offset overflow in the underlying device.
      * @endif
      */
-    void seek(size_t pos)
+    void seek_impl(size_t pos)
         requires (cvt_cpt::support_positioning<KernelType>)
     {
-        BT::assert_not_tainted();
-        // Fast path for no-op self-seek: skip validation and kernel work when
-        // pos already equals the current position. Intentional even in modes
-        // where the validation below would otherwise reject — callers using
-        // seek(saved_pos) for position-restore must not be rejected when
-        // saved_pos happens to equal tell().
-        if (this->tell() == pos) return;
-
         const bool needs_state_reset =
             m_cvt_kernel.is_var_length() || m_cvt_kernel.is_state_dep();
 
@@ -1124,10 +1112,9 @@ public:
      *                   position overflows, or if the resulting device position is misaligned.
      * @endif
      */
-    void rseek(size_t pos)
+    void rseek_impl(size_t pos)
         requires (cvt_cpt::support_positioning<KernelType>)
     {
-        BT::assert_not_tainted();
         if (m_cvt_kernel.is_var_length() || m_cvt_kernel.is_state_dep())
             throw cvt_error("code_cvt::rseek fail: cannot seek with dependent converter");
 

--- a/include/cvt/crypt/vigenere_cvt.h
+++ b/include/cvt/crypt/vigenere_cvt.h
@@ -36,9 +36,9 @@ namespace IOv2::Crypt::Classic
 /// @see chacha20_cvt for cryptographically secure encryption
 template <io_converter KernelType>
     requires std::is_integral_v<typename KernelType::internal_type>
-class vigenere_cvt : public abs_cvt<vigenere_cvt<KernelType>, KernelType, typename KernelType::internal_type, false, true>
+class vigenere_cvt : public abs_cvt<vigenere_cvt<KernelType>, KernelType, typename KernelType::internal_type, true, true>
 {
-    using BT = abs_cvt<vigenere_cvt<KernelType>, KernelType, typename KernelType::internal_type, false, true>;
+    using BT = abs_cvt<vigenere_cvt<KernelType>, KernelType, typename KernelType::internal_type, true, true>;
     friend BT;  // for put_main, get_main, and private CRTP hooks
     constexpr static size_t s_buf_len = 16;
 public:
@@ -172,19 +172,16 @@ private:
         // commit() is the responsibility of abs_cvt::put.
     }
 
-public:
     /// positioning
-    [[nodiscard]] size_t tell() const
+    [[nodiscard]] size_t tell_impl() const
         requires (cvt_cpt::support_positioning<KernelType>)
     {
-        BT::assert_not_tainted();
         return m_pos;
     }
 
-    void seek(size_t pos)
+    void seek_impl(size_t pos)
         requires (cvt_cpt::support_positioning<KernelType>)
     {
-        BT::assert_not_tainted();
         // The kernel is not required to land exactly on `pos` (e.g. clamping,
         // alignment, internal buffering), so the keystream index must be
         // resynced via tell() rather than using `pos` directly.
@@ -215,10 +212,9 @@ public:
         if (seek_err) std::rethrow_exception(seek_err);
     }
 
-    void rseek(size_t pos)
+    void rseek_impl(size_t pos)
         requires (cvt_cpt::support_positioning<KernelType>)
     {
-        BT::assert_not_tainted();
         // See seek() above for the same resync-via-tell rationale.
         std::exception_ptr rseek_err;
         try { BT::m_kernel.rseek(pos); }


### PR DESCRIPTION
- Rename template param default_positioning → enable_positioning
- abs_cvt::tell/seek/rseek/is_eof now dispatch to *_impl hooks if the derived class provides them, falling back to m_kernel directly
- seek() fast-path (no-op self-seek) and assert_not_tainted() lifted into abs_cvt; removed from code_cvt and vigenere_cvt *_impl overrides
- Add [[nodiscard]] to abs_cvt::is_eof()
- Update doc comments throughout to reflect renamed param and NVI behaviour