### PR TITLE
docs(cvt): add bilingual Doxygen documentation to crypt converters

### DIFF
--- a/include/cvt/crypt/chacha20_cvt.h
+++ b/include/cvt/crypt/chacha20_cvt.h
@@ -1,3 +1,27 @@
+/**
+ * @file chacha20_cvt.h
+ * @lang{ZH}
+ * ChaCha20 流加密转换器。
+ *
+ * 本文件提供两个组件：
+ * - `chacha20_cvt`：基于 Botan ChaCha20 的流加密/解密转换器。写入（加密）模式下
+ *   随机生成 IV 并将其前置于密文流；读取（解密）模式下从流头部读取 IV 进行初始化。
+ * - `chacha20_cvt_creator`：工厂类，用于在管道中统一构造 `chacha20_cvt` 实例。
+ * @endif
+ *
+ * @lang{EN}
+ * ChaCha20 stream-cipher converter.
+ *
+ * This file provides two components:
+ * - `chacha20_cvt`: A stream encryption/decryption converter backed by Botan's
+ *   ChaCha20 implementation. In write (encryption) mode the IV is randomly generated
+ *   and prepended to the ciphertext stream; in read (decryption) mode the IV is read
+ *   from the stream head.
+ * - `chacha20_cvt_creator`: A factory class for constructing `chacha20_cvt` instances
+ *   uniformly within a pipeline.
+ * @endif
+ */
+
 #pragma once
 #include <cvt/abs_cvt.h>
 #include <cvt/cvt_concepts.h>
@@ -22,8 +46,44 @@
 
 namespace IOv2::Crypt
 {
+/**
+ * @lang{ZH}
+ * `chacha20_cvt` 的内部辅助命名空间，不作为公开 API 使用。
+ * @endif
+ *
+ * @lang{EN}
+ * Internal helper namespace for `chacha20_cvt`; not part of the public API.
+ * @endif
+ */
 namespace chacha20_cvt_helpers
 {
+/**
+ * @lang{ZH}
+ * 将任意字符串密码通过 SHA-256 哈希派生为 ChaCha20 密钥。
+ *
+ * 拒绝空字符串：对空串哈希会得到公开常量 `SHA-256("")`，
+ * 将其用作流密码密钥意味着零保密性，因此直接抛出异常。
+ * @endif
+ *
+ * @lang{EN}
+ * Derives a ChaCha20 key from an arbitrary passphrase string by hashing it with SHA-256.
+ *
+ * Empty input is rejected: hashing an empty string yields the publicly known constant
+ * `SHA-256("")`, which provides zero confidentiality when used as a stream-cipher key.
+ * @endif
+ *
+ * @param key
+ * @lang{ZH} 原始密码字符串，不得为空。 @endif
+ * @lang{EN} The raw passphrase string; must not be empty. @endif
+ *
+ * @return
+ * @lang{ZH} 长度为 32 字节的 SHA-256 摘要，可直接用作 ChaCha20 密钥。 @endif
+ * @lang{EN} A 32-byte SHA-256 digest suitable for direct use as a ChaCha20 key. @endif
+ *
+ * @throws cvt_error
+ * @lang{ZH} 若 `key` 为空；或无法创建 SHA-256 哈希对象。 @endif
+ * @lang{EN} If `key` is empty, or if the SHA-256 hash object cannot be created. @endif
+ */
 inline Botan::secure_vector<uint8_t> key_gen(std::string_view key)
 {
     // Reject empty input: hashing an empty string would silently yield the
@@ -42,6 +102,51 @@ inline Botan::secure_vector<uint8_t> key_gen(std::string_view key)
 }
 }
 
+/**
+ * @lang{ZH}
+ * 基于 ChaCha20 的流加密/解密转换器。
+ *
+ * 将上游 kernel 的字节流透明地进行 ChaCha20 加解密：
+ * - **写入（加密）模式**：`bos_impl()` 随机生成 IV，将 IV 明文写入 kernel，
+ *   随后 `put_main()` 对用户数据加密后写出。
+ * - **读取（解密）模式**：`bos_impl()` 从 kernel 读取 IV，随后 `get_main()`
+ *   从 kernel 读取密文并解密后交付给用户。
+ *
+ * `internal_type` 须为单字节整数类型，以保证每个用户元素在字节流中的偏移
+ * 与密钥流偏移精确对齐。跨调用的非对齐残留字节由 `m_leftover` 缓冲区管理。
+ * @endif
+ *
+ * @lang{EN}
+ * ChaCha20-based stream encryption/decryption converter.
+ *
+ * Transparently applies ChaCha20 to the byte stream of the upstream kernel:
+ * - **Write (encryption) mode**: `bos_impl()` generates a random IV, writes it
+ *   verbatim to the kernel, and subsequent `put_main()` calls encrypt user data
+ *   before forwarding it.
+ * - **Read (decryption) mode**: `bos_impl()` reads the IV from the kernel, and
+ *   subsequent `get_main()` calls decrypt ciphertext read from the kernel before
+ *   delivering it to the user.
+ *
+ * `internal_type` must be a single-byte integral type so that every user element
+ * maps exactly onto one byte in the keystream. Sub-element ciphertext fragments
+ * carried across calls are managed by the `m_leftover` buffer.
+ * @endif
+ *
+ * @tparam KernelType
+ * @lang{ZH} 底层 IO 转换核心类型，须满足 `io_converter` concept。 @endif
+ * @lang{EN} The underlying IO converter kernel type, which must satisfy the `io_converter` concept. @endif
+ *
+ * @tparam TInt
+ * @lang{ZH}
+ * 用户侧元素类型（`internal_type`），默认与 kernel 的 `internal_type` 相同。
+ * 须为单字节平凡可复制类型，且具有唯一对象表示。
+ * @endif
+ * @lang{EN}
+ * The user-facing element type (`internal_type`), defaulting to the kernel's
+ * `internal_type`. Must be a single-byte, trivially copyable type with unique
+ * object representations.
+ * @endif
+ */
 template <io_converter KernelType, typename TInt = typename KernelType::internal_type>
     requires (std::is_integral_v<typename KernelType::internal_type> &&
               sizeof(typename KernelType::internal_type) == sizeof(uint8_t) &&
@@ -65,6 +170,34 @@ public:
         "internal_type must fit within a single chacha20 block");
 
 public:
+    /**
+     * @lang{ZH}
+     * 从字符串密码构造 ChaCha20 转换器。
+     *
+     * 内部调用 `chacha20_cvt_helpers::key_gen(key)` 将 `key` 通过 SHA-256
+     * 派生为实际密钥材料。
+     * @endif
+     *
+     * @lang{EN}
+     * Constructs a ChaCha20 converter from a passphrase string.
+     *
+     * Internally calls `chacha20_cvt_helpers::key_gen(key)` to derive actual
+     * key material from `key` via SHA-256.
+     * @endif
+     *
+     * @param kernel
+     * @lang{ZH} 底层 IO 转换核心，以移动语义传入。 @endif
+     * @lang{EN} The underlying IO converter kernel, transferred by move. @endif
+     *
+     * @param key
+     * @lang{ZH} 原始密码字符串，不得为空。 @endif
+     * @lang{EN} The raw passphrase string; must not be empty. @endif
+     *
+     * @throws cvt_error
+     * @lang{ZH} 若无法创建 ChaCha20 流密码对象；或 `key` 为空；或 SHA-256 不可用。 @endif
+     * @lang{EN} If the ChaCha20 stream cipher cannot be created, if `key` is empty,
+     * or if SHA-256 is unavailable. @endif
+     */
     chacha20_cvt(KernelType kernel, std::string_view key)
         : BT(std::move(kernel))
         , m_cipher(Botan::StreamCipher::create("ChaCha20"))
@@ -75,6 +208,35 @@ public:
         m_key = chacha20_cvt_helpers::key_gen(key);
     }
 
+    /**
+     * @lang{ZH}
+     * 从原始密钥字节构造 ChaCha20 转换器。
+     *
+     * 直接使用 `key` 作为 ChaCha20 密钥，不再进行哈希派生。
+     * 调用方须确保 `key` 的长度对 ChaCha20 有效（通常为 16 或 32 字节）。
+     * @endif
+     *
+     * @lang{EN}
+     * Constructs a ChaCha20 converter from raw key bytes.
+     *
+     * Uses `key` directly as the ChaCha20 key without any additional hashing.
+     * The caller must ensure that `key` has a valid length for ChaCha20
+     * (typically 16 or 32 bytes).
+     * @endif
+     *
+     * @param kernel
+     * @lang{ZH} 底层 IO 转换核心，以移动语义传入。 @endif
+     * @lang{EN} The underlying IO converter kernel, transferred by move. @endif
+     *
+     * @param key
+     * @lang{ZH} 原始 ChaCha20 密钥字节序列；长度须为 ChaCha20 所支持的合法值。 @endif
+     * @lang{EN} Raw ChaCha20 key bytes; length must be valid for ChaCha20. @endif
+     *
+     * @throws cvt_error
+     * @lang{ZH} 若无法创建 ChaCha20 流密码对象；或 `key` 长度不合法。 @endif
+     * @lang{EN} If the ChaCha20 stream cipher cannot be created, or if `key` has an
+     * invalid length. @endif
+     */
     chacha20_cvt(KernelType kernel, const Botan::secure_vector<uint8_t>& key)
         : BT(std::move(kernel))
         , m_cipher(Botan::StreamCipher::create("ChaCha20"))
@@ -163,6 +325,26 @@ private:
         return local_err;
     }
 
+    /**
+     * @lang{ZH}
+     * `abs_cvt::attach()` 的 CRTP 钩子，在 kernel 层 `attach()` 之后调用。
+     *
+     * 调用 `m_cipher->clear()` 重置密码器状态，并清零跨调用残留缓冲区，
+     * 确保新会话从干净状态开始，不受前次会话的密钥流影响。
+     * @endif
+     *
+     * @lang{EN}
+     * CRTP hook for `abs_cvt::attach()`, called after the kernel-level `attach()`.
+     *
+     * Calls `m_cipher->clear()` to reset cipher state and zeroes the cross-call
+     * leftover buffer. Ensures a new session starts from a clean state, independent
+     * of any previous session's keystream.
+     * @endif
+     *
+     * @throws cvt_error
+     * @lang{ZH} 若 `m_cipher` 为空或密钥缺失（已移动走的对象）。 @endif
+     * @lang{EN} If `m_cipher` is null or the key is missing (moved-from object). @endif
+     */
     void attach_impl()
     {
         if (!m_cipher || m_key.empty())
@@ -175,6 +357,39 @@ private:
         m_leftover_len = 0;
     }
 
+    /**
+     * @lang{ZH}
+     * `abs_cvt::bos()` 的 CRTP 钩子，处理流起始（BOS）的 IV 协商。
+     *
+     * - **输出模式**：随机生成 IV，设置密码器密钥与 IV，然后将 IV 明文写入 kernel。
+     * - **输入模式**：从 kernel 读取 IV，设置密码器密钥与 IV。
+     *
+     * 调用前会清零残留缓冲区，确保新流的解密不受前次流尾部残留的影响。
+     * @endif
+     *
+     * @lang{EN}
+     * CRTP hook for `abs_cvt::bos()`, handling IV negotiation at the beginning
+     * of stream (BOS).
+     *
+     * - **Output mode**: generates a random IV, initializes the cipher with the key
+     *   and IV, then writes the IV in plaintext to the kernel.
+     * - **Input mode**: reads the IV from the kernel and initializes the cipher.
+     *
+     * The leftover buffer is zeroed before processing to ensure decryption of the
+     * new stream is not contaminated by residual bytes from a previous stream.
+     * @endif
+     *
+     * @throws cvt_error
+     * @lang{ZH}
+     * 若 `m_cipher` 为空或密钥缺失；若密码器报告 IV 长度为零；
+     * 若 IV 读取不完整；或 IO 方向既非输入也非输出。
+     * @endif
+     * @lang{EN}
+     * If `m_cipher` is null or the key is missing; if the cipher reports a zero IV
+     * length; if the IV read is incomplete; or if the IO direction is neither input
+     * nor output.
+     * @endif
+     */
     void bos_impl()
     {
         if (!m_cipher || m_key.empty())
@@ -380,6 +595,39 @@ private:
         return elements_delivered;
     }
 
+    /**
+     * @lang{ZH}
+     * 加密主内容流并以 `block_size` 为单位批量写入 kernel。
+     *
+     * 以 `block_size`（64 字节）为块大小，逐块从用户缓冲区读取数据，
+     * 调用 `m_cipher->cipher()` 原地加密后通过 `writer` 提交到 kernel。
+     * 若 `to_size` 超过 `size_t` 所能安全表示的最大字节数，则分批处理。
+     *
+     * 本函数无需本地 taint 处理：`abs_cvt::put` 已将整个 `put_main`
+     * 包裹在 taint-on-throw 的 catch-all 中。详见 `get_main` 的文档。
+     * @endif
+     *
+     * @lang{EN}
+     * Encrypts the main-content stream and submits it to the kernel in
+     * `block_size`-aligned chunks.
+     *
+     * Reads from the user buffer in blocks of `block_size` (64 bytes), encrypts
+     * each block in-place via `m_cipher->cipher()`, and commits it to the kernel
+     * through `writer`. If `to_size` would overflow the safe byte-count range of
+     * `size_t`, it is processed in multiple passes.
+     *
+     * No local taint handling is needed: `abs_cvt::put` already wraps the entire
+     * `put_main` in a taint-on-throw catch-all. See `get_main` for the full rationale.
+     * @endif
+     *
+     * @param[in,out] writer  The buffered writer.
+     * @param[in]     _to     The user input buffer to encrypt.
+     * @param[in]     to_size The number of `internal_type` elements to encrypt.
+     *
+     * @throws cvt_error
+     * @lang{ZH} 若 `m_cipher` 为空（已移动走的对象）。 @endif
+     * @lang{EN} If `m_cipher` is null (moved-from object). @endif
+     */
     void put_main(cvt_writer<KernelType>& writer, const internal_type* _to, size_t to_size)
         requires (cvt_cpt::support_put<KernelType>)
     {
@@ -426,6 +674,27 @@ private:
     size_t                                      m_leftover_len{0};
 };
 
+/**
+ * @lang{ZH}
+ * `chacha20_cvt` 的工厂类，用于在转换器管道中统一构造加密转换器实例。
+ *
+ * 在构造时通过 `chacha20_cvt_helpers::key_gen()` 将字符串密码预先派生为密钥，
+ * 之后每次调用 `create()` 均复用该密钥，无需重复哈希。
+ * @endif
+ *
+ * @lang{EN}
+ * Factory class for `chacha20_cvt`, for uniform construction of encryption
+ * converter instances within a pipeline.
+ *
+ * Derives key material from a passphrase via `chacha20_cvt_helpers::key_gen()`
+ * at construction time; subsequent `create()` calls reuse the derived key without
+ * re-hashing.
+ * @endif
+ *
+ * @tparam TInt
+ * @lang{ZH} 用户侧元素类型，透传给 `chacha20_cvt`。 @endif
+ * @lang{EN} The user-facing element type, forwarded to `chacha20_cvt`. @endif
+ */
 template <typename TInt>
 struct chacha20_cvt_creator
 {

--- a/include/cvt/crypt/hash_cvt.h
+++ b/include/cvt/crypt/hash_cvt.h
@@ -1,3 +1,34 @@
+/**
+ * @file hash_cvt.h
+ * @lang{ZH}
+ * 哈希摘要转换器。
+ *
+ * 本文件提供以下组件：
+ * - `hash_algo`：支持的哈希算法枚举（MD5、SHA-256）。
+ * - `hash_fmt`：哈希摘要输出格式枚举（二进制、大写十六进制、小写十六进制）。
+ * - `set_hash_fmt`：用于通过 `adjust()` 动态切换输出格式的行为对象。
+ * - `dump_hash`：用于在主内容阶段结束前手动触发哈希输出的行为对象。
+ * - `hash_cvt`：只写哈希摘要转换器，在 `detach()` 或 `dump_hash` 行为触发时
+ *   将当前哈希结果写入底层 kernel。
+ * - `hash_cvt_creator`：工厂类，用于在管道中统一构造 `hash_cvt` 实例。
+ * @endif
+ *
+ * @lang{EN}
+ * Hash-digest converter.
+ *
+ * This file provides the following components:
+ * - `hash_algo`: Enumeration of supported hash algorithms (MD5, SHA-256).
+ * - `hash_fmt`: Enumeration of hash-digest output formats (binary, upper-hex, lower-hex).
+ * - `set_hash_fmt`: Behavior object for dynamically switching the output format via `adjust()`.
+ * - `dump_hash`: Behavior object for manually flushing the hash output before the
+ *   main-content phase ends.
+ * - `hash_cvt`: A write-only hash-digest converter that writes the current hash result
+ *   to the underlying kernel on `detach()` or in response to a `dump_hash` behavior.
+ * - `hash_cvt_creator`: A factory class for constructing `hash_cvt` instances within
+ *   a pipeline.
+ * @endif
+ */
+
 #pragma once
 #include <cvt/abs_cvt.h>
 #include <cvt/cvt_concepts.h>
@@ -18,19 +49,52 @@
 
 namespace IOv2::Crypt
 {
+/**
+ * @lang{ZH}
+ * `hash_cvt` 支持的哈希算法。
+ * @endif
+ *
+ * @lang{EN}
+ * Hash algorithms supported by `hash_cvt`.
+ * @endif
+ */
 enum class hash_algo : uint8_t
 {
-    MD5,
-    SHA256,
+    MD5,    ///< @lang{ZH} MD5 算法（128 位）。仅用于兼容性目的；不提供安全性保证。 @endif @lang{EN} MD5 algorithm (128-bit). For compatibility only; provides no security guarantees. @endif
+    SHA256, ///< @lang{ZH} SHA-256 算法（256 位）。 @endif @lang{EN} SHA-256 algorithm (256-bit). @endif
 };
 
+/**
+ * @lang{ZH}
+ * 哈希摘要的输出格式。
+ * @endif
+ *
+ * @lang{EN}
+ * Output format for the hash digest.
+ * @endif
+ */
 enum class hash_fmt : unsigned char
 {
-    binary,
-    upper_hex,
-    lower_hex
+    binary,    ///< @lang{ZH} 原始二进制字节。 @endif @lang{EN} Raw binary bytes. @endif
+    upper_hex, ///< @lang{ZH} 大写十六进制字符串（如 `"A1B2C3..."`）。 @endif @lang{EN} Uppercase hexadecimal string (e.g. `"A1B2C3..."`). @endif
+    lower_hex  ///< @lang{ZH} 小写十六进制字符串（如 `"a1b2c3..."`），为默认格式。 @endif @lang{EN} Lowercase hexadecimal string (e.g. `"a1b2c3..."`); the default format. @endif
 };
 
+/**
+ * @lang{ZH}
+ * 用于在 `hash_cvt` 上动态切换哈希输出格式的行为对象。
+ *
+ * 通过 `cvt.adjust(set_hash_fmt{hash_fmt::upper_hex})` 传入，
+ * 影响下次 `dump_hash` 或 `detach()` 时输出摘要的格式。
+ * @endif
+ *
+ * @lang{EN}
+ * Behavior object for dynamically switching the hash output format on `hash_cvt`.
+ *
+ * Pass via `cvt.adjust(set_hash_fmt{hash_fmt::upper_hex})` to change the format
+ * used when the digest is next written out (on `dump_hash` or `detach()`).
+ * @endif
+ */
 struct set_hash_fmt : cvt_behavior
 {
     explicit set_hash_fmt(hash_fmt val)
@@ -39,6 +103,25 @@ struct set_hash_fmt : cvt_behavior
     hash_fmt m_val;
 };
 
+/**
+ * @lang{ZH}
+ * 触发 `hash_cvt` 在主内容阶段中途手动输出当前哈希摘要的行为对象。
+ *
+ * 通过 `cvt.adjust(dump_hash{})` 触发，输出后哈希状态被清零，
+ * 后续写入的数据将参与新一轮哈希计算。可携带一个可选的分隔符字节，
+ * 在摘要写出之后立即将其写入 kernel。
+ * @endif
+ *
+ * @lang{EN}
+ * Behavior object that causes `hash_cvt` to flush the current hash digest
+ * mid-stream without waiting for `detach()`.
+ *
+ * Triggered via `cvt.adjust(dump_hash{})`. After flushing, the hash state is
+ * cleared and subsequent writes contribute to a fresh digest. An optional
+ * delimiter byte can be supplied; if present, it is written to the kernel
+ * immediately after the digest.
+ * @endif
+ */
 struct dump_hash : cvt_behavior
 {
     explicit dump_hash(std::optional<uint8_t> delim = std::nullopt)
@@ -47,6 +130,50 @@ struct dump_hash : cvt_behavior
     std::optional<uint8_t> m_delim;
 };
 
+/**
+ * @lang{ZH}
+ * 只写哈希摘要转换器。
+ *
+ * 接收用户写入的数据并持续更新内部哈希状态（通过 `put_main()`），
+ * 在以下时机将摘要写入底层 kernel：
+ * - 调用 `detach()`（或对象析构）时，若存在未输出的主内容。
+ * - 通过 `adjust(dump_hash{})` 手动触发时。
+ *
+ * 默认输出格式为小写十六进制（`hash_fmt::lower_hex`），
+ * 可通过 `adjust(set_hash_fmt{...})` 切换。
+ * 仅支持输出模式（`put`），不支持 `get`。
+ * @endif
+ *
+ * @lang{EN}
+ * Write-only hash-digest converter.
+ *
+ * Accepts data written by the user and continuously updates the internal hash
+ * state via `put_main()`. The digest is written to the underlying kernel at the
+ * following points:
+ * - On `detach()` (or object destruction) if there is unwritten main content.
+ * - When manually triggered via `adjust(dump_hash{})`.
+ *
+ * The default output format is lowercase hexadecimal (`hash_fmt::lower_hex`),
+ * switchable via `adjust(set_hash_fmt{...})`.
+ * Only write (output) mode is supported; `get` is not available.
+ * @endif
+ *
+ * @tparam KernelType
+ * @lang{ZH} 底层 IO 转换核心类型，须满足 `io_converter` concept 且支持 `put`。 @endif
+ * @lang{EN} The underlying IO converter kernel type; must satisfy `io_converter` and
+ * support `put`. @endif
+ *
+ * @tparam TInt
+ * @lang{ZH}
+ * 用户侧元素类型（`internal_type`），默认与 kernel 的 `internal_type` 相同。
+ * 须为单字节平凡可复制类型，且具有唯一对象表示。
+ * @endif
+ * @lang{EN}
+ * The user-facing element type (`internal_type`), defaulting to the kernel's
+ * `internal_type`. Must be a single-byte, trivially copyable type with unique
+ * object representations.
+ * @endif
+ */
 template <io_converter KernelType, typename TInt = typename KernelType::internal_type>
     requires (std::is_integral_v<typename KernelType::internal_type> &&
               sizeof(typename KernelType::internal_type) == sizeof(uint8_t) &&
@@ -64,11 +191,48 @@ public:
     using external_type = typename KernelType::internal_type;
 
 public:
+    /**
+     * @lang{ZH}
+     * 构造 `hash_cvt`，指定底层 kernel 与哈希算法。
+     * @endif
+     *
+     * @lang{EN}
+     * Constructs a `hash_cvt` with the given underlying kernel and hash algorithm.
+     * @endif
+     *
+     * @param kernel
+     * @lang{ZH} 底层 IO 转换核心，以移动语义传入。 @endif
+     * @lang{EN} The underlying IO converter kernel, transferred by move. @endif
+     *
+     * @param algo
+     * @lang{ZH} 要使用的哈希算法。 @endif
+     * @lang{EN} The hash algorithm to use. @endif
+     *
+     * @throws Botan::Lookup_Error
+     * @lang{ZH} 若无法创建对应的哈希函数对象。 @endif
+     * @lang{EN} If the hash function object cannot be created. @endif
+     */
     hash_cvt(KernelType kernel, hash_algo algo)
         : BT(std::move(kernel))
         , m_hash(Botan::HashFunction::create_or_throw(algo_to_str(algo)))
     {}
 
+    /**
+     * @lang{ZH}
+     * 拷贝构造函数。复制 kernel 与哈希状态（通过 `copy_state()`），不会触发摘要输出。
+     *
+     * 若 `copy_state()` 返回 `nullptr`，`m_has_main_cont` 被强制置为 `false`，
+     * 防止析构时对无效哈希对象调用 `dump_stream()`。
+     * @endif
+     *
+     * @lang{EN}
+     * Copy constructor. Copies the kernel and hash state (via `copy_state()`),
+     * without triggering any digest output.
+     *
+     * If `copy_state()` returns `nullptr`, `m_has_main_cont` is forced to `false`
+     * to prevent `dump_stream()` being called on a null hash object at destruction.
+     * @endif
+     */
     hash_cvt(const hash_cvt& val)
         requires (std::copy_constructible<KernelType>)
         : BT(val)
@@ -194,6 +358,24 @@ private:
         return local_err;
     }
 
+    /**
+     * @lang{ZH}
+     * `abs_cvt::attach()` 的 CRTP 钩子，在 kernel 层 `attach()` 之后调用。
+     *
+     * 调用 `m_hash->clear()` 重置哈希状态，确保新会话从空消息状态开始。
+     * @endif
+     *
+     * @lang{EN}
+     * CRTP hook for `abs_cvt::attach()`, called after the kernel-level `attach()`.
+     *
+     * Calls `m_hash->clear()` to reset the hash state, ensuring a new session
+     * starts from an empty-message state.
+     * @endif
+     *
+     * @throws cvt_error
+     * @lang{ZH} 若 `m_hash` 为空（已移动走的对象）。 @endif
+     * @lang{EN} If `m_hash` is null (moved-from object). @endif
+     */
     void attach_impl()
     {
         if (!m_hash)
@@ -201,6 +383,26 @@ private:
         m_hash->clear();
     }
 
+    /**
+     * @lang{ZH}
+     * `abs_cvt::bos()` 的 CRTP 钩子，处理流起始（BOS）。
+     *
+     * `hash_cvt` 仅支持输出模式；若 `m_io_status` 不为 `output` 则抛出异常。
+     * 调用 `m_hash->clear()` 为新流准备干净的哈希状态。
+     * @endif
+     *
+     * @lang{EN}
+     * CRTP hook for `abs_cvt::bos()`, invoked at the beginning of stream (BOS).
+     *
+     * `hash_cvt` supports output mode only; throws if `m_io_status` is not `output`.
+     * Calls `m_hash->clear()` to prepare a clean hash state for the new stream.
+     * @endif
+     *
+     * @throws cvt_error
+     * @lang{ZH} 若当前不处于输出模式；或 `m_hash` 为空（已移动走的对象）。 @endif
+     * @lang{EN} If the current mode is not output, or if `m_hash` is null
+     * (moved-from object). @endif
+     */
     void bos_impl()
     {
         if (BT::m_io_status != io_status::output)
@@ -211,6 +413,41 @@ private:
         m_hash->clear();
     }
 
+    /**
+     * @lang{ZH}
+     * 将用户数据送入哈希函数，不向 kernel 写出任何内容。
+     *
+     * 以字节为单位将 `to_size * sizeof(internal_type)` 字节传递给
+     * `m_hash->update()`。本函数不产生任何输出；摘要在 `detach()` 或
+     * `dump_hash` 行为触发时才写出。调用后 `m_has_main_cont` 被置为 `true`，
+     * 标记存在未输出的哈希内容。
+     * @endif
+     *
+     * @lang{EN}
+     * Feeds user data into the hash function without writing anything to the kernel.
+     *
+     * Passes `to_size * sizeof(internal_type)` bytes to `m_hash->update()`.
+     * No output is produced here; the digest is written only on `detach()` or in
+     * response to a `dump_hash` behavior. Sets `m_has_main_cont` to `true` to mark
+     * that there is unwritten hash content.
+     * @endif
+     *
+     * @param writer
+     * @lang{ZH} 内部写入辅助器，本函数中未实际使用。 @endif
+     * @lang{EN} The internal write helper; unused in this function. @endif
+     *
+     * @param to
+     * @lang{ZH} 用户输入数据缓冲区。 @endif
+     * @lang{EN} The user input data buffer. @endif
+     *
+     * @param to_size
+     * @lang{ZH} 输入的 `internal_type` 元素数量。 @endif
+     * @lang{EN} Number of `internal_type` elements in the input. @endif
+     *
+     * @throws cvt_error
+     * @lang{ZH} 若 `m_hash` 为空；或 `to_size * sizeof(internal_type)` 发生溢出。 @endif
+     * @lang{EN} If `m_hash` is null, or if `to_size * sizeof(internal_type)` overflows. @endif
+     */
     void put_main(cvt_writer<KernelType>& /*writer*/, const internal_type* to, size_t to_size)
     {
         if (to_size == 0) return;
@@ -226,6 +463,31 @@ private:
         m_has_main_cont = true;
     }
 
+    /**
+     * @lang{ZH}
+     * `abs_cvt::adjust()` 的 CRTP 钩子，处理 `hash_cvt` 专属行为对象。
+     *
+     * - `set_hash_fmt`：更新下次摘要输出时使用的格式（`m_out_fmt`）。
+     * - `dump_hash`：若有未输出的主内容，立即调用 `dump_stream()` 输出摘要；
+     *   若携带分隔符字节，则在摘要之后将其写入 kernel。若分隔符写入失败，
+     *   调用 `set_tainted()` 防止后续产生无边界的串联摘要。
+     * @endif
+     *
+     * @lang{EN}
+     * CRTP hook for `abs_cvt::adjust()`, handling `hash_cvt`-specific behavior objects.
+     *
+     * - `set_hash_fmt`: Updates the format used for the next digest output (`m_out_fmt`).
+     * - `dump_hash`: If there is unwritten main content, immediately calls `dump_stream()`
+     *   to flush the digest. If a delimiter byte is provided, it is written to the kernel
+     *   after the digest. If the delimiter write fails, `set_tainted()` is called to
+     *   prevent subsequent dumps from producing boundary-less concatenated digests.
+     * @endif
+     *
+     * @param acc
+     * @lang{ZH} 行为对象，须为 `set_hash_fmt` 或 `dump_hash`；否则忽略。 @endif
+     * @lang{EN} The behavior object; must be `set_hash_fmt` or `dump_hash`, otherwise
+     * ignored. @endif
+     */
     void adjust_impl(const cvt_behavior& acc)
     {
         if (const auto* shf_ptr = dynamic_cast<const set_hash_fmt*>(&acc); shf_ptr)
@@ -258,6 +520,27 @@ private:
     }
 
 private:
+    /**
+     * @lang{ZH}
+     * 将 `hash_algo` 枚举值转换为 Botan 可识别的算法名称字符串。
+     * @endif
+     *
+     * @lang{EN}
+     * Converts a `hash_algo` enumerator to the algorithm name string recognized by Botan.
+     * @endif
+     *
+     * @param algo
+     * @lang{ZH} 要转换的算法枚举值。 @endif
+     * @lang{EN} The algorithm enumerator to convert. @endif
+     *
+     * @return
+     * @lang{ZH} 对应的 Botan 算法名称字符串（如 `"MD5"`、`"SHA-256"`）。 @endif
+     * @lang{EN} The corresponding Botan algorithm name string (e.g. `"MD5"`, `"SHA-256"`). @endif
+     *
+     * @throws cvt_error
+     * @lang{ZH} 若 `algo` 不是已知枚举值。 @endif
+     * @lang{EN} If `algo` is not a recognized enumerator. @endif
+     */
     static const char* algo_to_str(hash_algo algo)
     {
         switch (algo)
@@ -269,6 +552,45 @@ private:
         }
     }
 
+    /**
+     * @lang{ZH}
+     * 将当前哈希摘要写入 kernel，并重置哈希状态。
+     *
+     * 使用 `copy_state()->final()` 计算摘要以提供强异常安全性：若 kernel
+     * 写入失败，原始哈希状态保持不变，调用方可重试。写出格式由 `m_out_fmt` 决定。
+     * 成功后将 `m_has_main_cont` 置为 `false`，并调用 `m_hash->clear()`
+     * 重置内部状态；若 `clear()` 抛出，则 taint。
+     *
+     * kernel 层写入失败不会导致 `hash_cvt` 本身 taint：`hash_cvt` 的不变量
+     * 在 kernel 侧局部写入失败时仍保持完整（`m_has_main_cont` 保持 `true`，
+     * `m_hash` 经由 `copy_state()` 未被修改），允许调用方恢复 kernel 后重试。
+     * @endif
+     *
+     * @lang{EN}
+     * Writes the current hash digest to the kernel and resets the hash state.
+     *
+     * Uses `copy_state()->final()` to compute the digest, providing strong exception
+     * safety: if the kernel write fails, the original hash state is unchanged and
+     * the caller may retry. Output format is determined by `m_out_fmt`. On success,
+     * `m_has_main_cont` is set to `false` and `m_hash->clear()` is called to reset
+     * internal state; if `clear()` throws, the cvt is tainted.
+     *
+     * A failure in the kernel write does NOT taint `hash_cvt` itself because
+     * `hash_cvt`'s own invariants remain intact on a partial kernel write
+     * (`m_has_main_cont` stays `true`, `m_hash` is untouched via `copy_state()`),
+     * allowing the caller to recover the kernel and retry.
+     * @endif
+     *
+     * @throws cvt_error
+     * @lang{ZH}
+     * 若无法复制哈希状态；若摘要为空；若 `m_out_fmt` 为无效值；
+     * 或若 kernel 写入抛出异常（从 kernel 层传播）。
+     * @endif
+     * @lang{EN}
+     * If the hash state cannot be copied; if the digest is empty; if `m_out_fmt`
+     * is invalid; or if the kernel write throws (propagated from the kernel layer).
+     * @endif
+     */
     void dump_stream()
     {
         if (!m_has_main_cont) return;
@@ -332,6 +654,20 @@ private:
     hash_fmt     m_out_fmt{hash_fmt::lower_hex};
 };
 
+/**
+ * @lang{ZH}
+ * `hash_cvt` 的工厂类，用于在转换器管道中统一构造哈希摘要转换器实例。
+ * @endif
+ *
+ * @lang{EN}
+ * Factory class for `hash_cvt`, for uniform construction of hash-digest converter
+ * instances within a pipeline.
+ * @endif
+ *
+ * @tparam TInt
+ * @lang{ZH} 用户侧元素类型，透传给 `hash_cvt`。 @endif
+ * @lang{EN} The user-facing element type, forwarded to `hash_cvt`. @endif
+ */
 template <typename TInt>
 struct hash_cvt_creator
 {

--- a/include/cvt/crypt/vigenere_cvt.h
+++ b/include/cvt/crypt/vigenere_cvt.h
@@ -1,3 +1,30 @@
+/**
+ * @file vigenere_cvt.h
+ * @lang{ZH}
+ * 维吉尼亚密码转换器（仅供教学和演示用途）。
+ *
+ * @warning **请勿用于生产安全场景。**
+ *
+ * 本文件提供两个组件：
+ * - `vigenere_cvt`：基于维吉尼亚多表替换密码的双向流转换器，
+ *   支持读（解密）和写（加密）两种方向，以及可选的定位操作。
+ * - `vigenere_cvt_creator`：工厂类，用于在管道中统一构造 `vigenere_cvt` 实例。
+ * @endif
+ *
+ * @lang{EN}
+ * Vigenère cipher converter, for educational and demonstration purposes only.
+ *
+ * @warning **NOT FOR PRODUCTION SECURITY USE.**
+ *
+ * This file provides two components:
+ * - `vigenere_cvt`: A bidirectional stream converter based on the Vigenère
+ *   polyalphabetic substitution cipher, supporting both read (decryption) and
+ *   write (encryption) directions as well as optional positioning.
+ * - `vigenere_cvt_creator`: A factory class for constructing `vigenere_cvt`
+ *   instances within a pipeline.
+ * @endif
+ */
+
 #pragma once
 #include <cvt/abs_cvt.h>
 #include <cvt/cvt_concepts.h>
@@ -13,27 +40,52 @@
 
 namespace IOv2::Crypt::Classic
 {
-/// @brief Vigenère cipher converter for educational and demonstration purposes.
-///
-/// @warning **NOT FOR PRODUCTION SECURITY USE**
-///
-/// The Vigenère cipher is a historical polyalphabetic substitution cipher
-/// that has been completely broken since the 19th century. It provides
-/// NO cryptographic security and should NEVER be used to protect sensitive data.
-///
-/// Known vulnerabilities:
-/// - Kasiski examination can determine key length from ciphertext alone
-/// - Frequency analysis breaks each position as a simple Caesar cipher
-/// - No resistance to known-plaintext or chosen-plaintext attacks
-///
-/// For actual encryption needs, use `chacha20_cvt` or other modern ciphers.
-///
-/// This class is provided for:
-/// - Educational purposes (learning about classical ciphers)
-/// - Simple obfuscation (NOT security)
-/// - Historical/demonstration purposes
-///
-/// @see chacha20_cvt for cryptographically secure encryption
+/**
+ * @lang{ZH}
+ * 维吉尼亚密码转换器（仅供教学和演示用途）。
+ *
+ * @warning **请勿用于生产安全场景。**
+ *
+ * 维吉尼亚密码是一种历史性多表替换密码，自 19 世纪以来已被彻底破解，
+ * 不提供任何密码学安全性，绝不应用于保护敏感数据。
+ *
+ * 已知漏洞：
+ * - Kasiski 检验可仅凭密文推断密钥长度。
+ * - 频率分析可将每个位置视为简单的凯撒密码逐一破解。
+ * - 对已知明文攻击和选择明文攻击无任何抵抗力。
+ *
+ * 如需真正的加密能力，请使用 `chacha20_cvt` 或其他现代密码。
+ *
+ * 本类仅适用于：
+ * - 教学目的（了解古典密码学）。
+ * - 简单混淆（非安全用途）。
+ * - 历史/演示目的。
+ * @endif
+ *
+ * @lang{EN}
+ * Vigenère cipher converter, for educational and demonstration purposes only.
+ *
+ * @warning **NOT FOR PRODUCTION SECURITY USE.**
+ *
+ * The Vigenère cipher is a historical polyalphabetic substitution cipher that
+ * has been completely broken since the 19th century. It provides NO cryptographic
+ * security and should NEVER be used to protect sensitive data.
+ *
+ * Known vulnerabilities:
+ * - Kasiski examination can determine key length from ciphertext alone.
+ * - Frequency analysis breaks each position as a simple Caesar cipher.
+ * - No resistance to known-plaintext or chosen-plaintext attacks.
+ *
+ * For actual encryption needs, use `chacha20_cvt` or other modern ciphers.
+ *
+ * This class is provided for:
+ * - Educational purposes (learning about classical ciphers).
+ * - Simple obfuscation (NOT security).
+ * - Historical/demonstration purposes.
+ *
+ * @see chacha20_cvt
+ * @endif
+ */
 template <io_converter KernelType>
     requires std::is_integral_v<typename KernelType::internal_type>
 class vigenere_cvt : public abs_cvt<vigenere_cvt<KernelType>, KernelType, typename KernelType::internal_type, true, true>
@@ -47,6 +99,28 @@ public:
     using external_type = internal_type;
 
 public:
+    /**
+     * @lang{ZH}
+     * 构造维吉尼亚密码转换器。
+     * @endif
+     *
+     * @lang{EN}
+     * Constructs a Vigenère cipher converter.
+     * @endif
+     *
+     * @param dev
+     * @lang{ZH} 底层 IO 转换核心，以移动语义传入。 @endif
+     * @lang{EN} The underlying IO converter kernel, transferred by move. @endif
+     *
+     * @param s
+     * @lang{ZH} 密钥字符串，不得为空；其字符类型须与 `internal_type` 一致。 @endif
+     * @lang{EN} The key string; must not be empty; its character type must match
+     * `internal_type`. @endif
+     *
+     * @throws cvt_error
+     * @lang{ZH} 若 `s` 为空。 @endif
+     * @lang{EN} If `s` is empty. @endif
+     */
     vigenere_cvt(KernelType dev, std::basic_string_view<internal_type> s)
         : BT(std::move(dev))
         , m_key([s]
@@ -86,6 +160,23 @@ private:
         return nullptr;
     }
 
+    /**
+     * @lang{ZH}
+     * `abs_cvt::attach()` 的 CRTP 钩子，在 kernel 层 `attach()` 之后调用。
+     *
+     * 验证密钥非空，防止已移动走的对象被误用。
+     * @endif
+     *
+     * @lang{EN}
+     * CRTP hook for `abs_cvt::attach()`, called after the kernel-level `attach()`.
+     *
+     * Validates that the key is non-empty, guarding against misuse of a moved-from object.
+     * @endif
+     *
+     * @throws cvt_error
+     * @lang{ZH} 若密钥为空（已移动走的对象）。 @endif
+     * @lang{EN} If the key is empty (moved-from object). @endif
+     */
     void attach_impl()
     {
         if (m_key.empty())
@@ -93,34 +184,98 @@ private:
     }
 
     /**
+     * @lang{ZH}
+     * `abs_cvt::main_cont_beg()` 的 CRTP 钩子，在 kernel 层 `main_cont_beg()` 之后调用。
+     *
+     * 将密钥偏移量 `m_pos` 归零，使主内容阶段的加解密从密钥起始位置开始。
+     * @endif
+     *
+     * @lang{EN}
      * CRTP hook for `abs_cvt::main_cont_beg()`, called after the kernel-level
      * `main_cont_beg()`.
      *
      * Resets the key-offset position `m_pos` to zero so that main-content
      * encryption/decryption starts from the beginning of the key.
+     * @endif
      */
     void main_cont_beg_impl()
     {
         m_pos = 0;
     }
 
-    // Vigenère arithmetic is performed in the unsigned domain to avoid
-    // signed integer overflow UB when internal_type is a signed multi-byte
-    // type (e.g. int32_t). Unsigned subtraction/addition is well-defined
-    // (modulo 2^N wrap), and the back-cast to internal_type is well-defined
-    // under C++20's two's-complement guarantee. Encryption (add_wrap) and
-    // decryption (sub_wrap) remain exact inverses in the mod-2^N group.
+    /**
+     * @lang{ZH}
+     * 在无符号域内执行模减法，返回 `(a - b) mod 2^N`，用于解密。
+     *
+     * 使用无符号运算以避免有符号整数溢出未定义行为（例如当 `internal_type` 为
+     * `int32_t` 时）。回转为 `internal_type` 在 C++20 二补数保证下行为明确。
+     * 与 `add_wrap` 互为逆运算，确保加解密在 mod-2^N 群中精确互逆。
+     * @endif
+     *
+     * @lang{EN}
+     * Performs modular subtraction in the unsigned domain, returning `(a - b) mod 2^N`,
+     * used for decryption.
+     *
+     * Uses unsigned arithmetic to avoid signed-integer-overflow UB (e.g. when
+     * `internal_type` is `int32_t`). The back-cast to `internal_type` is well-defined
+     * under C++20's two's-complement guarantee. Is the exact inverse of `add_wrap`,
+     * ensuring encryption and decryption are precise inverses in the mod-2^N group.
+     * @endif
+     */
     static constexpr internal_type sub_wrap(internal_type a, internal_type b) noexcept
     {
         using U = std::make_unsigned_t<internal_type>;
         return static_cast<internal_type>(static_cast<U>(a) - static_cast<U>(b));
     }
+    /**
+     * @lang{ZH}
+     * 在无符号域内执行模加法，返回 `(a + b) mod 2^N`，用于加密。
+     *
+     * 与 `sub_wrap` 互为逆运算，确保加解密在 mod-2^N 群中精确互逆。
+     * @endif
+     *
+     * @lang{EN}
+     * Performs modular addition in the unsigned domain, returning `(a + b) mod 2^N`,
+     * used for encryption.
+     *
+     * Is the exact inverse of `sub_wrap`, ensuring encryption and decryption are
+     * precise inverses in the mod-2^N group.
+     * @endif
+     */
     static constexpr internal_type add_wrap(internal_type a, internal_type b) noexcept
     {
         using U = std::make_unsigned_t<internal_type>;
         return static_cast<internal_type>(static_cast<U>(a) + static_cast<U>(b));
     }
 
+    /**
+     * @lang{ZH}
+     * 解密主内容流并以 `internal_type` 元素为单位输出。
+     *
+     * 从 `reader` 读取密文，按密钥循环位置对每个元素执行 `sub_wrap`（减去密钥字符），
+     * 输出到用户缓冲区 `to`。密钥偏移量 `m_pos` 在每次元素处理后递增。
+     * @endif
+     *
+     * @lang{EN}
+     * Decrypts the main-content stream and delivers it in `internal_type`-aligned units.
+     *
+     * Reads ciphertext from `reader` and applies `sub_wrap` (subtracts the key character
+     * at the current cyclic key position) to each element, writing the result to the
+     * user buffer `to`. The key-offset `m_pos` is incremented after each element.
+     * @endif
+     *
+     * @param[in,out] reader The buffered reader.
+     * @param[out]    to     The user output buffer.
+     * @param[in]     to_max The maximum number of elements to deliver.
+     *
+     * @return
+     * @lang{ZH} 实际解密并写入用户缓冲的元素数量。 @endif
+     * @lang{EN} The number of elements actually decrypted into the user buffer. @endif
+     *
+     * @throws cvt_error
+     * @lang{ZH} 若密钥为空（已移动走的对象）。 @endif
+     * @lang{EN} If the key is empty (moved-from object). @endif
+     */
     size_t get_main(cvt_reader<KernelType>& reader, internal_type* to, size_t to_max)
         requires (cvt_cpt::support_get<KernelType>)
     {
@@ -148,6 +303,30 @@ private:
         return total_count;
     }
 
+    /**
+     * @lang{ZH}
+     * 加密主内容流并写入 kernel。
+     *
+     * 对用户缓冲区 `to` 中的每个元素执行 `add_wrap`（加上密钥循环位置处的密钥字符），
+     * 通过 `writer` 将密文提交到 kernel。密钥偏移量 `m_pos` 在每次元素处理后递增。
+     * @endif
+     *
+     * @lang{EN}
+     * Encrypts the main-content stream and writes it to the kernel.
+     *
+     * Applies `add_wrap` (adds the key character at the current cyclic key position)
+     * to each element in the user buffer `to`, then commits the ciphertext to the
+     * kernel via `writer`. The key-offset `m_pos` is incremented after each element.
+     * @endif
+     *
+     * @param[in,out] writer  The buffered writer.
+     * @param[in]     to      The user input buffer to encrypt.
+     * @param[in]     to_size The number of `internal_type` elements to encrypt.
+     *
+     * @throws cvt_error
+     * @lang{ZH} 若密钥为空（已移动走的对象）。 @endif
+     * @lang{EN} If the key is empty (moved-from object). @endif
+     */
     void put_main(cvt_writer<KernelType>& writer, const internal_type* to, size_t to_size)
         requires (cvt_cpt::support_put<KernelType>)
     {
@@ -174,31 +353,67 @@ private:
         // commit() is the responsibility of abs_cvt::put.
     }
 
-    /// positioning
+    /**
+     * @lang{ZH}
+     * `abs_cvt::tell()` 的 CRTP 钩子，返回当前密钥偏移量。
+     * @endif
+     *
+     * @lang{EN}
+     * CRTP hook for `abs_cvt::tell()`. Returns the current key-offset.
+     * @endif
+     *
+     * @return
+     * @lang{ZH} 当前密钥偏移量 `m_pos`。 @endif
+     * @lang{EN} The current key-offset `m_pos`. @endif
+     */
     [[nodiscard]] size_t tell_impl() const
         requires (cvt_cpt::support_positioning<KernelType>)
     {
         return m_pos;
     }
 
+    /**
+     * @lang{ZH}
+     * `abs_cvt::seek()` 的 CRTP 钩子，将 kernel 定位到绝对位置 `pos`。
+     *
+     * 调用 `m_kernel.seek(pos)` 后通过 `m_kernel.tell()` 重新同步 `m_pos`，
+     * 而非直接使用 `pos`。原因：kernel 可能因对齐、夹紧或内部缓冲而实际落在
+     * 不同位置；`tell()` 返回 kernel 的真实位置，确保密钥流偏移与字节流偏移对齐。
+     * 若 `seek()` 抛出，仍尝试 `tell()` 以保持同步；若 `tell()` 也抛出，
+     * 则无法确定 kernel 的实际位置，密钥流将失同步 —— 必须 taint。
+     * @endif
+     *
+     * @lang{EN}
+     * CRTP hook for `abs_cvt::seek()`, positioning the kernel to the absolute
+     * position `pos`.
+     *
+     * Calls `m_kernel.seek(pos)` and then re-syncs `m_pos` via `m_kernel.tell()`
+     * rather than using `pos` directly. This is necessary because the kernel may
+     * land on a different position due to alignment, clamping, or internal buffering;
+     * `tell()` returns the kernel's actual position, keeping the keystream offset
+     * aligned with the byte stream. If `seek()` throws, `tell()` is still attempted
+     * to maintain synchronisation; if `tell()` also throws, the kernel's actual
+     * position is indeterminate and the keystream would desync — the converter must taint.
+     * @endif
+     *
+     * @param pos
+     * @lang{ZH} 目标绝对字节偏移量。 @endif
+     * @lang{EN} The target absolute byte offset. @endif
+     *
+     * @throws
+     * @lang{ZH}
+     * 重新抛出 `seek()` 的异常（若有）；若 `tell()` 抛出则抛出 `tell()` 的异常
+     * （`seek()` 的异常被丢弃，因为 `tell()` 失败意味着位置不可知）。
+     * @endif
+     * @lang{EN}
+     * Re-throws the `seek()` exception (if any); if `tell()` throws, throws the
+     * `tell()` exception (the `seek()` exception is discarded because a `tell()`
+     * failure means the position is indeterminate).
+     * @endif
+     */
     void seek_impl(size_t pos)
         requires (cvt_cpt::support_positioning<KernelType>)
     {
-        // The kernel is not required to land exactly on `pos` (e.g. clamping,
-        // alignment, internal buffering), so the keystream index must be
-        // resynced via tell() rather than using `pos` directly.
-        //
-        // The kernel only needs to provide a basic exception guarantee on
-        // seek(): if seek throws, the kernel position may have moved. Either
-        // way, the kernel is in *some* well-defined position, and tell() will
-        // report it. So we always attempt to resync m_pos via tell(), even
-        // when seek throws — that keeps the keystream index aligned with the
-        // kernel's real position and lets the user safely retry or continue.
-        //
-        // Only when tell() itself throws can we no longer determine where the
-        // kernel landed; that desync would silently corrupt the keystream, so
-        // we taint. If both seek() and tell() throw, the seek exception wins
-        // (it is what the user actually invoked).
         std::exception_ptr seek_err;
         try { BT::m_kernel.seek(pos); }
         catch (...) { seek_err = std::current_exception(); }
@@ -214,10 +429,30 @@ private:
         if (seek_err) std::rethrow_exception(seek_err);
     }
 
+    /**
+     * @lang{ZH}
+     * `abs_cvt::rseek()` 的 CRTP 钩子，将 kernel 相对当前位置移动 `pos` 字节。
+     *
+     * 逻辑与 `seek_impl()` 完全相同，但调用 `m_kernel.rseek(pos)` 执行相对定位。
+     * 详见 `seek_impl()` 的文档。
+     * @endif
+     *
+     * @lang{EN}
+     * CRTP hook for `abs_cvt::rseek()`, positioning the kernel relative to the
+     * current position by `pos` bytes.
+     *
+     * The logic is identical to `seek_impl()`, but calls `m_kernel.rseek(pos)` for
+     * relative positioning. See `seek_impl()` for the full rationale.
+     * @endif
+     *
+     * @param pos
+     * @lang{ZH} 相对于当前位置的字节偏移量。 @endif
+     * @lang{EN} Byte offset relative to the current position. @endif
+     */
     void rseek_impl(size_t pos)
         requires (cvt_cpt::support_positioning<KernelType>)
     {
-        // See seek() above for the same resync-via-tell rationale.
+        // See seek_impl() above for the same resync-via-tell rationale.
         std::exception_ptr rseek_err;
         try { BT::m_kernel.rseek(pos); }
         catch (...) { rseek_err = std::current_exception(); }
@@ -237,6 +472,25 @@ private:
     std::vector<internal_type> m_key;
 };
 
+/**
+ * @lang{ZH}
+ * `vigenere_cvt` 的工厂类，用于在转换器管道中统一构造维吉尼亚密码转换器实例。
+ *
+ * 在构造时验证并存储密钥；每次调用 `create()` 均使用同一密钥。
+ * @endif
+ *
+ * @lang{EN}
+ * Factory class for `vigenere_cvt`, for uniform construction of Vigenère cipher
+ * converter instances within a pipeline.
+ *
+ * Validates and stores the key at construction time; subsequent `create()` calls
+ * reuse the same key.
+ * @endif
+ *
+ * @tparam TChar
+ * @lang{ZH} 密钥及数据流的字符类型。 @endif
+ * @lang{EN} The character type of the key and data stream. @endif
+ */
 template <typename TChar>
 class vigenere_cvt_creator
 {


### PR DESCRIPTION
Add @lang{ZH}/@lang{EN} bilingual Doxygen comments to all three headers in include/cvt/crypt/, matching the style established in abs_cvt.h. Covers file-level @file blocks, class/struct/enum docs, template parameter docs, and all member function docs.

- chacha20_cvt.h: document key_gen(), chacha20_cvt class and its constructors, attach_impl(), bos_impl(), put_main(), and chacha20_cvt_creator.
- hash_cvt.h: document hash_algo and hash_fmt enums (including enumerators), set_hash_fmt, dump_hash, hash_cvt and its members, algo_to_str(), dump_stream(), and hash_cvt_creator.
- vigenere_cvt.h: convert existing English-only comments to bilingual format; add docs for attach_impl(), sub_wrap()/add_wrap(), get_main(), put_main(), tell_impl(), seek_impl(), rseek_impl(), and vigenere_cvt_creator.