### PR TITLE
refactor(facet): switch numeric to localeconv, extract widechar helper

### DIFF
--- a/include/facet/facet_helper.h
+++ b/include/facet/facet_helper.h
@@ -1,5 +1,4 @@
 #pragma once
-#include <common/clocale_wrapper.h>
 #include <cvt/cvt_facilities.h>
 #include <facet/ctype_details.h>
 
@@ -8,12 +7,8 @@
 #include <cstdint>
 #include <limits>
 #include <string>
-#include <string_view>
 #include <type_traits>
 #include <vector>
-
-#include <langinfo.h>
-#include <nl_types.h>
 
 namespace IOv2::FacetHelper
 {
@@ -39,6 +34,45 @@ namespace IOv2::FacetHelper
         ctype_conf<wchar_t> tmp_ctype(locale_name);
         auto res = tmp_ctype.narrow(wide_str[0]);
         return res.has_value() ? res.value() : '\0';
+    }
+
+    // Convert the first character of a (possibly multibyte) narrow string
+    // `narrow` to a wide character `CharT` in the given locale, returning
+    // `default_char` when `narrow` is empty or conversion produces no
+    // characters.
+    //
+    // Suitable for fields read out of `lconv` / `nl_langinfo()` that
+    // semantically represent a single user-visible character (e.g.
+    // decimal_point, thousands_sep, mon_decimal_point, mon_thousands_sep).
+    //
+    // Why `const std::string&` and not `const char*`: `lconv*` and
+    // `nl_langinfo()` pointers may be invalidated by any setlocale() /
+    // uselocale() call. The conversion below transitively performs such
+    // calls (via detail::to_wstring/to_u32string), so the input must be a
+    // caller-owned snapshot rather than a borrowed pointer into the
+    // libc-owned locale data. Taking std::string makes this contract
+    // unmissable at every call site.
+    template <typename CharT>
+        requires std::is_same_v<CharT, wchar_t> ||
+            (std::is_same_v<CharT, char32_t> &&
+                (sizeof(char32_t) == sizeof(wchar_t)) &&
+                (static_cast<wchar_t>(U'李') == L'李') &&
+                (static_cast<char32_t>(L'伟') == U'伟'))
+    inline CharT string_to_widechar_convert(const std::string& narrow,
+                                            const std::string& locale_name,
+                                            CharT default_char)
+    {
+        if (narrow.empty()) return default_char;
+        if constexpr (std::is_same_v<CharT, wchar_t>)
+        {
+            auto wide = detail::to_wstring(narrow.c_str(), locale_name);
+            return wide.empty() ? default_char : wide[0];
+        }
+        else
+        {
+            auto wide = detail::to_u32string(narrow.c_str(), locale_name);
+            return wide.empty() ? default_char : wide[0];
+        }
     }
 
     // Internal helper function.
@@ -176,32 +210,5 @@ namespace IOv2::FacetHelper
         if (grouping[min_val] > 0)
             test &= grouping_tmp[0] <= grouping[min_val];
         return test;
-    }
-
-    // Portable nl_langinfo function (use narrow POSIX item and convert to wide)
-    template <typename CharT>
-    requires std::is_same_v<CharT, wchar_t> ||
-        (std::is_same_v<CharT, char32_t> &&
-            (sizeof(char32_t) == sizeof(wchar_t)) &&
-            (static_cast<wchar_t>(U'李') == L'李') &&
-            (static_cast<char32_t>(L'伟') == U'伟'))
-    inline CharT nl_langinfo_char(nl_item item, const std::string& locale_name, CharT default_char)
-    {
-        clocale_wrapper inter_locale(locale_name.c_str());
-        clocale_user guard(inter_locale);
-
-        const char* narrow = nl_langinfo(item);
-        if (!narrow || narrow[0] == '\0')
-            return default_char;
-        if constexpr (std::is_same_v<CharT, wchar_t>)
-        {
-            auto wide = detail::to_wstring(narrow, locale_name);
-            return wide.empty() ? default_char : wide[0];
-        }
-        else
-        {
-            auto wide = detail::to_u32string(narrow, locale_name);
-            return wide.empty() ? default_char : wide[0];
-        }
     }
 }

--- a/include/facet/monetary_details.h
+++ b/include/facet/monetary_details.h
@@ -348,22 +348,19 @@ public:
             clocale_user guard(inter_locale);
             const lconv* lc = localeconv();
 
-            auto to_charT = [&](const char* narrow) -> CharT {
-                if (!narrow || !narrow[0]) return static_cast<CharT>('\0');
-                if constexpr (std::is_same_v<CharT, wchar_t>)
-                {
-                    auto wide = detail::to_wstring(narrow, name);
-                    return wide.empty() ? static_cast<CharT>('\0') : wide[0];
-                }
-                else
-                {
-                    auto wide = detail::to_u32string(narrow, name);
-                    return wide.empty() ? static_cast<CharT>('\0') : wide[0];
-                }
-            };
+            // Snapshot the single-character fields before the wide-char
+            // converter is called: it transitively invokes setlocale/
+            // uselocale, which may invalidate every string pointer inside
+            // `lc`.
+            const std::string mon_dp_raw =
+                lc->mon_decimal_point ? lc->mon_decimal_point : "";
+            const std::string mon_ts_raw =
+                lc->mon_thousands_sep ? lc->mon_thousands_sep : "";
 
-            m_decimal_point = to_charT(lc->mon_decimal_point);
-            m_thousands_sep = to_charT(lc->mon_thousands_sep);
+            m_decimal_point = FacetHelper::string_to_widechar_convert<CharT>(
+                mon_dp_raw, name, static_cast<CharT>('\0'));
+            m_thousands_sep = FacetHelper::string_to_widechar_convert<CharT>(
+                mon_ts_raw, name, static_cast<CharT>('\0'));
             
             if (static_cast<int>(m_decimal_point) == 0)
             {

--- a/include/facet/numeric_details.h
+++ b/include/facet/numeric_details.h
@@ -1,6 +1,5 @@
 #pragma once
 #include <langinfo.h>
-#include <cstring>
 #include <string>
 #include <vector>
 
@@ -27,38 +26,47 @@ public:
             m_thousands_sep = ',';
             m_true_name = "true";
             m_false_name = "false";
+            return;
         }
-        else
+
+        // Snapshot all locale-dependent strings while the locale guard is
+        // active. The lconv* and nl_langinfo() pointers may be invalidated
+        // by any subsequent setlocale()/uselocale() call (e.g. inside
+        // string_to_char_convert / detail::to_wstring), so copy first
+        // and convert after.
+        std::string dp_raw, ts_raw, grp_raw, yes_raw, no_raw;
+        bool yes_set = false, no_set = false;
         {
             clocale_wrapper inter_locale(name.c_str());
             clocale_user guard(inter_locale);
-            
-            m_decimal_point = FacetHelper::string_to_char_convert(nl_langinfo(DECIMAL_POINT), name);
-            m_thousands_sep = FacetHelper::string_to_char_convert(nl_langinfo(THOUSANDS_SEP), name);
-                    
-            if (m_thousands_sep != '\0')
-            {
-                const char* src = nl_langinfo(GROUPING);
-                const size_t len = strlen(src);
-                if (len != 0)
-                {
-                    // Copy raw POSIX grouping bytes, then normalise into the
-                    // internal convention here at the POSIX boundary.
-                    // Downstream (numeric, user-derived numeric_conf) sees
-                    // only the internal form.
-                    m_grouping.resize(len);
-                    for (size_t i = 0; i < len; ++i)
-                        m_grouping[i] = static_cast<uint8_t>(src[i]);
-                    FacetHelper::adjust_grouping(m_grouping);
-                }
-            }
+            const lconv* lc = localeconv();
+            if (lc->decimal_point) dp_raw  = lc->decimal_point;
+            if (lc->thousands_sep) ts_raw  = lc->thousands_sep;
+            if (lc->grouping)      grp_raw = lc->grouping;
 
-            auto yesStr = nl_langinfo(YESSTR);
-            m_true_name = yesStr ? yesStr : "true";
-            
-            auto noStr = nl_langinfo(NOSTR);
-            m_false_name = noStr ? noStr : "false";
+            if (auto* p = nl_langinfo(YESSTR)) { yes_raw = p; yes_set = true; }
+            if (auto* p = nl_langinfo(NOSTR))  { no_raw  = p; no_set  = true; }
         }
+
+        m_decimal_point = FacetHelper::string_to_char_convert(dp_raw.c_str(), name);
+        m_thousands_sep = FacetHelper::string_to_char_convert(ts_raw.c_str(), name);
+
+        if (m_thousands_sep != '\0' && !grp_raw.empty())
+        {
+            // Copy raw POSIX grouping bytes, then normalise into the
+            // internal convention here at the POSIX boundary.
+            // Downstream (numeric, user-derived numeric_conf) sees
+            // only the internal form.
+            m_grouping.resize(grp_raw.size());
+            for (size_t i = 0; i < grp_raw.size(); ++i)
+                m_grouping[i] = static_cast<uint8_t>(grp_raw[i]);
+            FacetHelper::adjust_grouping(m_grouping);
+        }
+
+        if (yes_set) m_true_name  = yes_raw;
+        else         m_true_name  = "true";
+        if (no_set)  m_false_name = no_raw;
+        else         m_false_name = "false";
     }
     
 public:
@@ -110,57 +118,64 @@ public:
             return;
         }
 
-        m_decimal_point = FacetHelper::nl_langinfo_char<CharT>(DECIMAL_POINT, name, static_cast<CharT>('.'));
-        m_thousands_sep = FacetHelper::nl_langinfo_char<CharT>(THOUSANDS_SEP, name, static_cast<CharT>('\0'));
-
-        clocale_wrapper inter_locale(name.c_str());
-        clocale_user guard(inter_locale);
-
-        if (m_thousands_sep != '\0')
+        // Snapshot all locale-dependent strings while the locale guard is
+        // active. The lconv* and nl_langinfo() pointers may be invalidated
+        // by any subsequent setlocale()/uselocale() call (e.g. inside
+        // detail::to_wstring / detail::to_u32string), so copy first and
+        // convert after.
+        std::string dp_raw, ts_raw, grp_raw, yes_raw, no_raw;
+        bool yes_set = false, no_set = false;
         {
-            const char* src = nl_langinfo(GROUPING);
-            const size_t len = strlen(src);
-            if (len != 0)
-            {
-                // Copy raw POSIX grouping bytes, then normalise into the
-                // internal convention here at the POSIX boundary.
-                m_grouping.resize(len);
-                for (size_t i = 0; i < len; ++i)
-                    m_grouping[i] = (uint8_t)(src[i]);
-                FacetHelper::adjust_grouping(m_grouping);
-            }
+            clocale_wrapper inter_locale(name.c_str());
+            clocale_user guard(inter_locale);
+            const lconv* lc = localeconv();
+            if (lc->decimal_point) dp_raw  = lc->decimal_point;
+            if (lc->thousands_sep) ts_raw  = lc->thousands_sep;
+            if (lc->grouping)      grp_raw = lc->grouping;
+
+            if (auto* p = nl_langinfo(YESSTR)) { yes_raw = p; yes_set = true; }
+            if (auto* p = nl_langinfo(NOSTR))  { no_raw  = p; no_set  = true; }
         }
 
-        auto yesStr = nl_langinfo(YESSTR);
-        if (yesStr == nullptr)
+        m_decimal_point = FacetHelper::string_to_widechar_convert<CharT>(
+            dp_raw, name, static_cast<CharT>('.'));
+        m_thousands_sep = FacetHelper::string_to_widechar_convert<CharT>(
+            ts_raw, name, static_cast<CharT>('\0'));
+
+        if (m_thousands_sep != static_cast<CharT>('\0') && !grp_raw.empty())
         {
-            if constexpr (std::is_same_v<CharT, wchar_t>)
-                m_true_name = L"true";
-            else
-                m_true_name = U"true";
+            // Copy raw POSIX grouping bytes, then normalise into the
+            // internal convention here at the POSIX boundary.
+            m_grouping.resize(grp_raw.size());
+            for (size_t i = 0; i < grp_raw.size(); ++i)
+                m_grouping[i] = static_cast<uint8_t>(grp_raw[i]);
+            FacetHelper::adjust_grouping(m_grouping);
+        }
+
+        if (!yes_set)
+        {
+            if constexpr (std::is_same_v<CharT, wchar_t>) m_true_name = L"true";
+            else                                          m_true_name = U"true";
         }
         else
         {
             if constexpr(std::is_same_v<CharT, wchar_t>)
-                m_true_name = detail::to_wstring(yesStr, name);
+                m_true_name = detail::to_wstring(yes_raw.c_str(), name);
             else
-                m_true_name = detail::to_u32string(yesStr, name);
+                m_true_name = detail::to_u32string(yes_raw.c_str(), name);
         }
-        
-        auto noStr = nl_langinfo(NOSTR);
-        if (noStr == nullptr)
+
+        if (!no_set)
         {
-            if constexpr (std::is_same_v<CharT, wchar_t>)
-                m_false_name = L"false";
-            else
-                m_false_name = U"false";
+            if constexpr (std::is_same_v<CharT, wchar_t>) m_false_name = L"false";
+            else                                          m_false_name = U"false";
         }
         else
         {
             if constexpr(std::is_same_v<CharT, wchar_t>)
-                m_false_name = detail::to_wstring(noStr, name);
+                m_false_name = detail::to_wstring(no_raw.c_str(), name);
             else
-                m_false_name = detail::to_u32string(noStr, name);
+                m_false_name = detail::to_u32string(no_raw.c_str(), name);
         }
     }
     


### PR DESCRIPTION
- Replace numeric_conf's POSIX-only nl_langinfo_char path with the standard C localeconv path (matches monetary_conf style; lifts the POSIX-only dependency for DECIMAL_POINT / THOUSANDS_SEP / GROUPING). YESSTR / NOSTR have no lconv equivalent and keep using nl_langinfo.

- Snapshot lconv / nl_langinfo strings at the locale boundary so the pointer-invalidation rule (C11 7.11.2.1, POSIX nl_langinfo) cannot cause use-after-invalidation when downstream conversions invoke uselocale internally.

- Extract the narrow-to-widechar single-char conversion (previously duplicated as to_charT lambdas in numeric_details.h and monetary_details.h) into FacetHelper::string_to_widechar_convert. The helper takes const std::string& by design: the parameter type itself enforces that callers must hand over a caller-owned snapshot, not a borrowed pointer into libc-owned locale data.

- Apply the snapshot pattern at monetary_conf's two relevant call sites (mon_decimal_point / mon_thousands_sep). The remaining lconv reads in monetary_conf are unchanged - known pre-existing concern, separate refactor.

- Drop nl_langinfo_char from facet_helper.h and the now-unused <langinfo.h> / <nl_types.h> / <common/clocale_wrapper.h> includes.