### PR TITLE
fix(facet): fix missing/unnecessary includes and nl_langinfo locale assumption

### DIFF
--- a/include/facet/ctype_details.h
+++ b/include/facet/ctype_details.h
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <cwchar>
 #include <cwctype>
 #include <limits>
 #include <optional>

--- a/include/facet/facet_helper.h
+++ b/include/facet/facet_helper.h
@@ -1,7 +1,7 @@
 #pragma once
+#include <common/clocale_wrapper.h>
 #include <cvt/cvt_facilities.h>
 #include <facet/ctype_details.h>
-#include <io/io_base.h>
 
 #include <cassert>
 #include <limits>
@@ -116,6 +116,9 @@ namespace IOv2::FacetHelper
             (static_cast<char32_t>(L'伟') == U'伟'))
     inline CharT nl_langinfo_char(nl_item item, const std::string& locale_name, CharT default_char)
     {
+        clocale_wrapper inter_locale(locale_name.c_str());
+        clocale_user guard(inter_locale);
+
         const char* narrow = nl_langinfo(item);
         if (!narrow || narrow[0] == '\0')
             return default_char;

--- a/include/facet/monetary.h
+++ b/include/facet/monetary.h
@@ -1,9 +1,11 @@
 #pragma once
+#include <common/metafunctions.h>
+#include <facet/monetary_details.h>
+#include <io/io_base.h>
+
 #include <concepts>
 #include <iterator>
 #include <memory>
-#include <common/metafunctions.h>
-#include <facet/monetary_details.h>
 
 namespace IOv2
 {

--- a/include/facet/numeric.h
+++ b/include/facet/numeric.h
@@ -4,6 +4,7 @@
 #include <common/metafunctions.h>
 #include <facet/ctype.h>
 #include <facet/numeric_details.h>
+#include <io/io_base.h>
 #include <type_traits>
 
 namespace IOv2

--- a/include/facet/numeric_details.h
+++ b/include/facet/numeric_details.h
@@ -105,12 +105,12 @@ public:
             return;
         }
 
+        m_decimal_point = FacetHelper::nl_langinfo_char<CharT>(DECIMAL_POINT, name, static_cast<CharT>('.'));
+        m_thousands_sep = FacetHelper::nl_langinfo_char<CharT>(THOUSANDS_SEP, name, static_cast<CharT>('\0'));
+
         clocale_wrapper inter_locale(name.c_str());
         clocale_user guard(inter_locale);
 
-        m_decimal_point = FacetHelper::nl_langinfo_char<CharT>(DECIMAL_POINT, name, static_cast<CharT>('.'));
-        m_thousands_sep = FacetHelper::nl_langinfo_char<CharT>(THOUSANDS_SEP, name, static_cast<CharT>('\0'));
-                
         if (m_thousands_sep != '\0')
         {
             const char* src = nl_langinfo(GROUPING);


### PR DESCRIPTION


- ctype_details.h: add direct <cwchar> include for btowc/wctob declarations
- facet_helper.h: remove transitive <io/io_base.h>; add <common/clocale_wrapper.h>; set C locale explicitly in nl_langinfo_char before calling nl_langinfo so the correct locale data is retrieved regardless of caller's global locale state
- numeric_details.h: move nl_langinfo_char calls out of clocale_user guard scope since nl_langinfo_char now manages its own locale guard internally
- numeric.h: add direct <io/io_base.h> include for ios_base/ios_defs
- monetary.h: reorder includes (local headers before C++ headers); add direct <io/io_base.h> include