### PR TITLE
refactor(facet): clarify pack/rule trait names and guard head/tail against empty packs

### DIFF
--- a/include/facet/facet_common.h
+++ b/include/facet/facet_common.h
@@ -56,16 +56,16 @@ template <typename...>
 struct facet_create_pack;
 
 template <typename T>
-constexpr static bool is_facet_create_rule = false;
+constexpr static bool is_nonempty_facet_create_rule = false;
 
 template <typename... T>
-constexpr static bool is_facet_create_rule<facet_create_rule<T...>> = (sizeof...(T) != 0);
+constexpr static bool is_nonempty_facet_create_rule<facet_create_rule<T...>> = (sizeof...(T) != 0);
 
 template <typename T>
-constexpr static bool is_facet_create_pack = false;
+constexpr static bool is_nonempty_facet_create_pack = false;
 
-template <typename ...T>
-constexpr static bool is_facet_create_pack<facet_create_pack<T...>> = (sizeof...(T) != 0);
+template <typename... T>
+constexpr static bool is_nonempty_facet_create_pack<facet_create_pack<T...>> = (sizeof...(T) != 0);
 
 template <typename T>
 constexpr static size_t facet_create_pack_size = 0;
@@ -73,7 +73,9 @@ constexpr static size_t facet_create_pack_size = 0;
 template <typename... T>
 constexpr static size_t facet_create_pack_size<facet_create_pack<T...>> = sizeof...(T);
 
-template <typename T> struct facet_create_pack_head;
+template <typename T>
+    requires (facet_create_pack_size<T> > 0)
+struct facet_create_pack_head;
 
 template <typename H, typename... T>
 struct facet_create_pack_head<facet_create_pack<H, T...>>
@@ -81,7 +83,9 @@ struct facet_create_pack_head<facet_create_pack<H, T...>>
     using type = H;
 };
 
-template <typename T> struct facet_create_pack_tail;
+template <typename T>
+    requires (facet_create_pack_size<T> > 0)
+struct facet_create_pack_tail;
 
 template <typename H, typename... T>
 struct facet_create_pack_tail<facet_create_pack<H, T...>>

--- a/include/locale/locale.h
+++ b/include/locale/locale.h
@@ -100,7 +100,7 @@ class locale
         template <typename TC, typename... TRem>
         bool has_helper() const
         {
-            if constexpr(is_facet_create_pack<TC>)
+            if constexpr(is_nonempty_facet_create_pack<TC>)
             {
                 auto checked = ft_wrapper<TC>(m_ref);
                 if (checked.has()) return true;
@@ -123,7 +123,7 @@ class locale
         template <typename TF, typename TC, typename... TSub>
         std::shared_ptr<TF> get_helper()
         {
-            if constexpr(is_facet_create_pack<TC>)
+            if constexpr(is_nonempty_facet_create_pack<TC>)
             {
                 auto creator = ft_wrapper<TC>(m_ref);
                 
@@ -260,7 +260,7 @@ public:
     }
     
     template <typename TF>
-        requires (is_facet_create_rule<typename TF::create_rules>)
+        requires (is_nonempty_facet_create_rule<typename TF::create_rules>)
     bool has() const
     {
         {
@@ -284,7 +284,7 @@ public:
     }
 
     template <typename TF>
-        requires (is_facet_create_rule<typename TF::create_rules>)
+        requires (is_nonempty_facet_create_rule<typename TF::create_rules>)
     std::shared_ptr<TF> get() const
     {
         {


### PR DESCRIPTION


Rename is_facet_create_rule/pack to is_nonempty_facet_create_rule/pack so the name directly documents that empty instantiations return false, separating the "shape detection" intent from the "non-empty" constraint.

Add requires (facet_create_pack_size<T> > 0) to the primary templates of facet_create_pack_head and facet_create_pack_tail so that instantiating either with an empty pack produces a clear constraint diagnostic rather than a silent hard error at the point of ::type access.