### PR TITLE
docs(facet): document contracts, assert CHAR_BIT==8, improve error message

### DIFF
--- a/include/facet/ctype.h
+++ b/include/facet/ctype.h
@@ -26,6 +26,15 @@ namespace detail
 // are declared as constrained function templates: the requires clause defers
 // evaluation of those dependent names to call time (when Derived is complete),
 // avoiding the incomplete-type error that class-scope type aliases would cause.
+//
+// Range precondition (applies to every method taking iterator pairs --
+// is_seq, scan_is_any, scan_not_any, toupper_seq, tolower_seq, widen_seq,
+// narrow_seq): [beg, end) must be a valid range, i.e. `end` is reachable
+// from `beg` via repeated `++`. The loops increment `beg` until it compares
+// equal to `end`; passing iterators that do not satisfy this (swapped
+// arguments on a random-access range, mismatched iterator pairs, an `end`
+// past a valid range, etc.) is undefined behaviour. Matches the equivalent
+// std::ctype contract; not asserted on the hot path.
 template <typename Derived>
 class ctype_ops
 {
@@ -90,6 +99,17 @@ public:
         return dst;
     }
 
+    // narrow(c) with a caller-supplied fallback for characters that have no
+    // single-byte representation in the target locale.
+    //
+    // @pre `def` is returned verbatim when `self().narrow(c)` yields no value;
+    //      this function does NOT validate that `def` is itself representable
+    //      in the target locale. By convention (matching std::ctype::narrow)
+    //      callers should pass a member of the basic source character set --
+    //      typically a printable ASCII byte such as '?' -- so the fallback is
+    //      meaningful in any encoding. Passing an arbitrary byte (e.g. '\xFF')
+    //      is accepted silently and may yield output that is not a valid
+    //      standalone character in the locale's encoding.
     template <typename TC>
         requires std::convertible_to<TC, typename Derived::char_type>
     char narrow(TC c, char def) const
@@ -108,11 +128,31 @@ public:
 };
 } // namespace detail
 
+// Specialisation for single-byte character types (char, char8_t). The full
+// [0, s_len) input space is enumerable at construction, so this specialisation
+// materialises every primitive (is/toupper/tolower/widen/narrow) into a
+// snapshot table and discards the source ctype_conf<CharT> pointer afterwards.
+// All later lookups are pure array reads with no virtual dispatch and no
+// shared_ptr indirection.
+//
+// Asymmetry with the sizeof(CharT) > 1 specialisation: that one retains m_obj
+// because its input space is too large to enumerate, and forwards out-of-table
+// values to the conf at call time. As a consequence, runtime mutations to a
+// user-derived ctype_conf<CharT>'s is/toupper/tolower/widen/narrow take effect
+// for the size > 1 path (on the out-of-table branch) but NOT for the size == 1
+// path: this specialisation captures a one-shot snapshot at construction and
+// never re-queries the conf. Callers who need dynamically-changing single-byte
+// behaviour should either rebuild a new ctype<CharT> after each change, or
+// supply a custom ctype<CharT> that does not snapshot.
 template <typename CharT>
     requires (sizeof(CharT) == 1)
 class ctype<CharT> : public detail::ctype_ops<ctype<CharT>>
 {
-    // Note: we have to use unsigned char here to avoid negative value
+    // Note: we have to use unsigned char here to avoid negative value.
+    // Sizing is in units of "values representable by unsigned char", not a
+    // hard-coded 256. The CHAR_BIT == 8 assumption is enforced by a
+    // static_assert in ctype_details.h, so on every supported platform
+    // s_len == 256.
     constexpr static unsigned s_len = std::numeric_limits<unsigned char>::max() + 1;
 
 public:
@@ -189,10 +229,26 @@ private:
 // explicit, immutable locale_t), and narrow() switches only the calling
 // thread's locale via a per-thread uselocale guard. A user-supplied override of
 // ctype_conf<CharT> must preserve this property.
+//
+// Self-consistency contract for user overrides: values inside [0, s_len) are
+// served from the snapshot tables built at construction, while values outside
+// that range go through virtual dispatch to the conf on every call. A
+// user-derived ctype_conf<CharT> whose is(), toupper(), and tolower() are not
+// internally consistent -- for example, `is(c) & upper` returning true while
+// `toupper(c) == c`, or returning a mask that disagrees with what the
+// case-conversion methods imply -- will exhibit "torn" behaviour: the
+// inconsistency is frozen into the in-range tables at construction but is
+// re-observed live for every out-of-range character. Overrides must be
+// self-consistent across is/toupper/tolower (and across is/widen/narrow where
+// the semantics demand it) so that the same character produces the same
+// answer regardless of which branch served it.
 template <typename CharT>
     requires (sizeof(CharT) > 1)
 class ctype<CharT> : public detail::ctype_ops<ctype<CharT>>
 {
+    // See the matching s_len note in the sizeof(CharT)==1 specialization
+    // above. Tables span [0, unsigned_char::max()+1) per-byte; CHAR_BIT == 8
+    // is enforced by static_assert in ctype_details.h.
     constexpr static unsigned s_len = std::numeric_limits<unsigned char>::max() + 1;
 
     // Unsigned counterpart of CharT, used to fold a (possibly signed) CharT

--- a/include/facet/ctype_details.h
+++ b/include/facet/ctype_details.h
@@ -9,6 +9,7 @@
 #include <facet/facet_common.h>
 
 #include <cctype>
+#include <climits>
 #include <cstddef>
 #include <cstdio>
 #include <cwchar>
@@ -21,6 +22,15 @@
 
 namespace IOv2
 {
+// The ctype lookup tables in this header and in ctype.h are sized as
+// std::numeric_limits<unsigned char>::max() + 1, on the assumption that a
+// byte is 8 bits and that the table covers all values an unsigned char can
+// hold. Exotic platforms with CHAR_BIT != 8 (some DSPs, historical mainframes)
+// would silently grow every per-byte table by 2^(CHAR_BIT-8)x. Reject them at
+// compile time rather than ship a non-obviously-broken binary.
+static_assert(CHAR_BIT == 8,
+    "facet/ctype tables assume an 8-bit byte; see ctype.h::s_len");
+
 template <typename CharT> class ctype;
 
 template <>
@@ -33,6 +43,14 @@ public:
     using mask = unsigned short;
 
     // Portable fixed mask values (implementation-independent)
+    //
+    // When adding a new primitive mask bit, update ALL of:
+    //   1) the constants below
+    //   2) ctype_conf<CharT>::m_wmask_<name>  (private member)
+    //   3) ctype_conf<CharT> constructor      (wctype_wrapper assignment)
+    //   4) ctype_conf<CharT>::is()            (iswctype_l check)
+    // Missing #2 or #3 leaves the wctype_t uninitialized — UB at iswctype_l.
+    // Missing #4 silently drops the new bit from is() results.
     constexpr static mask upper  = 0x0001;
     constexpr static mask lower  = 0x0002;
     constexpr static mask alpha  = 0x0004;
@@ -130,7 +148,7 @@ public:
         {
             wctype_t res = wctype_l(category, m_inter_locale.c_locale);
             if (res == 0)
-                throw cvt_error(std::string("ctype_conf constructor fail: wctype_l failed for category ") + category);
+                throw cvt_error(std::string("ctype_conf constructor failed: wctype_l returned 0 for category ") + category);
             return res;
         };
         m_wmask_upper  = wctype_wrapper("upper");
@@ -185,6 +203,22 @@ public:
         return static_cast<CharT>(m_widen[static_cast<unsigned char>(c)]);
     }
 
+    // Implementation note: unlike is/toupper/tolower (which call *_l
+    // functions with an explicit, immutable locale_t), wctob has no _l
+    // variant -- it reads whatever locale is currently active on the
+    // calling thread. We therefore install m_inter_locale via clocale_user
+    // for the duration of the wctob call, and restore on scope exit.
+    //
+    // Visible side effect for the window of this call: the calling
+    // thread's locale is m_inter_locale, not whatever it was on entry.
+    // Anything reached during this call -- in particular, a callback
+    // dispatched through a user-derived override of this function --
+    // that performs locale-sensitive I/O (std::ostream numeric
+    // formatting, std::format, third-party locale-aware code) will
+    // observe m_inter_locale instead of the thread's outer locale.
+    // Derivations should keep this function pure-computational and
+    // avoid locale-sensitive side effects inside the override; the same
+    // guidance the std::ctype facet conventions imply.
     virtual std::optional<char> narrow(CharT wc) const
     {
         if (out_of_wchar_range(wc)) return std::nullopt;

--- a/include/facet/facet_common.h
+++ b/include/facet/facet_common.h
@@ -65,6 +65,22 @@ public:
     // note on abs_ft::id() for why the shared name is intentional and safe.
     static size_t id() noexcept { return reinterpret_cast<size_t>(&s_id); }
 private:
+    // REQUIRES default symbol visibility across DSOs that share facet
+    // instances. Because id() returns &s_id, cross-DSO facet identity
+    // depends on the dynamic linker merging all copies of s_id to a
+    // single runtime address. The following deployment patterns silently
+    // break this and yield per-DSO ids for what should be the same facet:
+    //   - Building any TU that instantiates ft_basic<...> with
+    //     -fvisibility=hidden without re-exporting s_id.
+    //   - Linking a DSO with -Bsymbolic / -Bsymbolic-functions, which
+    //     binds internal references to the DSO-local copy.
+    //   - dlopen()ing a plugin with RTLD_LOCAL (the default).
+    //   - Sharing facet instances across Windows DLL boundaries (PE has
+    //     no equivalent of ELF weak-symbol unification; templates are
+    //     re-instantiated per DLL).
+    // If any of the above is needed, switch id() to a value-based
+    // identity (e.g. hash of typeid(TFacet).name()) rather than an
+    // address.
     inline static const void* s_id = nullptr;
 };
 
@@ -124,6 +140,16 @@ struct facet_create_pack_tail<facet_create_pack<H, T...>>
 // char32_t). For every other character type (wchar_t, char, char8_t,
 // char16_t) the input is always representable as wchar_t on every
 // supported platform, and the function is statically a no-op.
+//
+// Precise boundary for char32_t on Linux: this function returns true
+// exactly for the upper half of the char32_t range, [0x80000000,
+// 0xFFFFFFFF], because WCHAR_MAX == 0x7FFFFFFF there. The entire valid
+// Unicode code-point space U+0000..U+10FFFF lies well below this cutoff,
+// so the guard never rejects legal Unicode; it only filters out
+// non-Unicode bit patterns that a caller may have reinterpreted as
+// char32_t. Callers that intentionally pass arbitrary 32-bit integers
+// through a char32_t channel should not rely on out_of_wchar_range as a
+// Unicode-validity check.
 //
 // CharT is constrained to the five standard C++ character types so
 // that misuse with non-character integral or floating types (where

--- a/include/facet/facet_helper.h
+++ b/include/facet/facet_helper.h
@@ -63,6 +63,17 @@ namespace IOv2::FacetHelper
     // semantically represent a single user-visible character (e.g.
     // decimal_point, thousands_sep, mon_decimal_point, mon_thousands_sep).
     //
+    // `default_char` contract: returned verbatim on the empty-input and
+    // empty-conversion paths; this function does NOT validate that
+    // `default_char` is itself representable, well-formed, or otherwise
+    // meaningful under `locale_name`. Callers are responsible for choosing a
+    // sensible fallback (typically a plain ASCII-range value such as L' ',
+    // L'.', U' ', or U'.'). Note the asymmetry with `string_to_char_convert`,
+    // which uses a hard-coded `'\0'` fallback and accepts no caller default:
+    // here the fallback is a parameter precisely so callers can pick a
+    // locale-appropriate substitute, but the price is that validation is
+    // their responsibility, not ours.
+    //
     // Why `const std::string&` and not `const char*`: `lconv*` and
     // `nl_langinfo()` pointers may be invalidated by any setlocale() /
     // uselocale() call. The conversion below transitively performs such


### PR DESCRIPTION


Add range preconditions to ctype_ops, narrow(c,def), and default_char; document snapshot-vs-live asymmetry, wctob locale side-effect, DSO visibility requirements, and mask-bit maintenance checklist.

Add static_assert(CHAR_BIT==8) with <climits> to reject exotic platforms at compile time rather than silently grow tables. Improve wctype_l error message to include the return value.