### PR TITLE
fix(facet): fix grouping UB and clean up ctype/helper quality issues

### DIFF
--- a/include/facet/ctype.h
+++ b/include/facet/ctype.h
@@ -1,11 +1,10 @@
 #pragma once
 
+#include <common/lru_cache.h>
+#include <common/metafunctions.h>
+#include <facet/ctype_details.h>
 #include <memory>
 #include <mutex>
-
-#include <common/metafunctions.h>
-#include <common/lru_cache.h>
-#include <facet/ctype_details.h>
 
 namespace IOv2
 {
@@ -47,7 +46,7 @@ public:
     {
         return m_table[static_cast<unsigned char>(c)];
     }
-    
+
     bool is_any(mask m, CharT c) const
     {
         return is(c) & m;
@@ -81,7 +80,7 @@ public:
     {
         return m_toupper[static_cast<unsigned char>(c)];
     }
-    
+
     template <typename InIt, typename OutIt>
     OutIt toupper_seq(InIt beg, InIt end, OutIt dst) const
     {
@@ -107,7 +106,7 @@ public:
     {
         return m_widen[static_cast<unsigned char>(c)];
     }
-    
+
     template <typename InIt, typename OutIt>
     OutIt widen_seq(InIt beg, InIt end, OutIt dst) const
     {
@@ -266,7 +265,7 @@ public:
         }
         return dst;
     }
-    
+
 private:
     mask do_is(CharT c) const
     {
@@ -283,7 +282,7 @@ private:
         }
         return *res;
     }
-    
+
     CharT do_toupper(CharT c) const
     {
         if (static_cast<unsigned>(c) < s_len)
@@ -299,7 +298,7 @@ private:
         }
         return *res;
     }
-    
+
     CharT do_tolower(CharT c) const
     {
         if (static_cast<unsigned>(c) < s_len)
@@ -315,7 +314,7 @@ private:
         }
         return *res;
     }
-    
+
     std::optional<char> do_narrow(CharT c) const
     {
         if (static_cast<unsigned>(c) < s_len)

--- a/include/facet/ctype_details.h
+++ b/include/facet/ctype_details.h
@@ -1,11 +1,12 @@
 #pragma once
+#include <common/clocale_wrapper.h>
+#include <facet/facet_common.h>
+
 #include <algorithm>
 #include <cctype>
 #include <cwctype>
+#include <limits>
 #include <optional>
-
-#include <facet/facet_common.h>
-#include <common/clocale_wrapper.h>
 
 namespace IOv2
 {
@@ -96,9 +97,9 @@ private:
 };
 
 template <typename CharT>
-    requires std::is_same_v<CharT, wchar_t> || 
-                (std::is_same_v<CharT, char32_t> && 
-                 (sizeof(char32_t) == sizeof(wchar_t)) && 
+    requires std::is_same_v<CharT, wchar_t> ||
+                (std::is_same_v<CharT, char32_t> &&
+                 (sizeof(char32_t) == sizeof(wchar_t)) &&
                  (static_cast<wchar_t>(U'李') == L'李') &&
                  (static_cast<char32_t>(L'伟') == U'伟'))
 class ctype_conf<CharT> : public ft_basic<ctype<CharT>>
@@ -111,7 +112,7 @@ public:
         clocale_user guard(m_inter_locale);
         for (size_t j = 0; j < sizeof(m_widen) / sizeof(wint_t); ++j)
           m_widen[j] = btowc(j);
-          
+
         m_wmask_upper  = wctype_l("upper",  m_inter_locale.c_locale);
         m_wmask_lower  = wctype_l("lower",  m_inter_locale.c_locale);
         m_wmask_alpha  = wctype_l("alpha",  m_inter_locale.c_locale);
@@ -122,7 +123,7 @@ public:
         m_wmask_cntrl  = wctype_l("cntrl",  m_inter_locale.c_locale);
         m_wmask_punct  = wctype_l("punct",  m_inter_locale.c_locale);
     }
-    
+
     virtual base_ft<ctype>::mask is(CharT _c) const
     {
         base_ft<ctype>::mask res = 0;
@@ -193,7 +194,7 @@ public:
             return static_cast<mask>(0);
         return m_internal.is(static_cast<char>(c));
     }
-    
+
     virtual char8_t toupper(char8_t c) const
     {
         if (c & 0x80) return c;
@@ -207,13 +208,13 @@ public:
     }
 
     virtual char8_t widen(char c) const { return static_cast<char8_t>(c); }
-    
+
     virtual std::optional<char> narrow(char8_t c) const
     {
         if (c & 0x80) return std::nullopt;
         return static_cast<char>(c);
     }
-    
+
 private:
     ctype_conf<char> m_internal;
 };

--- a/include/facet/facet_helper.h
+++ b/include/facet/facet_helper.h
@@ -1,11 +1,13 @@
 #pragma once
-#include <langinfo.h>
-#include <nl_types.h>
-#include <limits>
-#include <string>
 #include <cvt/cvt_facilities.h>
 #include <facet/ctype_details.h>
 #include <io/io_base.h>
+
+#include <cassert>
+#include <limits>
+#include <string>
+#include <langinfo.h>
+#include <nl_types.h>
 
 namespace IOv2::FacetHelper
 {
@@ -19,16 +21,20 @@ namespace IOv2::FacetHelper
         // Convert char to wchar_t then narrow down
         std::wstring wide_str = detail::to_wstring(ptr, locale_name);
         if (wide_str.empty()) return '\0';
-        
+
         ctype_conf<wchar_t> tmp_ctype(locale_name);
         auto res = tmp_ctype.narrow(wide_str[0]);
         return res.has_value() ? res.value() : '\0';
     }
-    
+
+    // Internal helper function. Callers are responsible for ensuring that
+    // grouping is non-empty; this function does not validate that precondition.
     template <typename CharT>
     inline CharT* add_grouping(CharT* s, CharT sep, const std::vector<uint8_t>& grouping,
                                const CharT* first, const CharT* last)
     {
+        assert(!grouping.empty());
+
         size_t idx = 0;
         size_t ctr = 0;
         size_t gsize = grouping.size();
@@ -46,22 +52,30 @@ namespace IOv2::FacetHelper
         while (ctr--)
         {
             *s++ = sep;
-            for (char i = grouping[idx]; i > 0; --i)
+            for (uint8_t i = grouping[idx]; i > 0; --i)
                 *s++ = *first++;
         }
 
         while (idx--)
         {
             *s++ = sep;
-            for (char i = grouping[idx]; i > 0; --i)
+            for (uint8_t i = grouping[idx]; i > 0; --i)
                 *s++ = *first++;
         }
         return s;
     }
-    
+
+    // Internal helper function. Callers are responsible for ensuring that both
+    // grouping and grouping_tmp are non-empty; this function does not validate
+    // those preconditions. Callers guarantee grouping is non-empty because
+    // grouping_tmp is only populated inside !grouping.empty() branches, so
+    // the non-emptiness of grouping_tmp implies the non-emptiness of grouping.
     inline bool verify_grouping(const std::vector<uint8_t>& grouping,
                                 const std::string& grouping_tmp)
     {
+        assert(!grouping.empty());
+        assert(!grouping_tmp.empty());
+
         const size_t n = grouping_tmp.size() - 1;
         const size_t min_val = std::min(n, size_t(grouping.size() - 1));
         size_t i = n;

--- a/include/facet/monetary.h
+++ b/include/facet/monetary.h
@@ -470,7 +470,7 @@ private:
                 res.insert(res.begin(), '-');
 
             // Test for grouping fidelity.
-            if (grouping_tmp.size())
+            if (!grouping_tmp.empty())
             {
                 // Add the ending grouping.
                 grouping_tmp += static_cast<char>(testdecfound ? last_pos : n);

--- a/include/facet/numeric.h
+++ b/include/facet/numeric.h
@@ -862,7 +862,7 @@ private:
         bool success = true;
         // Digit grouping is checked. If grouping and found_grouping don't
         // match, then get very very upset, and set failbit.
-        if (found_grouping.size())
+        if (!found_grouping.empty())
         {
             // Add the ending grouping if a decimal or 'e'/'E' wasn't found.
             if (!found_dec && !found_sci)


### PR DESCRIPTION
- add_grouping: assert non-empty grouping to guard against OOB access on grouping[0] when grouping is empty (size_t underflow -> UB)
- add_grouping: change loop variable from char to uint8_t to prevent sign truncation when grouping value > 127 causing loop to not execute
- verify_grouping: assert non-empty grouping and grouping_tmp to guard against size_t underflow and subsequent OOB access
- monetary/numeric: replace .size() with .empty() for intent clarity
- ctype.h, ctype_details.h, facet_helper.h: reorder includes to follow local -> C++ -> C convention with alphabetical order within each group
- ctype.h, ctype_details.h, facet_helper.h: remove trailing whitespace
- ctype.h, ctype_details.h, facet_helper.h: add missing POSIX trailing newline
- ctype_details.h: add missing <limits> include for std::numeric_limits