### PR TITLE
fix(cvt): ensure consistent early return for zero-size get/put in crypt cvts

### DIFF
--- a/include/cvt/crypt/chacha20_cvt.h
+++ b/include/cvt/crypt/chacha20_cvt.h
@@ -195,6 +195,10 @@ private:
         {
             if constexpr (cvt_cpt::support_get<KernelType>)
             {
+                // Contract: kernel.get() on BOS path guarantees to return exactly the
+                // requested byte count, or throw an exception if insufficient data is
+                // available. The check below is purely defensive, verifying this
+                // invariant at runtime.
                 const size_t n = BT::m_kernel.get(iv_buf.data(), iv_len);
                 if (n != iv_len)
                     throw cvt_error("chacha20_cvt::bos fail: incomplete IV read");
@@ -291,9 +295,9 @@ private:
     size_t get_main(cvt_reader<KernelType>& reader, internal_type* _to, size_t to_max)
         requires (cvt_cpt::support_get<KernelType>)
     {
+        if (to_max == 0) return 0;
         if (!m_cipher)
             throw cvt_error("chacha20_cvt::get_main fail: cipher not initialized (moved-from object?)");
-        if (to_max == 0) return 0;
 
         constexpr size_t isize = sizeof(internal_type);
         constexpr size_t bulk_chunk = (block_size / isize) * isize;
@@ -379,6 +383,7 @@ private:
     void put_main(cvt_writer<KernelType>& writer, const internal_type* _to, size_t to_size)
         requires (cvt_cpt::support_put<KernelType>)
     {
+        if (to_size == 0) return;
         if (!m_cipher)
             throw cvt_error("chacha20_cvt::put_main fail: cipher not initialized (moved-from object?)");
 

--- a/include/cvt/crypt/hash_cvt.h
+++ b/include/cvt/crypt/hash_cvt.h
@@ -213,6 +213,7 @@ private:
 
     void put_main(cvt_writer<KernelType>& /*writer*/, const internal_type* to, size_t to_size)
     {
+        if (to_size == 0) return;
         if (!m_hash)
             throw cvt_error("hash_cvt::put_main fail: hash not initialized (moved-from object?)");
 
@@ -221,7 +222,6 @@ private:
         if (to_size > max_safe)
             throw cvt_error("hash_cvt::put_main fail: size overflow");
 
-        if (to_size == 0) return;
         m_hash->update(reinterpret_cast<const uint8_t*>(to), to_size * sizeof(internal_type)); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
         m_has_main_cont = true;
     }
@@ -277,6 +277,15 @@ private:
         // Use copy_state()->final() to preserve original state until put() succeeds.
         // This provides strong exception safety: if put() fails, state is unchanged
         // and the operation can be retried.
+        //
+        // Intentional: a failure inside `BT::m_kernel.put(...)` is the kernel's
+        // own concern — the kernel layer must taint itself per the abs_cvt
+        // contract. hash_cvt deliberately does NOT mirror that taint upward,
+        // because (a) hash_cvt's own invariants remain intact on a kernel-side
+        // partial write (`m_has_main_cont` stays true, `m_hash` is untouched
+        // via copy_state), and (b) leaving hash_cvt clean allows the caller to
+        // recover the kernel transiently and retry `dump_stream()` without
+        // losing the accumulated `update()` history.
         auto cp_state = m_hash->copy_state();
         if (!cp_state)
             throw cvt_error("hash_cvt::dump_stream fail: cannot copy hash state");

--- a/include/cvt/crypt/vigenere_cvt.h
+++ b/include/cvt/crypt/vigenere_cvt.h
@@ -124,6 +124,7 @@ private:
     size_t get_main(cvt_reader<KernelType>& reader, internal_type* to, size_t to_max)
         requires (cvt_cpt::support_get<KernelType>)
     {
+        if (to_max == 0) return 0;
         if (m_key.empty())
             throw cvt_error("vigenere_cvt: key not initialized (moved-from object?)");
 
@@ -150,6 +151,7 @@ private:
     void put_main(cvt_writer<KernelType>& writer, const internal_type* to, size_t to_size)
         requires (cvt_cpt::support_put<KernelType>)
     {
+        if (to_size == 0) return;
         if (m_key.empty())
             throw cvt_error("vigenere_cvt: key not initialized (moved-from object?)");
 


### PR DESCRIPTION


- chacha20_cvt: move zero-size check to top of get_main/put_main
- hash_cvt: move zero-size check to top of put_main
- vigenere_cvt: add zero-size checks to top of get_main/put_main
- Add comments clarifying design intent for hash_cvt exception safety and chacha20_cvt BOS contract
- Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>