### PR TITLE
fix(facet): unify grouping sentinel to uint8_t max, extract adjust_grouping helper

### DIFF
--- a/include/facet/facet_helper.h
+++ b/include/facet/facet_helper.h
@@ -90,13 +90,41 @@ namespace IOv2::FacetHelper
         return s;
     }
 
+    // Normalise a raw grouping vector and discard it if it carries no usable
+    // constraint. Sentinel convention (internal, platform-independent):
+    //   0   — repeat the previous group size indefinitely
+    //   255 — no further grouping
+    //   1–254 — explicit group size
+    //
+    // POSIX CHAR_MAX (127 on signed-char platforms) is normalised to 255 so
+    // that callers never need to know the platform's char signedness.
+    inline void adjust_grouping(std::vector<uint8_t>& grouping)
+    {
+        constexpr uint8_t posix_sentinel = static_cast<uint8_t>(std::numeric_limits<char>::max());
+        if constexpr (posix_sentinel != std::numeric_limits<uint8_t>::max())
+            for (auto& g : grouping)
+                if (g == posix_sentinel) g = std::numeric_limits<uint8_t>::max();
+
+        if ((!grouping.empty()) &&
+            (grouping[0] > 0) &&
+            (grouping[0] != std::numeric_limits<uint8_t>::max()))
+            return;
+        else
+            grouping.clear();
+    }
+
     // Internal helper function. Callers are responsible for ensuring that both
     // grouping and grouping_tmp are non-empty; this function does not validate
     // those preconditions. Callers guarantee grouping is non-empty because
     // grouping_tmp is only populated inside !grouping.empty() branches, so
     // the non-emptiness of grouping_tmp implies the non-emptiness of grouping.
+    //
+    // grouping uses an internal uint8_t sentinel convention:
+    //   0   — repeat the previous group size for all remaining groups
+    //   255 — no further grouping (normalised from POSIX CHAR_MAX at load time)
+    //   1–254 — explicit group size
     inline bool verify_grouping(const std::vector<uint8_t>& grouping,
-                                const std::string& grouping_tmp)
+                                const std::vector<uint8_t>& grouping_tmp)
     {
         assert(!grouping.empty());
         assert(!grouping_tmp.empty());
@@ -112,11 +140,11 @@ namespace IOv2::FacetHelper
             test = grouping_tmp[i] == grouping[j];
         for (; i && test; --i)
             test = grouping_tmp[i] == grouping[min_val];
-        // ... but the first parsed grouping can be <= numpunct
-        // grouping (only do the check if the numpunct char is > 0
-        // because <= 0 means any size is ok).
-        if (static_cast<signed char>(grouping[min_val]) > 0
-            && grouping[min_val] != std::numeric_limits<char>::max())
+        // ... but the first parsed grouping can be <= numpunct grouping.
+        // Skip this check when grouping[min_val] is 0 (repeat-last, no bound)
+        // or 255 (no-further-grouping sentinel).
+        if (grouping[min_val] > 0
+            && grouping[min_val] != std::numeric_limits<uint8_t>::max())
             test &= grouping_tmp[0] <= grouping[min_val];
         return test;
     }

--- a/include/facet/monetary.h
+++ b/include/facet/monetary.h
@@ -45,7 +45,7 @@ public:
         , m_decimal_point(p_obj->decimal_point())
         , m_thousands_sep(p_obj->thousands_sep())
     {
-        adjust_grouping();
+        FacetHelper::adjust_grouping(m_grouping);
     }
 
     const std::vector<uint8_t>& grouping() const { return m_grouping; }
@@ -144,21 +144,6 @@ public:
         if (!succ)
             throw stream_error("monetary parse fail");
         return beg;
-    }
-
-private:
-    // this trys to solve the case: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=39168
-    // Following the code in gcc: https://github.com/gcc-mirror/gcc/blob/19b98410eb43be60f7e2673afeaabd016321c625/libstdc%2B%2B-v3/include/bits/locale_facets.tcc#L91
-    // however, I don't know whether this is appropriate or not, since it does not consider the number except grouping[0]
-    // what's more: I don't know whether c++ standard has this limitation is resonable or not...
-    void adjust_grouping()
-    {
-        if ((!m_grouping.empty()) && 
-            (m_grouping[0] > 0) &&
-            (m_grouping[0] != std::numeric_limits<char>::max()))
-            return;
-        else
-            m_grouping.clear();
     }
 
 private:
@@ -319,8 +304,8 @@ private:
         int sign_size = 0;
         // True if sign is mandatory.
         const bool mandatory_sign = (!info.m_positive_sign.empty() && !info.m_negative_sign.empty());
-        // String of grouping info from thousands_sep plucked from units.
-        std::string grouping_tmp;
+        // Vector of grouping info from thousands_sep plucked from units.
+        std::vector<uint8_t> grouping_tmp;
         if (!m_grouping.empty())
             grouping_tmp.reserve(32);
         // Last position before the decimal point.
@@ -414,7 +399,7 @@ private:
                         if (n)
                         {
                             // Mark position for later analysis.
-                            grouping_tmp += static_cast<char>(n);
+                            grouping_tmp.push_back(static_cast<uint8_t>(n));
                             n = 0;
                         }
                         else
@@ -475,7 +460,7 @@ private:
             if (!grouping_tmp.empty())
             {
                 // Add the ending grouping.
-                grouping_tmp += static_cast<char>(testdecfound ? last_pos : n);
+                grouping_tmp.push_back(static_cast<uint8_t>(testdecfound ? last_pos : n));
                 succ = FacetHelper::verify_grouping(m_grouping, grouping_tmp);
             }
 

--- a/include/facet/monetary_details.h
+++ b/include/facet/monetary_details.h
@@ -238,7 +238,12 @@ public:
                 if (len != 0)
                 {
                     m_grouping.resize(len);
-                    for (size_t i = 0; i < len; ++i) m_grouping[i] = cgroup[i];
+                    for (size_t i = 0; i < len; ++i)
+                    {
+                        const uint8_t byte = static_cast<uint8_t>(cgroup[i]);
+                        m_grouping[i] = (byte == static_cast<uint8_t>(std::numeric_limits<char>::max()))
+                            ? std::numeric_limits<uint8_t>::max() : byte;
+                    }
                 }
             }
 
@@ -386,7 +391,12 @@ public:
                 if (len != 0)
                 {
                     m_grouping.resize(len);
-                    for (size_t i = 0; i < len; ++i) m_grouping[i] = cgroup[i];
+                    for (size_t i = 0; i < len; ++i)
+                    {
+                        const uint8_t byte = static_cast<uint8_t>(cgroup[i]);
+                        m_grouping[i] = (byte == static_cast<uint8_t>(std::numeric_limits<char>::max()))
+                            ? std::numeric_limits<uint8_t>::max() : byte;
+                    }
                 }
             }
 

--- a/include/facet/numeric.h
+++ b/include/facet/numeric.h
@@ -26,7 +26,7 @@ public:
         m_true_name = p_obj->truename();
         m_false_name = p_obj->falsename();
         m_grouping = p_obj->grouping();
-        adjust_grouping();
+        FacetHelper::adjust_grouping(m_grouping);
 
         char in_atoms_c[] = "-+xX0123456789abcdefABCDEF";
         m_ctype->widen_seq(in_atoms_c, in_atoms_c + 26, m_in_atoms);
@@ -632,7 +632,7 @@ private:
         const size_t len = (base == 16 ? s_iend - s_izero : base);
 
         // Extract.
-        std::string found_grouping;
+        std::vector<uint8_t> found_grouping;
         if (!m_grouping.empty()) found_grouping.reserve(32);
         bool testfail = false;
         bool testoverflow = false;
@@ -653,7 +653,7 @@ private:
                 // is a no-no, as is two consecutive thousands separators.
                 if (sep_pos)
                 {
-                    found_grouping += static_cast<char>(sep_pos);
+                    found_grouping.push_back(static_cast<uint8_t>(sep_pos));
                     sep_pos = 0;
                 }
                 else
@@ -690,7 +690,7 @@ private:
         if (!found_grouping.empty())
         {
             // Add the ending grouping.
-            found_grouping += static_cast<char>(sep_pos);
+            found_grouping.push_back(static_cast<uint8_t>(sep_pos));
 
             success = FacetHelper::verify_grouping(m_grouping, found_grouping);
         }
@@ -768,7 +768,7 @@ private:
         // Only need acceptable digits for floating point numbers.
         bool found_dec = false;
         bool found_sci = false;
-        std::string found_grouping;
+        std::vector<uint8_t> found_grouping;
         if (!m_grouping.empty())
             found_grouping.reserve(32);
         const char_type* lit_zero = m_in_atoms + s_izero;
@@ -785,7 +785,7 @@ private:
                     // is a no-no, as is two consecutive thousands separators.
                     if (sep_pos)
                     {
-                        found_grouping += static_cast<char>(sep_pos);
+                        found_grouping.push_back(static_cast<uint8_t>(sep_pos));
                         sep_pos = 0;
                     }
                     else
@@ -807,7 +807,7 @@ private:
                     // is applied. Therefore found_grouping is adjusted
                     // only if decimal_point comes after some thousands_sep.
                     if (found_grouping.size())
-                        found_grouping += static_cast<char>(sep_pos);
+                        found_grouping.push_back(static_cast<uint8_t>(sep_pos));
                     xtrc += '.';
                     found_dec = true;
                 }
@@ -828,7 +828,7 @@ private:
                 {
                     // Scientific notation.
                     if (found_grouping.size() && !found_dec)
-                        found_grouping += static_cast<char>(sep_pos);
+                        found_grouping.push_back(static_cast<uint8_t>(sep_pos));
                     xtrc += 'e';
                     found_sci = true;
 
@@ -867,7 +867,7 @@ private:
         {
             // Add the ending grouping if a decimal or 'e'/'E' wasn't found.
             if (!found_dec && !found_sci)
-                found_grouping += static_cast<char>(sep_pos);
+                found_grouping.push_back(static_cast<uint8_t>(sep_pos));
 
             success = FacetHelper::verify_grouping(m_grouping, found_grouping);
         }
@@ -909,18 +909,6 @@ private:
             res = false;
         }
         return res;
-    }
-
-private:
-    // this trys to solve the case: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=39168
-    void adjust_grouping()
-    {
-        if ((!m_grouping.empty()) && 
-            (m_grouping[0] > 0) &&
-            (m_grouping[0] < std::numeric_limits<char>::max()))
-            return;
-        else
-            m_grouping.clear();
     }
 
 private:

--- a/include/facet/numeric_details.h
+++ b/include/facet/numeric_details.h
@@ -44,7 +44,11 @@ public:
                 {
                     m_grouping.resize(len);
                     for (size_t i = 0; i < len; ++i)
-                        m_grouping[i] = (uint8_t)(src[i]);
+                    {
+                        const uint8_t byte = static_cast<uint8_t>(src[i]);
+                        m_grouping[i] = (byte == static_cast<uint8_t>(std::numeric_limits<char>::max()))
+                            ? std::numeric_limits<uint8_t>::max() : byte;
+                    }
                 }
             }
             


### PR DESCRIPTION


Switch the internal grouping representation from POSIX char semantics to a platform-independent uint8_t convention:
  0   — repeat the previous group size
  255 — no further grouping (was: CHAR_MAX, which is 127 or 255 depending on platform)
  1–254 — explicit group size

Loading boundaries (nl_langinfo/localeconv) and adjust_grouping now normalise POSIX CHAR_MAX to 255, so downstream code never needs to know the platform's char signedness.

verify_grouping's second parameter is changed from std::string to std::vector<uint8_t>, matching the first parameter and eliminating the implicit char/uint8_t mixed comparison.

adjust_grouping is extracted from numeric and monetary into FacetHelper so the normalisation and validity check live in one place.