### PR TITLE
fix(facet): tidy includes, validate wctype categories, harden ctype APIs

### DIFF
--- a/include/facet/ctype.h
+++ b/include/facet/ctype.h
@@ -3,6 +3,7 @@
 #include <common/lru_cache.h>
 #include <common/metafunctions.h>
 #include <facet/ctype_details.h>
+#include <facet/facet_common.h>
 
 #include <limits>
 #include <memory>
@@ -30,7 +31,10 @@ public:
     template <shared_ptr_to<ctype_conf<CharT>> TConfPtr>
     ctype(TConfPtr p_obj)
     {
-        avail_ptr(p_obj);
+        // Return value intentionally discarded: this specialization builds
+        // lookup tables eagerly and does not retain p_obj, so we only need
+        // avail_ptr's null check, not the unwrapped pointer.
+        (void)avail_ptr(p_obj);
         for (unsigned i = 0; i < s_len; ++i)
         {
             m_table[i] = p_obj->is((CharT)i);
@@ -157,7 +161,8 @@ public:
     using char_type = CharT;
     using mask = typename ctype_conf<CharT>::mask;
 
-    ctype(std::shared_ptr<const ctype_conf<CharT>> p_obj)
+    template <shared_ptr_to<ctype_conf<CharT>> TConfPtr>
+    ctype(TConfPtr p_obj)
         : m_obj(avail_ptr(p_obj))
     {
         for (unsigned i = 0; i < s_len; ++i)
@@ -262,10 +267,7 @@ public:
     OutIt narrow_seq(InIt beg, InIt end, char dflt, OutIt dst) const
     {
         while (beg < end)
-        {
-            auto res = do_narrow(*beg++);
-            *dst++ = res ? *res : dflt;
-        }
+            *dst++ = narrow(*beg++, dflt);
         return dst;
     }
 

--- a/include/facet/ctype_details.h
+++ b/include/facet/ctype_details.h
@@ -1,10 +1,18 @@
 #pragma once
+// Requires POSIX.1-2008 (_POSIX_C_SOURCE >= 200809L or _GNU_SOURCE).
+// The *_l character-classification and conversion functions used below
+// (isupper_l, toupper_l, wctype_l, iswctype_l, towupper_l, etc.) are
+// POSIX extensions, not standard C++. The build system must define the
+// appropriate feature-test macro before any system header is included.
 #include <common/clocale_wrapper.h>
+#include <common/defs.h>
 #include <facet/facet_common.h>
 
 #include <cctype>
+#include <cstdio>
 #include <cwchar>
 #include <cwctype>
+#include <iterator>
 #include <limits>
 #include <optional>
 #include <string>
@@ -111,19 +119,28 @@ public:
         : ft_basic<ctype<CharT>>()
         , m_inter_locale(name.c_str())
     {
-        clocale_user guard(m_inter_locale);
-        for (size_t j = 0; j < sizeof(m_widen) / sizeof(wint_t); ++j)
-          m_widen[j] = btowc(j);
+        {
+            clocale_user guard(m_inter_locale);
+            for (size_t j = 0; j < std::size(m_widen); ++j)
+                m_widen[j] = btowc(j);
+        }
 
-        m_wmask_upper  = wctype_l("upper",  m_inter_locale.c_locale);
-        m_wmask_lower  = wctype_l("lower",  m_inter_locale.c_locale);
-        m_wmask_alpha  = wctype_l("alpha",  m_inter_locale.c_locale);
-        m_wmask_digit  = wctype_l("digit",  m_inter_locale.c_locale);
-        m_wmask_xdigit = wctype_l("xdigit", m_inter_locale.c_locale);
-        m_wmask_space  = wctype_l("space",  m_inter_locale.c_locale);
-        m_wmask_print  = wctype_l("print",  m_inter_locale.c_locale);
-        m_wmask_cntrl  = wctype_l("cntrl",  m_inter_locale.c_locale);
-        m_wmask_punct  = wctype_l("punct",  m_inter_locale.c_locale);
+        auto wctype_wrapper = [&](const char* category)
+        {
+            wctype_t res = wctype_l(category, m_inter_locale.c_locale);
+            if (res == 0)
+                throw cvt_error(std::string("ctype_conf constructor fail: wctype_l failed for category ") + category);
+            return res;
+        };
+        m_wmask_upper  = wctype_wrapper("upper");
+        m_wmask_lower  = wctype_wrapper("lower");
+        m_wmask_alpha  = wctype_wrapper("alpha");
+        m_wmask_digit  = wctype_wrapper("digit");
+        m_wmask_xdigit = wctype_wrapper("xdigit");
+        m_wmask_space  = wctype_wrapper("space");
+        m_wmask_print  = wctype_wrapper("print");
+        m_wmask_cntrl  = wctype_wrapper("cntrl");
+        m_wmask_punct  = wctype_wrapper("punct");
     }
 
     virtual base_ft<ctype>::mask is(CharT _c) const
@@ -152,6 +169,12 @@ public:
         return towlower_l(static_cast<wchar_t>(c), m_inter_locale.c_locale);
     }
 
+    // Matches std::ctype<wchar_t>::widen() semantics: only required to be
+    // correct for the basic source character set. For multi-byte locales
+    // (e.g. UTF-8), high bytes are not standalone characters and btowc()
+    // returns WEOF for them at table-build time; the corresponding entries
+    // in m_widen hold WEOF cast to CharT (a sentinel-looking but
+    // unspecified value). Callers must not widen() such bytes.
     virtual CharT widen(char c) const
     {
         return static_cast<CharT>(m_widen[static_cast<unsigned char>(c)]);

--- a/include/facet/facet_common.h
+++ b/include/facet/facet_common.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <concepts>
 #include <cstddef>
 #include <memory>
 #include <stdexcept>
@@ -8,7 +9,7 @@ namespace IOv2
 {
 struct abs_ft
 {
-    abs_ft(size_t id)
+    explicit abs_ft(size_t id)
         : m_id(id) {}
 
     abs_ft(const abs_ft&) = delete;
@@ -34,10 +35,12 @@ template <typename TFacet> class ft_basic;
 template <template<typename> class TFacet, typename CharT>
 class ft_basic<TFacet<CharT>> : public base_ft<TFacet>
 {
+    static_assert(sizeof(void*) <= sizeof(size_t));
 public:
     using char_type = CharT;
 public:
     template <typename... T>
+        requires std::constructible_from<base_ft<TFacet>, size_t, T...>
     ft_basic(T&&... args)
         : base_ft<TFacet>(id(), std::forward<T>(args)...) {}
 

--- a/include/facet/facet_helper.h
+++ b/include/facet/facet_helper.h
@@ -77,14 +77,15 @@ namespace IOv2::FacetHelper
 
     // Internal helper function.
     //
-    // Preconditions (not validated):
-    //   - `grouping` is non-empty (only the first precondition is asserted).
+    // Preconditions:
+    //   - `grouping` is non-empty. [asserted in debug builds]
     //   - `[first, last)` is a valid range, i.e. `first <= last`. Passing
     //     `first > last` causes the inner copy loop to never terminate and
-    //     write past the output buffer.
+    //     write past the output buffer. [asserted in debug builds]
     //   - `s` points to an output buffer with sufficient capacity to hold
     //     `(last - first)` characters plus one separator per non-leading
     //     group; callers are responsible for sizing the buffer.
+    //     [not validated]
     template <typename CharT>
     inline CharT* add_grouping(CharT* s, CharT sep, const std::vector<uint8_t>& grouping,
                                const CharT* first, const CharT* last)
@@ -178,10 +179,13 @@ namespace IOv2::FacetHelper
     }
 
     // Internal helper function. Callers are responsible for ensuring that both
-    // grouping and grouping_tmp are non-empty; this function does not validate
-    // those preconditions. Callers guarantee grouping is non-empty because
-    // grouping_tmp is only populated inside !grouping.empty() branches, so
-    // the non-emptiness of grouping_tmp implies the non-emptiness of grouping.
+    // grouping and grouping_tmp are non-empty; non-emptiness is validated only
+    // by assert() in debug builds, release builds rely on the caller. Violating
+    // the precondition in release causes `size() - 1` to underflow to SIZE_MAX
+    // and subsequent indexing to read out of bounds. Callers guarantee grouping
+    // is non-empty because grouping_tmp is only populated inside
+    // !grouping.empty() branches, so the non-emptiness of grouping_tmp implies
+    // the non-emptiness of grouping.
     //
     // grouping uses the internal uint8_t convention established by
     // adjust_grouping(): 1–255 are explicit group sizes, 0 is the sole

--- a/test/Makefile
+++ b/test/Makefile
@@ -5,6 +5,14 @@ MODE = debug
 CXX ?= g++
 # CXX := /usr/bin/clang++
 
+# Feature-test macros (applied to all build modes via CPPFLAGS)
+# _POSIX_C_SOURCE=200809L exposes POSIX.1-2008 APIs required by this project:
+#   - locale_t, newlocale(), uselocale()  (clocale_wrapper)
+#   - isupper_l / islower_l / isalpha_l / isdigit_l / isxdigit_l /
+#     isspace_l / isprint_l / iscntrl_l / ispunct_l / toupper_l / tolower_l
+#   - wctype_l / iswctype_l / towupper_l / towlower_l  (ctype_details.h)
+CPPFLAGS := -D_POSIX_C_SOURCE=200809L
+
 ifeq ($(MODE),sanitizer)
     COMP_FLAGS := -Wall -Werror -Wshadow -std=c++23 -g -O1 -fsanitize=address,undefined -fno-omit-frame-pointer -I../include -I. -I/usr/include/botan-2/
     LINK_FLAGS := -lz -lbotan-2 -fsanitize=address,undefined
@@ -126,7 +134,7 @@ valgrind-util: util
 # Generic compilation rule
 $(OBJ_DIR)/%.o: ./%.cpp
 	@mkdir -p $(dir $@)
-	$(CXX) $(COMP_FLAGS) -c $< -o $@
+	$(CXX) $(COMP_FLAGS) $(CPPFLAGS) -c $< -o $@
 
 # Run all tests
 test: all


### PR DESCRIPTION
- Includes (IWYU): ctype.h now directly includes <facet/facet_common.h>
  (was relying on transitive include via ctype_details.h);
  ctype_details.h adds <cstdio> for EOF, <iterator> for std::size, and
  <common/defs.h> for cvt_error.

- POSIX feature-test requirement: ctype_details.h depends on the _l character-classification and conversion functions (POSIX.1-2008 extensions, not standard C++). Document this at the top of the header, and define -D_POSIX_C_SOURCE=200809L in test/Makefile via a shared CPPFLAGS that all build modes inherit.

- wctype_l validation: extract the 9 redundant wctype_l calls into a single lambda that throws cvt_error if any category fails (was silently storing 0, which makes subsequent iswctype_l UB per POSIX). The thrown message includes the category name for diagnostic context. Also narrow the clocale_user guard scope to just the btowc() loop, since all subsequent wctype_l calls take an explicit locale.

- Constructor consistency: ctype<sizeof>1>'s constructor is now template-constrained on shared_ptr_to like the sizeof==1 specialization, so generic callers see the same API on both paths.

- narrow_seq consistency: ctype<sizeof>1>::narrow_seq now delegates to the public narrow(c, dflt) instead of inlining the optional unpacking, matching the sizeof==1 specialization. Future changes to narrow(c, dflt) are picked up by both paths uniformly.

- ft_basic constraints: add requires std::constructible_from<base_ft<TFacet>, size_t, T...> so misuse fails at the call site instead of inside the base-class init list; this also makes detection idioms (requires-expressions) work.

- ft_basic pointer assumption: static_assert(sizeof(void*) <= sizeof(size_t)) on the reinterpret_cast in id(), turning the previously implicit assumption into a compile-time check.

- Array size: use std::size(m_widen) instead of the fragile sizeof(m_widen)/sizeof(wint_t) pattern that breaks silently if m_widen ever changes type.

- widen semantics: add a comment on ctype_conf<wchar_t>::widen explaining that the function matches std::ctype<wchar_t>::widen, whose contract only requires correctness for the basic source character set; for multi-byte locales, high bytes map through btowc()->WEOF and end up as unspecified CharT values that callers must not consume.

- abs_ft: mark single-arg constructor explicit.

- avail_ptr usage: in ctype<sizeof==1> ctor, (void)-cast the discarded avail_ptr() result and add a comment explaining why the return value is not retained on this path.

- Documentation: rewrite add_grouping and verify_grouping precondition blocks to label each precondition as [asserted in debug builds] or [not validated], and to describe the SIZE_MAX-underflow failure mode in release.