### PR TITLE
refactor(facet): move POSIX-to-internal grouping conversion to loader boundary

### DIFF
--- a/include/facet/facet_helper.h
+++ b/include/facet/facet_helper.h
@@ -90,27 +90,57 @@ namespace IOv2::FacetHelper
         return s;
     }
 
-    // Normalise a raw grouping vector and discard it if it carries no usable
-    // constraint. Sentinel convention (internal, platform-independent):
-    //   0   — repeat the previous group size indefinitely
-    //   255 — no further grouping
-    //   1–254 — explicit group size
+    // Normalise a raw POSIX-style grouping vector to the internal convention,
+    // or discard it if it carries no usable constraint.
     //
-    // POSIX CHAR_MAX (127 on signed-char platforms) is normalised to 255 so
-    // that callers never need to know the platform's char signedness.
+    // Internal convention (uint8_t, platform-independent):
+    //   1–255 — explicit group size.
+    //   0     — stop: no further grouping after this point (the ONLY sentinel).
+    //   The LAST element (if in 1–255) is implicitly repeated for all
+    //   remaining groups. If the last element is 0, the explicit stop wins.
+    //
+    // Conversions applied to raw POSIX input:
+    //   - POSIX "0 = repeat previous": the 0 and everything after it is
+    //     dropped. POSIX [N1, ..., Nk, 0, ...] becomes [N1, ..., Nk] in our
+    //     convention, because last-element implicit repeat already covers
+    //     that semantic exactly.
+    //   - POSIX CHAR_MAX (= stop): rewritten to internal 0. CHAR_MAX is 127
+    //     on signed-char platforms and 255 on unsigned-char platforms;
+    //     callers do not need to know the platform's char signedness after
+    //     this step.
+    //
+    // Order matters: stripping POSIX "0 = repeat" MUST happen before
+    // CHAR_MAX → 0 rewrite, otherwise our newly-introduced internal stop
+    // would be mistaken for a POSIX repeat-previous marker and dropped.
     inline void adjust_grouping(std::vector<uint8_t>& grouping)
     {
-        constexpr uint8_t posix_sentinel = static_cast<uint8_t>(std::numeric_limits<char>::max());
-        if constexpr (posix_sentinel != std::numeric_limits<uint8_t>::max())
-            for (auto& g : grouping)
-                if (g == posix_sentinel) g = std::numeric_limits<uint8_t>::max();
+        // Step 1: POSIX "0 = repeat previous" → drop the 0 and the tail.
+        auto zero = std::find(grouping.begin(), grouping.end(), uint8_t{0});
+        grouping.erase(zero, grouping.end());
 
-        if ((!grouping.empty()) &&
-            (grouping[0] > 0) &&
-            (grouping[0] != std::numeric_limits<uint8_t>::max()))
-            return;
-        else
+        // Step 2: POSIX CHAR_MAX (= stop) → internal 0 sentinel, plus
+        // canonical-form cleanup. After step 1 there are no 0s in the vector,
+        // so the FIRST CHAR_MAX is the only point at which we introduce one,
+        // and three cases fully cover the outcome:
+        //   - at begin():   grouping would start with the stop sentinel,
+        //                   i.e. no usable leading group ⇒ discard.
+        //                   (This also subsumes the empty-vector case left
+        //                   by step 1, since find on an empty range returns
+        //                   end() == begin().)
+        //   - in the tail:  rewrite to 0 and drop everything after it; those
+        //                   bytes are dead code anyway because add_grouping
+        //                   short-circuits on 0.
+        //   - not found:    nothing to do.
+        constexpr uint8_t posix_sentinel =
+            static_cast<uint8_t>(std::numeric_limits<char>::max());
+        auto stop = std::find(grouping.begin(), grouping.end(), posix_sentinel);
+        if (stop == grouping.begin())
             grouping.clear();
+        else if (stop != grouping.end())
+        {
+            *stop = 0;
+            grouping.erase(std::next(stop), grouping.end());
+        }
     }
 
     // Internal helper function. Callers are responsible for ensuring that both
@@ -119,10 +149,10 @@ namespace IOv2::FacetHelper
     // grouping_tmp is only populated inside !grouping.empty() branches, so
     // the non-emptiness of grouping_tmp implies the non-emptiness of grouping.
     //
-    // grouping uses an internal uint8_t sentinel convention:
-    //   0   — repeat the previous group size for all remaining groups
-    //   255 — no further grouping (normalised from POSIX CHAR_MAX at load time)
-    //   1–254 — explicit group size
+    // grouping uses the internal uint8_t convention established by
+    // adjust_grouping(): 1–255 are explicit group sizes, 0 is the sole
+    // "stop" sentinel, and the last 1–255 element is implicitly repeated
+    // for all remaining groups.
     inline bool verify_grouping(const std::vector<uint8_t>& grouping,
                                 const std::vector<uint8_t>& grouping_tmp)
     {
@@ -141,10 +171,9 @@ namespace IOv2::FacetHelper
         for (; i && test; --i)
             test = grouping_tmp[i] == grouping[min_val];
         // ... but the first parsed grouping can be <= numpunct grouping.
-        // Skip this check when grouping[min_val] is 0 (repeat-last, no bound)
-        // or 255 (no-further-grouping sentinel).
-        if (grouping[min_val] > 0
-            && grouping[min_val] != std::numeric_limits<uint8_t>::max())
+        // Skip this check when grouping[min_val] is 0 (stop sentinel,
+        // no upper bound on the first parsed group).
+        if (grouping[min_val] > 0)
             test &= grouping_tmp[0] <= grouping[min_val];
         return test;
     }

--- a/include/facet/monetary.h
+++ b/include/facet/monetary.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <common/metafunctions.h>
+#include <facet/facet_helper.h>
 #include <facet/monetary_details.h>
 #include <io/io_base.h>
 
@@ -45,7 +46,11 @@ public:
         , m_decimal_point(p_obj->decimal_point())
         , m_thousands_sep(p_obj->thousands_sep())
     {
-        FacetHelper::adjust_grouping(m_grouping);
+        // grouping() is contracted to return the INTERNAL convention
+        // (1–255 = group size, 0 = stop, last element implicitly repeats).
+        // monetary_conf and any user-derived override are both expected to
+        // satisfy this contract — POSIX-style normalisation is done at the
+        // POSIX boundary in monetary_conf, not here.
     }
 
     const std::vector<uint8_t>& grouping() const { return m_grouping; }

--- a/include/facet/monetary_details.h
+++ b/include/facet/monetary_details.h
@@ -237,13 +237,12 @@ public:
                 size_t len = strlen(cgroup);
                 if (len != 0)
                 {
+                    // Copy raw POSIX grouping bytes, then normalise into the
+                    // internal convention here at the POSIX boundary.
                     m_grouping.resize(len);
                     for (size_t i = 0; i < len; ++i)
-                    {
-                        const uint8_t byte = static_cast<uint8_t>(cgroup[i]);
-                        m_grouping[i] = (byte == static_cast<uint8_t>(std::numeric_limits<char>::max()))
-                            ? std::numeric_limits<uint8_t>::max() : byte;
-                    }
+                        m_grouping[i] = static_cast<uint8_t>(cgroup[i]);
+                    FacetHelper::adjust_grouping(m_grouping);
                 }
             }
 
@@ -390,13 +389,12 @@ public:
                 size_t len = strlen(cgroup);
                 if (len != 0)
                 {
+                    // Copy raw POSIX grouping bytes, then normalise into the
+                    // internal convention here at the POSIX boundary.
                     m_grouping.resize(len);
                     for (size_t i = 0; i < len; ++i)
-                    {
-                        const uint8_t byte = static_cast<uint8_t>(cgroup[i]);
-                        m_grouping[i] = (byte == static_cast<uint8_t>(std::numeric_limits<char>::max()))
-                            ? std::numeric_limits<uint8_t>::max() : byte;
-                    }
+                        m_grouping[i] = static_cast<uint8_t>(cgroup[i]);
+                    FacetHelper::adjust_grouping(m_grouping);
                 }
             }
 

--- a/include/facet/numeric.h
+++ b/include/facet/numeric.h
@@ -3,6 +3,7 @@
 #include <memory>
 #include <common/metafunctions.h>
 #include <facet/ctype.h>
+#include <facet/facet_helper.h>
 #include <facet/numeric_details.h>
 #include <io/io_base.h>
 #include <type_traits>
@@ -25,8 +26,12 @@ public:
         m_thousands_sep = p_obj->thousands_sep();
         m_true_name = p_obj->truename();
         m_false_name = p_obj->falsename();
+        // grouping() is contracted to return the INTERNAL convention
+        // (1–255 = group size, 0 = stop, last element implicitly repeats).
+        // numeric_conf and any user-derived override are both expected to
+        // satisfy this contract — POSIX-style normalisation is done at the
+        // POSIX boundary in numeric_conf, not here.
         m_grouping = p_obj->grouping();
-        FacetHelper::adjust_grouping(m_grouping);
 
         char in_atoms_c[] = "-+xX0123456789abcdefABCDEF";
         m_ctype->widen_seq(in_atoms_c, in_atoms_c + 26, m_in_atoms);

--- a/include/facet/numeric_details.h
+++ b/include/facet/numeric_details.h
@@ -42,16 +42,17 @@ public:
                 const size_t len = strlen(src);
                 if (len != 0)
                 {
+                    // Copy raw POSIX grouping bytes, then normalise into the
+                    // internal convention here at the POSIX boundary.
+                    // Downstream (numeric, user-derived numeric_conf) sees
+                    // only the internal form.
                     m_grouping.resize(len);
                     for (size_t i = 0; i < len; ++i)
-                    {
-                        const uint8_t byte = static_cast<uint8_t>(src[i]);
-                        m_grouping[i] = (byte == static_cast<uint8_t>(std::numeric_limits<char>::max()))
-                            ? std::numeric_limits<uint8_t>::max() : byte;
-                    }
+                        m_grouping[i] = static_cast<uint8_t>(src[i]);
+                    FacetHelper::adjust_grouping(m_grouping);
                 }
             }
-            
+
             auto yesStr = nl_langinfo(YESSTR);
             m_true_name = yesStr ? yesStr : "true";
             
@@ -121,12 +122,15 @@ public:
             const size_t len = strlen(src);
             if (len != 0)
             {
+                // Copy raw POSIX grouping bytes, then normalise into the
+                // internal convention here at the POSIX boundary.
                 m_grouping.resize(len);
                 for (size_t i = 0; i < len; ++i)
                     m_grouping[i] = (uint8_t)(src[i]);
+                FacetHelper::adjust_grouping(m_grouping);
             }
         }
-        
+
         auto yesStr = nl_langinfo(YESSTR);
         if (yesStr == nullptr)
         {

--- a/test/facet/monetary/test_monetary_char.cpp
+++ b/test/facet/monetary/test_monetary_char.cpp
@@ -331,7 +331,7 @@ void test_monetary_char_put_7()
     IOv2::ios_base<char> ios;
     
     auto tmp_io = std::make_shared<MoneyIO>("C");
-    tmp_io->set_grouping({CHAR_MAX});
+    tmp_io->set_grouping({});
     IOv2::monetary<char> obj(tmp_io);
     
     std::string digits(300, '1');
@@ -1296,7 +1296,7 @@ void test_monetary_char_get_23()
     IOv2::ios_base<char> ios;
     
     auto tmp_io = std::make_shared<MoneyIO>("C");
-    tmp_io->set_grouping({CHAR_MAX});
+    tmp_io->set_grouping({});
     IOv2::monetary<char> obj(tmp_io);
     
     std::string ss = "123,456";
@@ -2371,7 +2371,7 @@ void test_monetary_char_get_46()
     IOv2::ios_base<char> ios;
     
     auto tmp_io = std::make_shared<MoneyIO>("C");
-    tmp_io->set_grouping({CHAR_MAX});
+    tmp_io->set_grouping({});
     IOv2::monetary<char> obj(tmp_io);
 
     std::string digits;

--- a/test/facet/monetary/test_monetary_char32_t.cpp
+++ b/test/facet/monetary/test_monetary_char32_t.cpp
@@ -330,7 +330,7 @@ void test_monetary_char32_t_put_7()
     IOv2::ios_base<char32_t> ios;
     
     auto tmp_io = std::make_shared<MoneyIO>("C");
-    tmp_io->set_grouping({CHAR_MAX});
+    tmp_io->set_grouping({});
     IOv2::monetary<char32_t> obj(tmp_io);
     
     std::u32string  digits(300, L'1');
@@ -1295,7 +1295,7 @@ void test_monetary_char32_t_get_23()
     IOv2::ios_base<char32_t> ios;
     
     auto tmp_io = std::make_shared<MoneyIO>("C");
-    tmp_io->set_grouping({CHAR_MAX});
+    tmp_io->set_grouping({});
     IOv2::monetary<char32_t> obj(tmp_io);
     
     std::u32string  ss = U"123,456";

--- a/test/facet/monetary/test_monetary_char8_t.cpp
+++ b/test/facet/monetary/test_monetary_char8_t.cpp
@@ -330,7 +330,7 @@ void test_monetary_char8_t_put_7()
     IOv2::ios_base<char8_t> ios;
     
     auto tmp_io = std::make_shared<MoneyIO>("C");
-    tmp_io->set_grouping({CHAR_MAX});
+    tmp_io->set_grouping({});
     IOv2::monetary<char8_t> obj(tmp_io);
     
     std::u8string  digits(300, L'1');
@@ -1295,7 +1295,7 @@ void test_monetary_char8_t_get_23()
     IOv2::ios_base<char8_t> ios;
     
     auto tmp_io = std::make_shared<MoneyIO>("C");
-    tmp_io->set_grouping({CHAR_MAX});
+    tmp_io->set_grouping({});
     IOv2::monetary<char8_t> obj(tmp_io);
     
     std::u8string  ss = u8"123,456";

--- a/test/facet/monetary/test_monetary_wchar_t.cpp
+++ b/test/facet/monetary/test_monetary_wchar_t.cpp
@@ -330,7 +330,7 @@ void test_monetary_wchar_t_put_7()
     IOv2::ios_base<wchar_t> ios;
     
     auto tmp_io = std::make_shared<MoneyIO>("C");
-    tmp_io->set_grouping({CHAR_MAX});
+    tmp_io->set_grouping({});
     IOv2::monetary<wchar_t> obj(tmp_io);
     
     std::wstring digits(300, L'1');
@@ -1294,7 +1294,7 @@ void test_monetary_wchar_t_get_23()
     IOv2::ios_base<wchar_t> ios;
     
     auto tmp_io = std::make_shared<MoneyIO>("C");
-    tmp_io->set_grouping({CHAR_MAX});
+    tmp_io->set_grouping({});
     IOv2::monetary<wchar_t> obj(tmp_io);
     
     std::wstring ss = L"123,456";

--- a/test/facet/numeric/test_numeric_char.cpp
+++ b/test/facet/numeric/test_numeric_char.cpp
@@ -678,9 +678,9 @@ void test_numeric_char_put_15()
 void test_numeric_char_put_16()
 {
     dump_info("Test numeric<char>::put 16...");
-    auto p1 = std::make_shared<Punct>("C"); p1->set_grouping(std::vector{(uint8_t)-1});
-    auto p2 = std::make_shared<Punct>("C"); p2->set_grouping(std::vector{(uint8_t)2, (uint8_t)-1});
-    auto p3 = std::make_shared<Punct>("C"); p3->set_grouping(std::vector{(uint8_t)1, (uint8_t)2, (uint8_t)-1});
+    auto p1 = std::make_shared<Punct>("C"); p1->set_grouping(std::vector<uint8_t>{});
+    auto p2 = std::make_shared<Punct>("C"); p2->set_grouping(std::vector<uint8_t>{(uint8_t)2, (uint8_t)0});
+    auto p3 = std::make_shared<Punct>("C"); p3->set_grouping(std::vector<uint8_t>{(uint8_t)1, (uint8_t)2, (uint8_t)0});
     
     IOv2::numeric<char> ng1(p1, s_ctype_c);
     IOv2::numeric<char> ng2(p2, s_ctype_c);
@@ -2205,7 +2205,7 @@ void test_numeric_char_get_20()
     IOv2::ios_base<char> ios;
     long double l = -1;
     
-    auto p1 = std::make_shared<Punct>("C"); p1->set_grouping({CHAR_MAX});
+    auto p1 = std::make_shared<Punct>("C"); p1->set_grouping({});
     const IOv2::numeric<char> obj(p1, s_ctype_c);
      
     std::string iss = "123,456";
@@ -3829,7 +3829,7 @@ void test_numeric_char_get_41()
     IOv2::ios_base<char> ios;
     long double l = -1;
     
-    auto p1 = std::make_shared<Punct>("C"); p1->set_grouping({CHAR_MAX});
+    auto p1 = std::make_shared<Punct>("C"); p1->set_grouping({});
     const IOv2::numeric<char> obj(p1, s_ctype_c);
 
     using namespace IOv2;

--- a/test/facet/numeric/test_numeric_char32_t.cpp
+++ b/test/facet/numeric/test_numeric_char32_t.cpp
@@ -679,9 +679,9 @@ void test_numeric_char32_t_put_15()
 void test_numeric_char32_t_put_16()
 {
     dump_info("Test numeric<char32_t>::put 16...");
-    auto p1 = std::make_shared<Punct>("C"); p1->set_grouping(std::vector{(uint8_t)-1});
-    auto p2 = std::make_shared<Punct>("C"); p2->set_grouping(std::vector{(uint8_t)2, (uint8_t)-1});
-    auto p3 = std::make_shared<Punct>("C"); p3->set_grouping(std::vector{(uint8_t)1, (uint8_t)2, (uint8_t)-1});
+    auto p1 = std::make_shared<Punct>("C"); p1->set_grouping(std::vector<uint8_t>{});
+    auto p2 = std::make_shared<Punct>("C"); p2->set_grouping(std::vector<uint8_t>{(uint8_t)2, (uint8_t)0});
+    auto p3 = std::make_shared<Punct>("C"); p3->set_grouping(std::vector<uint8_t>{(uint8_t)1, (uint8_t)2, (uint8_t)0});
     
     IOv2::numeric<char32_t> ng1(p1, s_ctype_c);
     IOv2::numeric<char32_t> ng2(p2, s_ctype_c);
@@ -2198,7 +2198,7 @@ void test_numeric_char32_t_get_20()
     IOv2::ios_base<char32_t> ios;
     long double l = -1;
     
-    auto p1 = std::make_shared<Punct>("C"); p1->set_grouping({CHAR_MAX});
+    auto p1 = std::make_shared<Punct>("C"); p1->set_grouping({});
     const IOv2::numeric<char32_t> obj(p1, s_ctype_c);
      
     std::u32string  iss = U"123,456";

--- a/test/facet/numeric/test_numeric_char8_t.cpp
+++ b/test/facet/numeric/test_numeric_char8_t.cpp
@@ -677,9 +677,9 @@ void test_numeric_char8_t_put_15()
 void test_numeric_char8_t_put_16()
 {
     dump_info("Test numeric<char8_t>::put 16...");
-    auto p1 = std::make_shared<Punct>("C"); p1->set_grouping(std::vector{(uint8_t)-1});
-    auto p2 = std::make_shared<Punct>("C"); p2->set_grouping(std::vector{(uint8_t)2, (uint8_t)-1});
-    auto p3 = std::make_shared<Punct>("C"); p3->set_grouping(std::vector{(uint8_t)1, (uint8_t)2, (uint8_t)-1});
+    auto p1 = std::make_shared<Punct>("C"); p1->set_grouping(std::vector<uint8_t>{});
+    auto p2 = std::make_shared<Punct>("C"); p2->set_grouping(std::vector<uint8_t>{(uint8_t)2, (uint8_t)0});
+    auto p3 = std::make_shared<Punct>("C"); p3->set_grouping(std::vector<uint8_t>{(uint8_t)1, (uint8_t)2, (uint8_t)0});
     
     IOv2::numeric<char8_t> ng1(p1, s_ctype_c);
     IOv2::numeric<char8_t> ng2(p2, s_ctype_c);
@@ -2198,7 +2198,7 @@ void test_numeric_char8_t_get_20()
     IOv2::ios_base<char8_t> ios;
     long double l = -1;
     
-    auto p1 = std::make_shared<Punct>("C"); p1->set_grouping({CHAR_MAX});
+    auto p1 = std::make_shared<Punct>("C"); p1->set_grouping({});
     const IOv2::numeric<char8_t> obj(p1, s_ctype_c);
      
     std::u8string iss = u8"123,456";

--- a/test/facet/numeric/test_numeric_wchar_t.cpp
+++ b/test/facet/numeric/test_numeric_wchar_t.cpp
@@ -668,9 +668,9 @@ void test_numeric_wchar_t_put_15()
 void test_numeric_wchar_t_put_16()
 {
     dump_info("Test numeric<wchar_t>::put 16...");
-    auto p1 = std::make_shared<Punct>("C"); p1->set_grouping(std::vector{(uint8_t)-1});
-    auto p2 = std::make_shared<Punct>("C"); p2->set_grouping(std::vector{(uint8_t)2, (uint8_t)-1});
-    auto p3 = std::make_shared<Punct>("C"); p3->set_grouping(std::vector{(uint8_t)1, (uint8_t)2, (uint8_t)-1});
+    auto p1 = std::make_shared<Punct>("C"); p1->set_grouping(std::vector<uint8_t>{});
+    auto p2 = std::make_shared<Punct>("C"); p2->set_grouping(std::vector<uint8_t>{(uint8_t)2, (uint8_t)0});
+    auto p3 = std::make_shared<Punct>("C"); p3->set_grouping(std::vector<uint8_t>{(uint8_t)1, (uint8_t)2, (uint8_t)0});
     
     IOv2::numeric<wchar_t> ng1(p1, s_ctype_c);
     IOv2::numeric<wchar_t> ng2(p2, s_ctype_c);
@@ -2176,7 +2176,7 @@ void test_numeric_wchar_t_get_20()
     IOv2::ios_base<wchar_t> ios;
     long double l = -1;
     
-    auto p1 = std::make_shared<Punct>("C"); p1->set_grouping({CHAR_MAX});
+    auto p1 = std::make_shared<Punct>("C"); p1->set_grouping({});
     const IOv2::numeric<wchar_t> obj(p1, s_ctype_c);
      
     std::wstring iss = L"123,456";


### PR DESCRIPTION


Redesign the grouping convention so the boundary between POSIX semantics and the library's internal semantics is the conf loader, not the consumer. Downstream code (numeric/monetary facets, user-derived *_conf overrides) now sees a single, unambiguous internal convention:

  - 1-255 = explicit group size
  - 0     = stop (the only sentinel)
  - last element in 1-255 is implicitly repeated

POSIX "0 = repeat previous" and POSIX CHAR_MAX (= stop) are translated to the internal form by FacetHelper::adjust_grouping(), now invoked inside numeric_conf / monetary_conf right after reading nl_langinfo / localeconv, instead of inside the numeric / monetary ctor.

adjust_grouping is also simplified: a single std::find pass replaces POSIX 0 (drop the 0 and tail), then another std::find rewrites the first CHAR_MAX to 0 and erases its tail. The result is canonical: either empty, or [N1, ..., Nk] / [N1, ..., Nk-1, 0] with no internal dead elements.

verify_grouping drops the 255-sentinel check (255 is now a legal group size). add_grouping is unchanged; its >0 short-circuit already matches the new convention.

Tests: user-set groupings that previously relied on POSIX-style sentinels (CHAR_MAX, (uint8_t)-1) are rewritten to the internal convention - {CHAR_MAX} becomes {}, {N, CHAR_MAX} becomes {N, 0}, etc. The {0} / {N, 0} family that was already in internal form is left untouched.