### PR TITLE
fix(facet): tighten locale snapshot contract and harden wide-char API boundary

### DIFF
--- a/include/facet/ctype.h
+++ b/include/facet/ctype.h
@@ -62,7 +62,7 @@ public:
     template <typename InIt, typename OutIt>
     OutIt is_seq(InIt low, InIt high, OutIt vec) const
     {
-        while (low < high)
+        while (low != high)
             *vec++ = is(*low++);
         return vec;
     }
@@ -70,7 +70,7 @@ public:
     template <typename InIt>
     InIt scan_is_any(mask m, InIt beg, InIt end) const
     {
-        while ((beg < end) && (!(is(*beg) & m)))
+        while ((beg != end) && (!(is(*beg) & m)))
             ++beg;
         return beg;
     }
@@ -78,7 +78,7 @@ public:
     template <typename InIt>
     InIt scan_not_any(mask m, InIt beg, InIt end) const
     {
-        while ((beg < end) && (is(*beg) & m))
+        while ((beg != end) && (is(*beg) & m))
             ++beg;
         return beg;
     }
@@ -91,7 +91,7 @@ public:
     template <typename InIt, typename OutIt>
     OutIt toupper_seq(InIt beg, InIt end, OutIt dst) const
     {
-        while (beg < end)
+        while (beg != end)
             *dst++ = toupper(*beg++);
         return dst;
     }
@@ -104,7 +104,7 @@ public:
     template <typename InIt, typename OutIt>
     OutIt tolower_seq(InIt beg, InIt end, OutIt dst) const
     {
-        while (beg < end)
+        while (beg != end)
             *dst++ = tolower(*beg++);
         return dst;
     }
@@ -117,7 +117,7 @@ public:
     template <typename InIt, typename OutIt>
     OutIt widen_seq(InIt beg, InIt end, OutIt dst) const
     {
-        while (beg < end)
+        while (beg != end)
             *dst++ = widen(*beg++);
         return dst;
     }
@@ -136,7 +136,7 @@ public:
     template <typename InIt, typename OutIt>
     OutIt narrow_seq(InIt beg, InIt end, char dflt, OutIt dst) const
     {
-        while (beg < end)
+        while (beg != end)
             *dst++ = narrow(*beg++, dflt);
         return dst;
     }
@@ -192,7 +192,7 @@ public:
     template <typename InIt, typename OutIt>
     OutIt is_seq(InIt low, InIt high, OutIt vec) const
     {
-        while (low < high)
+        while (low != high)
             *vec++ = do_is(*low++);
         return vec;
     }
@@ -200,7 +200,7 @@ public:
     template <typename InIt>
     InIt scan_is_any(mask m, InIt beg, InIt end) const
     {
-        while ((beg < end) && (!(do_is(*beg) & m)))
+        while ((beg != end) && (!(do_is(*beg) & m)))
             ++beg;
         return beg;
     }
@@ -208,7 +208,7 @@ public:
     template <typename InIt>
     InIt scan_not_any(mask m, InIt beg, InIt end) const
     {
-        while ((beg < end) && (do_is(*beg) & m))
+        while ((beg != end) && (do_is(*beg) & m))
             ++beg;
         return beg;
     }
@@ -221,7 +221,7 @@ public:
     template <typename InIt, typename OutIt>
     OutIt toupper_seq(InIt beg, InIt end, OutIt dst) const
     {
-        while (beg < end)
+        while (beg != end)
             *dst++ = do_toupper(*beg++);
         return dst;
     }
@@ -234,20 +234,36 @@ public:
     template <typename InIt, typename OutIt>
     OutIt tolower_seq(InIt beg, InIt end, OutIt dst) const
     {
-        while (beg < end)
+        while (beg != end)
             *dst++ = do_tolower(*beg++);
         return dst;
     }
 
+    // Default behaviour (inherited from ctype_conf<CharT>::widen at
+    // construction time): matches std::ctype<wchar_t>::widen() semantics
+    // -- only guaranteed to be correct for the basic source character
+    // set. For multi-byte locales (e.g. UTF-8), high bytes are not
+    // standalone characters and btowc() returns WEOF for them at
+    // table-build time; the corresponding entries of m_widen hold WEOF
+    // cast to CharT (a sentinel-looking but unspecified value), and
+    // callers must not widen() such bytes under this default.
+    //
+    // This is only the default. A user may derive from ctype_conf<CharT>
+    // and override widen() to supply a different mapping; the lookup
+    // table held here is then rebuilt from that override when the
+    // owning ctype<CharT> is constructed, and the caveat above no
+    // longer applies under that derived behaviour.
     CharT widen(char c) const
     {
         return m_widen[static_cast<unsigned char>(c)];
     }
 
+    // See widen() above for the WEOF caveat applicable under the
+    // default ctype_conf<CharT>::widen behaviour.
     template <typename InIt, typename OutIt>
     OutIt widen_seq(InIt beg, InIt end, OutIt dst) const
     {
-        while (beg < end)
+        while (beg != end)
             *dst++ = widen(*beg++);
         return dst;
     }
@@ -266,7 +282,7 @@ public:
     template <typename InIt, typename OutIt>
     OutIt narrow_seq(InIt beg, InIt end, char dflt, OutIt dst) const
     {
-        while (beg < end)
+        while (beg != end)
             *dst++ = narrow(*beg++, dflt);
         return dst;
     }

--- a/include/facet/ctype_details.h
+++ b/include/facet/ctype_details.h
@@ -9,6 +9,7 @@
 #include <facet/facet_common.h>
 
 #include <cctype>
+#include <cstddef>
 #include <cstdio>
 #include <cwchar>
 #include <cwctype>
@@ -145,6 +146,8 @@ public:
 
     virtual base_ft<ctype>::mask is(CharT _c) const
     {
+        if (out_of_wchar_range(_c)) return 0;
+
         base_ft<ctype>::mask res = 0;
         const auto c = static_cast<wchar_t>(_c);
         if (iswctype_l(c, m_wmask_upper, m_inter_locale.c_locale))  res |= base_ft<ctype>::upper;
@@ -161,11 +164,13 @@ public:
 
     virtual CharT toupper(CharT c) const
     {
+        if (out_of_wchar_range(c)) return c;
         return towupper_l(static_cast<wchar_t>(c), m_inter_locale.c_locale);
     }
 
     virtual CharT tolower(CharT c) const
     {
+        if (out_of_wchar_range(c)) return c;
         return towlower_l(static_cast<wchar_t>(c), m_inter_locale.c_locale);
     }
 
@@ -182,6 +187,7 @@ public:
 
     virtual std::optional<char> narrow(CharT wc) const
     {
+        if (out_of_wchar_range(wc)) return std::nullopt;
         clocale_user guard(m_inter_locale);
         const int c = wctob(wc);
         if (c == EOF) return std::nullopt;
@@ -189,6 +195,11 @@ public:
     }
 
 private:
+    // The out-of-wchar-range guards used by is/toupper/tolower/narrow
+    // above are provided by IOv2::out_of_wchar_range in facet_common.h
+    // (reusable across facets); resolved here via unqualified lookup
+    // since this class lives in the same namespace.
+
     clocale_wrapper   m_inter_locale;
     wint_t            m_widen[1 + std::numeric_limits<unsigned char>::max()];
 

--- a/include/facet/facet_common.h
+++ b/include/facet/facet_common.h
@@ -1,8 +1,10 @@
 #pragma once
 #include <concepts>
 #include <cstddef>
+#include <cwchar>
 #include <memory>
 #include <stdexcept>
+#include <type_traits>
 #include <utility>
 
 namespace IOv2
@@ -92,6 +94,37 @@ struct facet_create_pack_tail<facet_create_pack<H, T...>>
 {
     using type = facet_create_pack<T...>;
 };
+
+// Returns true if `c` has no wchar_t representation. Used to guard the
+// C `*_l` wide-character functions (iswctype_l, towupper_l, towlower_l,
+// wctob, ...) at any facet's API boundary, since the C standard says
+// their behaviour is implementation-defined for inputs that are not
+// representable as a wchar_t.
+//
+// Only non-trivial for CharT == char32_t on platforms where char32_t
+// covers a strictly wider range than wchar_t (e.g. Linux: signed
+// 32-bit wchar_t with WCHAR_MAX = 0x7FFFFFFF, vs unsigned 32-bit
+// char32_t). For every other character type (wchar_t, char, char8_t,
+// char16_t) the input is always representable as wchar_t on every
+// supported platform, and the function is statically a no-op.
+//
+// CharT is constrained to the five standard C++ character types so
+// that misuse with non-character integral or floating types (where
+// the wchar_t-range question is meaningless) fails at compile time
+// instead of silently returning false.
+template <typename CharT>
+    requires std::is_same_v<CharT, char>     ||
+             std::is_same_v<CharT, wchar_t>  ||
+             std::is_same_v<CharT, char8_t>  ||
+             std::is_same_v<CharT, char16_t> ||
+             std::is_same_v<CharT, char32_t>
+constexpr bool out_of_wchar_range(CharT c) noexcept
+{
+    if constexpr (std::is_same_v<CharT, char32_t>)
+        return c > static_cast<char32_t>(WCHAR_MAX);
+    else
+        return false;
+}
 
 template <typename T>
 std::shared_ptr<T> avail_ptr(std::shared_ptr<T> obj)

--- a/include/facet/facet_helper.h
+++ b/include/facet/facet_helper.h
@@ -4,7 +4,9 @@
 
 #include <algorithm>
 #include <cassert>
+#include <cstddef>
 #include <cstdint>
+#include <iterator>
 #include <limits>
 #include <string>
 #include <type_traits>
@@ -12,23 +14,29 @@
 
 namespace IOv2::FacetHelper
 {
-    // Convert the first character of a (possibly multibyte) C string `ptr`
-    // to a narrow char in the given locale, returning '\0' if conversion
-    // is not representable.
+    // Convert the first character of a (possibly multibyte) narrow string
+    // `narrow` to a `char` in the given locale, returning '\0' if `narrow`
+    // is empty or conversion is not representable.
     //
-    // Preconditions (not validated):
-    //   - `ptr` is non-null.
-    //   - `ptr` points to a NUL-terminated C string.
-    inline char string_to_char_convert(const char* ptr, const std::string& locale_name)
+    // Suitable for fields read out of `lconv` / `nl_langinfo()` that
+    // semantically represent a single user-visible character (e.g.
+    // decimal_point, thousands_sep, mon_decimal_point, mon_thousands_sep).
+    //
+    // Why `const std::string&` and not `const char*`: `lconv*` and
+    // `nl_langinfo()` pointers may be invalidated by any setlocale() /
+    // uselocale() call. The conversion below transitively performs such
+    // calls (via detail::to_wstring), so the input must be a caller-owned
+    // snapshot rather than a borrowed pointer into the libc-owned locale
+    // data. Taking std::string makes this contract unmissable at every
+    // call site.
+    inline char string_to_char_convert(const std::string& narrow,
+                                       const std::string& locale_name)
     {
-        assert(ptr != nullptr);
-        if (*ptr == '\0')
-            return '\0';
-        if (ptr[1] == '\0')
-            return *ptr;
+        if (narrow.empty()) return '\0';
+        if (narrow.size() == 1) return narrow[0];
 
-        // Convert char to wchar_t then narrow down
-        std::wstring wide_str = detail::to_wstring(ptr, locale_name);
+        // Convert (multi-byte) narrow to wchar_t then narrow down
+        std::wstring wide_str = detail::to_wstring(narrow.c_str(), locale_name);
         if (wide_str.empty()) return '\0';
 
         ctype_conf<wchar_t> tmp_ctype(locale_name);

--- a/include/facet/monetary_details.h
+++ b/include/facet/monetary_details.h
@@ -216,8 +216,18 @@ public:
             clocale_user guard(inter_locale);
             const lconv* lc = localeconv();
 
-            m_decimal_point = FacetHelper::string_to_char_convert(lc->mon_decimal_point, name);
-            m_thousands_sep = FacetHelper::string_to_char_convert(lc->mon_thousands_sep, name);
+            // Snapshot lconv string fields before invoking
+            // string_to_char_convert: that function transitively calls
+            // setlocale()/uselocale() (via detail::to_wstring), which
+            // may invalidate libc-owned lconv pointers. Both snapshots
+            // are taken before any conversion, so the second pointer
+            // cannot be invalidated by the first call.
+            std::string mdp_raw, mts_raw;
+            if (lc->mon_decimal_point) mdp_raw = lc->mon_decimal_point;
+            if (lc->mon_thousands_sep) mts_raw = lc->mon_thousands_sep;
+
+            m_decimal_point = FacetHelper::string_to_char_convert(mdp_raw, name);
+            m_thousands_sep = FacetHelper::string_to_char_convert(mts_raw, name);
             if (m_decimal_point == '\0')
             {
                 m_frac_digits_int = 0;

--- a/include/facet/numeric_details.h
+++ b/include/facet/numeric_details.h
@@ -48,8 +48,8 @@ public:
             if (auto* p = nl_langinfo(NOSTR))  { no_raw  = p; no_set  = true; }
         }
 
-        m_decimal_point = FacetHelper::string_to_char_convert(dp_raw.c_str(), name);
-        m_thousands_sep = FacetHelper::string_to_char_convert(ts_raw.c_str(), name);
+        m_decimal_point = FacetHelper::string_to_char_convert(dp_raw, name);
+        m_thousands_sep = FacetHelper::string_to_char_convert(ts_raw, name);
 
         if (m_thousands_sep != '\0' && !grp_raw.empty())
         {


### PR DESCRIPTION


- string_to_char_convert now takes const std::string& (mirrors string_to_widechar_convert), forcing callers to snapshot lconv/ nl_langinfo bytes before any setlocale/uselocale call invalidates them.
- monetary_conf<char>: snapshot mon_decimal_point/mon_thousands_sep before invoking string_to_char_convert, since the call transitively performs uselocale via detail::to_wstring; both snapshots are taken before any conversion so neither pointer is read after invalidation.
- ctype_conf<wchar_t/char32_t>: guard is/toupper/tolower/narrow against CharT values not representable as wchar_t (char32_t > WCHAR_MAX); iswctype_l/towupper_l/towlower_l/wctob have implementation-defined behaviour for such inputs.
- Hoist out_of_wchar_range to facet_common.h so any CharT-parameterised facet can apply the same boundary guard via unqualified lookup; constrain CharT to the five standard character types so misuse with non-character integral or floating types fails at compile time.
- ctype<CharT> *_seq methods: replace operator< with operator!= so forward/input iterators are accepted; random-access was an unintended constraint.
- ctype<CharT>::widen (size>1): document the WEOF default-behaviour caveat inherited from ctype_conf<CharT>::widen for multi-byte locales, and note that derived configs may override it.
- Include hygiene: add <cstddef>/<iterator> to facet_helper.h and <cstddef> to ctype_details.h.