### PR TITLE
docs(facet): add Doxygen bilingual (ZH/EN) comments to facet headers

### DIFF
--- a/include/facet/ctype.h
+++ b/include/facet/ctype.h
@@ -1,3 +1,41 @@
+/**
+ * @file ctype.h
+ * @lang{ZH}
+ * `ctype` facet：字符分类、大小写转换及宽窄字符映射。
+ *
+ * 本文件提供以下核心组件：
+ * - `detail::ctype_ops<Derived>`：CRTP 混入类，基于派生类的五个单字符原语
+ *   （`is`、`toupper`、`tolower`、`widen`、`narrow`）提供序列操作变体及
+ *   带回退的 `narrow(c, def)` 重载。
+ * - `ctype<CharT>`（`sizeof(CharT) == 1`，即 `char`、`char8_t`）：单字节特化；
+ *   构造时将全部 256 个值的五张原语表一次性快照到数组中，后续查询为零虚调用的 O(1)
+ *   数组读取，且不持有 `ctype_conf<CharT>` 指针。
+ * - `ctype<CharT>`（`sizeof(CharT) > 1`，即 `wchar_t`、`char32_t`）：多字节特化；
+ *   对 `[0, s_len)` 区间同样预建快照表，对超出区间的值则在每次调用时直接转发到
+ *   底层 `ctype_conf<CharT>`，无缓存、无锁，满足多线程安全契约。
+ * - CTAD 推导指引：从 `shared_ptr<ctype_conf<CharT>>` 自动推导 `ctype<CharT>`。
+ * @endif
+ *
+ * @lang{EN}
+ * `ctype` facet: character classification, case conversion, and widen/narrow mapping.
+ *
+ * This file provides the following core components:
+ * - `detail::ctype_ops<Derived>`: CRTP mixin class that provides sequence-operation
+ *   variants and a fallback-taking `narrow(c, def)` overload, derived from the five
+ *   single-character primitives of the `Derived` class (`is`, `toupper`, `tolower`,
+ *   `widen`, `narrow`).
+ * - `ctype<CharT>` (`sizeof(CharT) == 1`, i.e. `char`, `char8_t`): Single-byte
+ *   specialization; at construction all five primitive tables are snapshotted for all
+ *   256 values into plain arrays. Later lookups are O(1) array reads with no virtual
+ *   dispatch and no `ctype_conf<CharT>` pointer retained.
+ * - `ctype<CharT>` (`sizeof(CharT) > 1`, i.e. `wchar_t`, `char32_t`): Multi-byte
+ *   specialization; values in `[0, s_len)` are served from precomputed snapshot tables;
+ *   values beyond that range are forwarded directly to the underlying `ctype_conf<CharT>`
+ *   on each call, lock-free, satisfying the multi-thread safety contract.
+ * - CTAD deduction guide: deduces `ctype<CharT>` from `shared_ptr<ctype_conf<CharT>>`.
+ * @endif
+ */
+
 #pragma once
 
 #include <common/metafunctions.h>
@@ -13,35 +51,93 @@
 
 namespace IOv2
 {
+/**
+ * @lang{ZH}
+ * `ctype` facet 模板的前向声明。
+ * @endif
+ *
+ * @lang{EN}
+ * Forward declaration of the `ctype` facet template.
+ * @endif
+ */
 template <typename CharT>
 class ctype;
 
 namespace detail
 {
-// CRTP mixin supplying sequence operations and the narrow(c, default) overload
-// in terms of the Derived class's five single-character primitives: is(),
-// toupper(), tolower(), widen(), and narrow(). Both ctype<CharT> specialisations
-// inherit from this to avoid duplicating these definitions.
-//
-// Methods whose parameter types depend on Derived::char_type or Derived::mask
-// are declared as constrained function templates: the requires clause defers
-// evaluation of those dependent names to call time (when Derived is complete),
-// avoiding the incomplete-type error that class-scope type aliases would cause.
-//
-// Range precondition (applies to every method taking iterator pairs --
-// is_seq, scan_is_any, scan_not_any, toupper_seq, tolower_seq, widen_seq,
-// narrow_seq): [beg, end) must be a valid range, i.e. `end` is reachable
-// from `beg` via repeated `++`. The loops increment `beg` until it compares
-// equal to `end`; passing iterators that do not satisfy this (swapped
-// arguments on a random-access range, mismatched iterator pairs, an `end`
-// past a valid range, etc.) is undefined behaviour. Matches the equivalent
-// std::ctype contract; not asserted on the hot path.
+/**
+ * @lang{ZH}
+ * CRTP 混入类：基于派生类的五个单字符原语提供序列操作及带回退的 `narrow` 重载。
+ *
+ * `ctype<CharT>` 的两个特化均从本类继承，以避免重复定义序列方法。
+ *
+ * 参数类型依赖 `Derived::char_type` 或 `Derived::mask` 的方法被声明为受约束的函数模板：
+ * `requires` 子句将这些依赖名称的求值推迟到调用时（此时 `Derived` 已是完整类型），
+ * 从而避免类作用域类型别名在 `Derived` 不完整时引发的错误。
+ *
+ * @par 区间前置条件
+ * 所有接受迭代器对的方法（`is_seq`、`scan_is_any`、`scan_not_any`、`toupper_seq`、
+ * `tolower_seq`、`widen_seq`、`narrow_seq`）均要求 `[beg, end)` 为合法区间，即
+ * 从 `beg` 经反复递增可到达 `end`。传入不满足此条件的迭代器（如随机访问区间上
+ * 顺序颠倒的参数、不匹配的迭代器对、超出合法区间末尾的 `end` 等）属于未定义行为。
+ * 与等效的 `std::ctype` 契约一致；在热路径上不做断言。
+ * @endif
+ *
+ * @lang{EN}
+ * CRTP mixin class supplying sequence operations and the `narrow(c, default)` overload
+ * in terms of the `Derived` class's five single-character primitives: `is()`,
+ * `toupper()`, `tolower()`, `widen()`, and `narrow()`. Both `ctype<CharT>`
+ * specializations inherit from this to avoid duplicating these definitions.
+ *
+ * Methods whose parameter types depend on `Derived::char_type` or `Derived::mask`
+ * are declared as constrained function templates: the `requires` clause defers
+ * evaluation of those dependent names to call time (when `Derived` is complete),
+ * avoiding the incomplete-type error that class-scope type aliases would cause.
+ *
+ * @par Range precondition
+ * Every method taking iterator pairs (`is_seq`, `scan_is_any`, `scan_not_any`,
+ * `toupper_seq`, `tolower_seq`, `widen_seq`, `narrow_seq`) requires `[beg, end)` to
+ * be a valid range, i.e. `end` is reachable from `beg` via repeated `++`. Passing
+ * iterators that do not satisfy this (swapped arguments on a random-access range,
+ * mismatched iterator pairs, an `end` past a valid range, etc.) is undefined behaviour.
+ * Matches the equivalent `std::ctype` contract; not asserted on the hot path.
+ * @endif
+ *
+ * @tparam Derived
+ * @lang{ZH} CRTP 派生类自身的类型，须提供 `is`、`toupper`、`tolower`、`widen`、`narrow` 五个原语。 @endif
+ * @lang{EN} The CRTP derived class type, which must provide the five primitives: `is`,
+ * `toupper`, `tolower`, `widen`, and `narrow`. @endif
+ */
 template <typename Derived>
 class ctype_ops
 {
+    /** @lang{ZH} 返回对 CRTP 派生类实例的常量引用。 @endif
+     *  @lang{EN} Returns a const reference to the CRTP derived class instance. @endif */
     const Derived& self() const { return static_cast<const Derived&>(*this); }
 
 public:
+    /**
+     * @lang{ZH}
+     * 测试字符 `c` 是否具有掩码 `m` 中的任意分类属性。
+     * @endif
+     *
+     * @lang{EN}
+     * Tests whether character `c` has any of the classification properties in mask `m`.
+     * @endif
+     *
+     * @param m
+     * @lang{ZH} 要检测的分类属性位掩码。 @endif
+     * @lang{EN} The classification property bitmask to test against. @endif
+     *
+     * @param c
+     * @lang{ZH} 待检测的字符。 @endif
+     * @lang{EN} The character to test. @endif
+     *
+     * @return
+     * @lang{ZH} 若 `c` 具有 `m` 中至少一个分类属性则返回 `true`；否则返回 `false`。 @endif
+     * @lang{EN} `true` if `c` has at least one of the classification properties in `m`;
+     * `false` otherwise. @endif
+     */
     template <typename TM, typename TC>
         requires std::convertible_to<TM, typename Derived::mask> &&
                  std::convertible_to<TC, typename Derived::char_type>
@@ -50,6 +146,31 @@ public:
         return self().is(c) & m;
     }
 
+    /**
+     * @lang{ZH}
+     * 对范围 `[low, high)` 内的每个字符调用 `is()`，将结果依次写入 `vec`。
+     * @endif
+     *
+     * @lang{EN}
+     * Calls `is()` on each character in `[low, high)` and writes the results to `vec`.
+     * @endif
+     *
+     * @param low
+     * @lang{ZH} 输入范围的起始迭代器。 @endif
+     * @lang{EN} Start iterator of the input range. @endif
+     *
+     * @param high
+     * @lang{ZH} 输入范围的末尾迭代器（独占上界）。 @endif
+     * @lang{EN} End iterator of the input range (exclusive). @endif
+     *
+     * @param vec
+     * @lang{ZH} 接收分类掩码结果的输出迭代器。 @endif
+     * @lang{EN} Output iterator to receive the classification mask results. @endif
+     *
+     * @return
+     * @lang{ZH} 写入最后一个元素之后的输出迭代器位置。 @endif
+     * @lang{EN} Output iterator pointing one past the last element written. @endif
+     */
     template <typename InIt, typename OutIt>
     OutIt is_seq(InIt low, InIt high, OutIt vec) const
     {
@@ -58,6 +179,33 @@ public:
         return vec;
     }
 
+    /**
+     * @lang{ZH}
+     * 在范围 `[beg, end)` 中前向扫描，返回第一个具有掩码 `m` 中任意属性的字符位置。
+     * 若无此字符则返回 `end`。
+     * @endif
+     *
+     * @lang{EN}
+     * Scans forward in `[beg, end)` and returns the first iterator whose character
+     * has any of the properties in mask `m`. Returns `end` if no such character exists.
+     * @endif
+     *
+     * @param m
+     * @lang{ZH} 要搜索的分类属性位掩码。 @endif
+     * @lang{EN} The classification property bitmask to search for. @endif
+     *
+     * @param beg
+     * @lang{ZH} 扫描范围的起始迭代器。 @endif
+     * @lang{EN} Start iterator of the scan range. @endif
+     *
+     * @param end
+     * @lang{ZH} 扫描范围的末尾迭代器（独占上界）。 @endif
+     * @lang{EN} End iterator of the scan range (exclusive). @endif
+     *
+     * @return
+     * @lang{ZH} 第一个具有 `m` 中任意属性的字符所在的迭代器；若不存在则返回 `end`。 @endif
+     * @lang{EN} Iterator to the first character with any property in `m`; `end` if none. @endif
+     */
     template <typename TM, typename InIt>
         requires std::convertible_to<TM, typename Derived::mask>
     InIt scan_is_any(TM m, InIt beg, InIt end) const
@@ -67,6 +215,34 @@ public:
         return beg;
     }
 
+    /**
+     * @lang{ZH}
+     * 在范围 `[beg, end)` 中前向扫描，返回第一个**不**具有掩码 `m` 中任意属性的字符位置。
+     * 若所有字符均具有 `m` 中至少一个属性则返回 `end`。
+     * @endif
+     *
+     * @lang{EN}
+     * Scans forward in `[beg, end)` and returns the first iterator whose character has
+     * **none** of the properties in mask `m`. Returns `end` if every character has at
+     * least one property in `m`.
+     * @endif
+     *
+     * @param m
+     * @lang{ZH} 要跳过的分类属性位掩码。 @endif
+     * @lang{EN} The classification property bitmask to skip over. @endif
+     *
+     * @param beg
+     * @lang{ZH} 扫描范围的起始迭代器。 @endif
+     * @lang{EN} Start iterator of the scan range. @endif
+     *
+     * @param end
+     * @lang{ZH} 扫描范围的末尾迭代器（独占上界）。 @endif
+     * @lang{EN} End iterator of the scan range (exclusive). @endif
+     *
+     * @return
+     * @lang{ZH} 第一个不具有 `m` 中任意属性的字符所在的迭代器；若不存在则返回 `end`。 @endif
+     * @lang{EN} Iterator to the first character with no property in `m`; `end` if none. @endif
+     */
     template <typename TM, typename InIt>
         requires std::convertible_to<TM, typename Derived::mask>
     InIt scan_not_any(TM m, InIt beg, InIt end) const
@@ -76,6 +252,31 @@ public:
         return beg;
     }
 
+    /**
+     * @lang{ZH}
+     * 对范围 `[beg, end)` 内的每个字符调用 `toupper()`，将结果依次写入 `dst`。
+     * @endif
+     *
+     * @lang{EN}
+     * Calls `toupper()` on each character in `[beg, end)` and writes the results to `dst`.
+     * @endif
+     *
+     * @param beg
+     * @lang{ZH} 输入范围的起始迭代器。 @endif
+     * @lang{EN} Start iterator of the input range. @endif
+     *
+     * @param end
+     * @lang{ZH} 输入范围的末尾迭代器（独占上界）。 @endif
+     * @lang{EN} End iterator of the input range (exclusive). @endif
+     *
+     * @param dst
+     * @lang{ZH} 接收大写转换结果的输出迭代器。 @endif
+     * @lang{EN} Output iterator to receive the uppercase results. @endif
+     *
+     * @return
+     * @lang{ZH} 写入最后一个元素之后的输出迭代器位置。 @endif
+     * @lang{EN} Output iterator pointing one past the last element written. @endif
+     */
     template <typename InIt, typename OutIt>
     OutIt toupper_seq(InIt beg, InIt end, OutIt dst) const
     {
@@ -84,6 +285,31 @@ public:
         return dst;
     }
 
+    /**
+     * @lang{ZH}
+     * 对范围 `[beg, end)` 内的每个字符调用 `tolower()`，将结果依次写入 `dst`。
+     * @endif
+     *
+     * @lang{EN}
+     * Calls `tolower()` on each character in `[beg, end)` and writes the results to `dst`.
+     * @endif
+     *
+     * @param beg
+     * @lang{ZH} 输入范围的起始迭代器。 @endif
+     * @lang{EN} Start iterator of the input range. @endif
+     *
+     * @param end
+     * @lang{ZH} 输入范围的末尾迭代器（独占上界）。 @endif
+     * @lang{EN} End iterator of the input range (exclusive). @endif
+     *
+     * @param dst
+     * @lang{ZH} 接收小写转换结果的输出迭代器。 @endif
+     * @lang{EN} Output iterator to receive the lowercase results. @endif
+     *
+     * @return
+     * @lang{ZH} 写入最后一个元素之后的输出迭代器位置。 @endif
+     * @lang{EN} Output iterator pointing one past the last element written. @endif
+     */
     template <typename InIt, typename OutIt>
     OutIt tolower_seq(InIt beg, InIt end, OutIt dst) const
     {
@@ -92,6 +318,32 @@ public:
         return dst;
     }
 
+    /**
+     * @lang{ZH}
+     * 对范围 `[beg, end)` 内的每个窄字符调用 `widen()`，将结果依次写入 `dst`。
+     * @endif
+     *
+     * @lang{EN}
+     * Calls `widen()` on each narrow character in `[beg, end)` and writes the results
+     * to `dst`.
+     * @endif
+     *
+     * @param beg
+     * @lang{ZH} 输入范围的起始迭代器。 @endif
+     * @lang{EN} Start iterator of the input range. @endif
+     *
+     * @param end
+     * @lang{ZH} 输入范围的末尾迭代器（独占上界）。 @endif
+     * @lang{EN} End iterator of the input range (exclusive). @endif
+     *
+     * @param dst
+     * @lang{ZH} 接收拓宽结果的输出迭代器。 @endif
+     * @lang{EN} Output iterator to receive the widened results. @endif
+     *
+     * @return
+     * @lang{ZH} 写入最后一个元素之后的输出迭代器位置。 @endif
+     * @lang{EN} Output iterator pointing one past the last element written. @endif
+     */
     template <typename InIt, typename OutIt>
     OutIt widen_seq(InIt beg, InIt end, OutIt dst) const
     {
@@ -100,17 +352,44 @@ public:
         return dst;
     }
 
-    // narrow(c) with a caller-supplied fallback for characters that have no
-    // single-byte representation in the target locale.
-    //
-    // @pre `def` is returned verbatim when `self().narrow(c)` yields no value;
-    //      this function does NOT validate that `def` is itself representable
-    //      in the target locale. By convention (matching std::ctype::narrow)
-    //      callers should pass a member of the basic source character set --
-    //      typically a printable ASCII byte such as '?' -- so the fallback is
-    //      meaningful in any encoding. Passing an arbitrary byte (e.g. '\xFF')
-    //      is accepted silently and may yield output that is not a valid
-    //      standalone character in the locale's encoding.
+    /**
+     * @lang{ZH}
+     * 将字符 `c` 窄化为 `char`，若无对应单字节表示则返回回退字符 `def`。
+     *
+     * @par `def` 前置条件
+     * 当 `self().narrow(c)` 不返回值时，`def` 原样返回；本函数**不**验证 `def` 在目标
+     * locale 中是否可表示。按照惯例（与 `std::ctype::narrow` 一致），调用方应传入基本源
+     * 字符集中的成员——通常是可打印的 ASCII 字节，如 `'?'`——以确保回退字符在任何编码
+     * 下均有意义。传入任意字节（如 `'\xFF'`）会被静默接受，但可能产生在 locale 编码中
+     * 不是合法独立字符的输出。
+     * @endif
+     *
+     * @lang{EN}
+     * Narrows character `c` to `char`, returning the fallback character `def` if no
+     * single-byte representation exists.
+     *
+     * @par `def` precondition
+     * `def` is returned verbatim when `self().narrow(c)` yields no value; this function
+     * does NOT validate that `def` is itself representable in the target locale. By
+     * convention (matching `std::ctype::narrow`) callers should pass a member of the
+     * basic source character set — typically a printable ASCII byte such as `'?'` —
+     * so the fallback is meaningful in any encoding. Passing an arbitrary byte (e.g.
+     * `'\xFF'`) is accepted silently and may yield output that is not a valid standalone
+     * character in the locale's encoding.
+     * @endif
+     *
+     * @param c
+     * @lang{ZH} 待窄化的字符。 @endif
+     * @lang{EN} The character to narrow. @endif
+     *
+     * @param def
+     * @lang{ZH} 当 `c` 无对应单字节表示时返回的回退字符。 @endif
+     * @lang{EN} The fallback character returned when `c` has no single-byte representation. @endif
+     *
+     * @return
+     * @lang{ZH} `c` 的单字节窄化结果；若无对应表示则返回 `def`。 @endif
+     * @lang{EN} The single-byte narrowed result for `c`; `def` if no representation exists. @endif
+     */
     template <typename TC>
         requires std::convertible_to<TC, typename Derived::char_type>
     char narrow(TC c, char def) const
@@ -119,6 +398,36 @@ public:
         return res ? *res : def;
     }
 
+    /**
+     * @lang{ZH}
+     * 对范围 `[beg, end)` 内的每个字符调用 `narrow(c, dflt)`，将结果依次写入 `dst`。
+     * @endif
+     *
+     * @lang{EN}
+     * Calls `narrow(c, dflt)` on each character in `[beg, end)` and writes the results
+     * to `dst`.
+     * @endif
+     *
+     * @param beg
+     * @lang{ZH} 输入范围的起始迭代器。 @endif
+     * @lang{EN} Start iterator of the input range. @endif
+     *
+     * @param end
+     * @lang{ZH} 输入范围的末尾迭代器（独占上界）。 @endif
+     * @lang{EN} End iterator of the input range (exclusive). @endif
+     *
+     * @param dflt
+     * @lang{ZH} 无对应单字节表示时使用的回退字符。 @endif
+     * @lang{EN} The fallback character to use when no single-byte representation exists. @endif
+     *
+     * @param dst
+     * @lang{ZH} 接收窄化结果的输出迭代器。 @endif
+     * @lang{EN} Output iterator to receive the narrowed results. @endif
+     *
+     * @return
+     * @lang{ZH} 写入最后一个元素之后的输出迭代器位置。 @endif
+     * @lang{EN} Output iterator pointing one past the last element written. @endif
+     */
     template <typename InIt, typename OutIt>
     OutIt narrow_seq(InIt beg, InIt end, char dflt, OutIt dst) const
     {
@@ -129,22 +438,46 @@ public:
 };
 } // namespace detail
 
-// Specialisation for single-byte character types (char, char8_t). The full
-// [0, s_len) input space is enumerable at construction, so this specialisation
-// materialises every primitive (is/toupper/tolower/widen/narrow) into a
-// snapshot table and discards the source ctype_conf<CharT> pointer afterwards.
-// All later lookups are pure array reads with no virtual dispatch and no
-// shared_ptr indirection.
-//
-// Asymmetry with the sizeof(CharT) > 1 specialisation: that one retains m_obj
-// because its input space is too large to enumerate, and forwards out-of-table
-// values to the conf at call time. As a consequence, runtime mutations to a
-// user-derived ctype_conf<CharT>'s is/toupper/tolower/widen/narrow take effect
-// for the size > 1 path (on the out-of-table branch) but NOT for the size == 1
-// path: this specialisation captures a one-shot snapshot at construction and
-// never re-queries the conf. Callers who need dynamically-changing single-byte
-// behaviour should either rebuild a new ctype<CharT> after each change, or
-// supply a custom ctype<CharT> that does not snapshot.
+/**
+ * @lang{ZH}
+ * 单字节字符类型（`char`、`char8_t`）的 `ctype` facet 特化。
+ *
+ * 输入空间 `[0, s_len)` 在构造时完全可枚举，因此本特化将所有五张原语表（`is`/`toupper`/
+ * `tolower`/`widen`/`narrow`）一次性快照到平坦数组中，之后丢弃 `ctype_conf<CharT>`
+ * 指针。所有后续查询均为零虚调用、零 `shared_ptr` 间接的 O(1) 数组读取。
+ *
+ * @par 与 `sizeof(CharT) > 1` 特化的不对称性
+ * `sizeof > 1` 特化保留 `m_obj` 指针，因为其输入空间过大无法枚举，对超出表范围的值
+ * 在调用时转发给 conf。因此，对用户派生的 `ctype_conf<CharT>` 中 `is`/`toupper`/
+ * `tolower`/`widen`/`narrow` 的运行时修改，在 `sizeof > 1` 路径（超出表范围的分支）
+ * 上会即时生效，但在本特化上**不会**生效：本特化在构造时捕获了一次性快照，之后永远
+ * 不再查询 conf。需要动态变化单字节行为的调用方应在每次修改后重建一个新的 `ctype<CharT>`，
+ * 或提供一个不做快照的自定义 `ctype<CharT>`。
+ *
+ * @tparam CharT
+ * @lang{ZH} 单字节字符类型，须满足 `sizeof(CharT) == 1`。 @endif
+ * @lang{EN} The single-byte character type; must satisfy `sizeof(CharT) == 1`. @endif
+ *
+ * @lang{EN}
+ * `ctype` facet specialization for single-byte character types (`char`, `char8_t`).
+ *
+ * The full `[0, s_len)` input space is enumerable at construction, so this
+ * specialization materializes all five primitive tables (`is`/`toupper`/`tolower`/
+ * `widen`/`narrow`) into a one-shot snapshot and discards the `ctype_conf<CharT>`
+ * pointer afterwards. All later lookups are pure O(1) array reads with no virtual
+ * dispatch and no `shared_ptr` indirection.
+ *
+ * @par Asymmetry with the `sizeof(CharT) > 1` specialization
+ * The `sizeof > 1` specialization retains `m_obj` because its input space is too large
+ * to enumerate and forwards out-of-table values to the conf at call time. As a
+ * consequence, runtime mutations to a user-derived `ctype_conf<CharT>`'s `is`/`toupper`/
+ * `tolower`/`widen`/`narrow` take effect for the `sizeof > 1` path (on the out-of-table
+ * branch) but NOT for this specialization: it captures a one-shot snapshot at
+ * construction and never re-queries the conf. Callers who need dynamically-changing
+ * single-byte behaviour should either rebuild a new `ctype<CharT>` after each change,
+ * or supply a custom `ctype<CharT>` that does not snapshot.
+ * @endif
+ */
 template <typename CharT>
     requires (sizeof(CharT) == 1)
 class ctype<CharT> : public detail::ctype_ops<ctype<CharT>>
@@ -154,14 +487,46 @@ class ctype<CharT> : public detail::ctype_ops<ctype<CharT>>
     // hard-coded 256. The CHAR_BIT == 8 assumption is enforced by a
     // static_assert in ctype_details.h, so on every supported platform
     // s_len == 256.
+    /** @lang{ZH} 查找表的元素数量，等于 `unsigned char` 可表示的不同值的个数（所有支持平台上均为 256）。 @endif
+     *  @lang{EN} Number of entries in each lookup table, equal to the number of distinct
+     *  values representable by `unsigned char` (256 on all supported platforms). @endif */
     constexpr static unsigned s_len = std::numeric_limits<unsigned char>::max() + 1;
 
 public:
+    /** @lang{ZH} locale 批量 facet 构造机制所用的构造规则，指定构造本 facet 所需的 `ctype_conf<CharT>`。 @endif
+     *  @lang{EN} Construction rule for the locale's batch facet-construction mechanism,
+     *  specifying that `ctype_conf<CharT>` is needed to construct this facet. @endif */
     using create_rules = facet_create_rule<ctype_conf<CharT>>;
 
+    /** @lang{ZH} 此 facet 操作的字符类型。 @endif
+     *  @lang{EN} The character type operated on by this facet. @endif */
     using char_type = CharT;
+
+    /** @lang{ZH} 字符分类属性的位掩码类型，与 `base_ft<ctype>::mask` 一致。 @endif
+     *  @lang{EN} Bitmask type for character-classification properties, consistent with
+     *  `base_ft<ctype>::mask`. @endif */
     using mask = typename ctype_conf<CharT>::mask;
 
+    /**
+     * @lang{ZH}
+     * 构造函数。从 `p_obj` 提供的 `ctype_conf<CharT>` 实例为全部 256 个字节值预建
+     * 五张快照表，之后不再持有 `p_obj`。
+     * @endif
+     *
+     * @lang{EN}
+     * Constructor. Builds five snapshot tables for all 256 byte values from the
+     * `ctype_conf<CharT>` instance provided by `p_obj`; the pointer is not retained
+     * afterwards.
+     * @endif
+     *
+     * @param p_obj
+     * @lang{ZH} 指向 `ctype_conf<CharT>` 实例的共享指针，不得为空。 @endif
+     * @lang{EN} Shared pointer to the `ctype_conf<CharT>` instance; must not be empty. @endif
+     *
+     * @throws std::runtime_error
+     * @lang{ZH} 若 `p_obj` 为空指针。 @endif
+     * @lang{EN} If `p_obj` is an empty pointer. @endif
+     */
     template <shared_ptr_to<ctype_conf<CharT>> TConfPtr>
     ctype(TConfPtr p_obj)
     {
@@ -183,26 +548,91 @@ public:
     ctype& operator=(ctype&&) = delete;
 
 public:
+    /**
+     * @lang{ZH}
+     * 返回字符 `c` 的分类掩码（O(1) 快照表查询）。
+     * @endif
+     *
+     * @lang{EN}
+     * Returns the classification mask for character `c` (O(1) snapshot table lookup).
+     * @endif
+     *
+     * @param c @lang{ZH} 待分类的字符。 @endif @lang{EN} The character to classify. @endif
+     * @return @lang{ZH} `c` 的分类掩码。 @endif @lang{EN} The classification mask for `c`. @endif
+     */
     mask is(CharT c) const
     {
         return m_table[static_cast<unsigned char>(c)];
     }
 
+    /**
+     * @lang{ZH}
+     * 返回字符 `c` 的大写形式（O(1) 快照表查询）。
+     * @endif
+     *
+     * @lang{EN}
+     * Returns the uppercase form of character `c` (O(1) snapshot table lookup).
+     * @endif
+     *
+     * @param c @lang{ZH} 待转换的字符。 @endif @lang{EN} The character to convert. @endif
+     * @return @lang{ZH} `c` 的大写形式。 @endif @lang{EN} The uppercase form of `c`. @endif
+     */
     CharT toupper(CharT c) const
     {
         return m_toupper[static_cast<unsigned char>(c)];
     }
 
+    /**
+     * @lang{ZH}
+     * 返回字符 `c` 的小写形式（O(1) 快照表查询）。
+     * @endif
+     *
+     * @lang{EN}
+     * Returns the lowercase form of character `c` (O(1) snapshot table lookup).
+     * @endif
+     *
+     * @param c @lang{ZH} 待转换的字符。 @endif @lang{EN} The character to convert. @endif
+     * @return @lang{ZH} `c` 的小写形式。 @endif @lang{EN} The lowercase form of `c`. @endif
+     */
     CharT tolower(CharT c) const
     {
         return m_tolower[static_cast<unsigned char>(c)];
     }
 
+    /**
+     * @lang{ZH}
+     * 将窄字符 `c` 拓宽为 `CharT`（O(1) 快照表查询）。
+     * @endif
+     *
+     * @lang{EN}
+     * Widens the narrow character `c` to `CharT` (O(1) snapshot table lookup).
+     * @endif
+     *
+     * @param c @lang{ZH} 待拓宽的窄字符。 @endif @lang{EN} The narrow character to widen. @endif
+     * @return @lang{ZH} `c` 对应的 `CharT` 值。 @endif @lang{EN} The `CharT` value corresponding to `c`. @endif
+     */
     CharT widen(char c) const
     {
         return m_widen[static_cast<unsigned char>(c)];
     }
 
+    /**
+     * @lang{ZH}
+     * 将字符 `c` 窄化为 `char`（O(1) 快照表查询）。
+     * 若构造时 `ctype_conf<CharT>::narrow` 对该值返回 `nullopt`，则此处同样返回 `nullopt`。
+     * @endif
+     *
+     * @lang{EN}
+     * Narrows character `c` to `char` (O(1) snapshot table lookup).
+     * Returns `nullopt` if `ctype_conf<CharT>::narrow` returned `nullopt` for this
+     * value at construction time.
+     * @endif
+     *
+     * @param c @lang{ZH} 待窄化的字符。 @endif @lang{EN} The character to narrow. @endif
+     * @return @lang{ZH} 包含窄化结果的 `std::optional<char>`；若无对应表示则为 `nullopt`。 @endif
+     * @lang{EN} A `std::optional<char>` with the narrowed result; `nullopt` if no
+     * single-byte representation exists. @endif
+     */
     std::optional<char> narrow(CharT c) const
     {
         return m_narrow[static_cast<unsigned char>(c)];
@@ -211,38 +641,82 @@ public:
     using detail::ctype_ops<ctype<CharT>>::narrow;
 
 private:
+    /** @lang{ZH} 分类掩码快照表，索引为 `unsigned char` 值。 @endif
+     *  @lang{EN} Classification mask snapshot table, indexed by `unsigned char` value. @endif */
     std::array<mask, s_len>                m_table;
+
+    /** @lang{ZH} 大写映射快照表，索引为 `unsigned char` 值。 @endif
+     *  @lang{EN} Uppercase mapping snapshot table, indexed by `unsigned char` value. @endif */
     std::array<CharT, s_len>               m_toupper;
+
+    /** @lang{ZH} 小写映射快照表，索引为 `unsigned char` 值。 @endif
+     *  @lang{EN} Lowercase mapping snapshot table, indexed by `unsigned char` value. @endif */
     std::array<CharT, s_len>               m_tolower;
+
+    /** @lang{ZH} 拓宽映射快照表，索引为 `unsigned char` 值。 @endif
+     *  @lang{EN} Widen mapping snapshot table, indexed by `unsigned char` value. @endif */
     std::array<CharT, s_len>               m_widen;
+
+    /** @lang{ZH} 窄化映射快照表，索引为 `unsigned char` 值；元素可为 `nullopt`。 @endif
+     *  @lang{EN} Narrow mapping snapshot table, indexed by `unsigned char` value;
+     *  elements may be `nullopt`. @endif */
     std::array<std::optional<char>, s_len> m_narrow;
 };
 
-// Specialisation for multi-byte character types (wchar_t, char32_t). Values in
-// [0, s_len) are served from precomputed lock-free tables; values beyond that
-// are forwarded directly to the underlying ctype_conf<CharT> on each call, with
-// no cache and no lock (see do_is() for the rationale).
-//
-// Thread-safety contract: because the out-of-table path calls the conf
-// concurrently, ctype_conf<CharT>'s const methods must be safe for concurrent
-// invocation. The default implementation is: its members are immutable after
-// construction, is/toupper/tolower use the *_l locale functions (which take an
-// explicit, immutable locale_t), and narrow() switches only the calling
-// thread's locale via a per-thread uselocale guard. A user-supplied override of
-// ctype_conf<CharT> must preserve this property.
-//
-// Self-consistency contract for user overrides: values inside [0, s_len) are
-// served from the snapshot tables built at construction, while values outside
-// that range go through virtual dispatch to the conf on every call. A
-// user-derived ctype_conf<CharT> whose is(), toupper(), and tolower() are not
-// internally consistent -- for example, `is(c) & upper` returning true while
-// `toupper(c) == c`, or returning a mask that disagrees with what the
-// case-conversion methods imply -- will exhibit "torn" behaviour: the
-// inconsistency is frozen into the in-range tables at construction but is
-// re-observed live for every out-of-range character. Overrides must be
-// self-consistent across is/toupper/tolower (and across is/widen/narrow where
-// the semantics demand it) so that the same character produces the same
-// answer regardless of which branch served it.
+/**
+ * @lang{ZH}
+ * 多字节字符类型（`wchar_t`、`char32_t`）的 `ctype` facet 特化。
+ *
+ * 对 `[0, s_len)` 区间内的值，从构造时预建的无锁快照表查询；对超出该区间的值，
+ * 在每次调用时直接转发到底层 `ctype_conf<CharT>`，无缓存、无锁。
+ *
+ * @par 线程安全契约
+ * 由于超出表范围的路径会并发调用 conf，`ctype_conf<CharT>` 的 `const` 方法须对并发
+ * 调用安全。默认实现满足此要求：成员在构造后不可变；`is`/`toupper`/`tolower` 使用显式
+ * 传入不可变 `locale_t` 的 `*_l` 函数；`narrow()` 仅通过每线程 `uselocale` 守卫切换
+ * 调用线程的 locale。用户提供的 `ctype_conf<CharT>` 重写须保持此属性。
+ *
+ * @par 用户重写的自洽性契约
+ * `[0, s_len)` 区间内的值由构造时建立的快照表提供，区间外的值则在每次调用时经由虚调用
+ * 转发到 conf。若用户派生的 `ctype_conf<CharT>` 中 `is()`、`toupper()`、`tolower()`
+ * 之间不自洽（例如 `is(c) & upper` 为 `true` 而 `toupper(c) == c`，或返回与大小写转换
+ * 结果相矛盾的掩码），将出现"撕裂"行为：区间内字符使用构造时冻结的快照，区间外字符使用
+ * 每次调用时的实时结果。重写须在 `is`/`toupper`/`tolower`（以及在语义上要求的
+ * `is`/`widen`/`narrow`）之间保持自洽，以确保无论经由哪条分支服务，同一字符都产生
+ * 相同的结果。
+ *
+ * @tparam CharT
+ * @lang{ZH} 多字节字符类型，须满足 `sizeof(CharT) > 1`。 @endif
+ * @lang{EN} The multi-byte character type; must satisfy `sizeof(CharT) > 1`. @endif
+ *
+ * @lang{EN}
+ * `ctype` facet specialization for multi-byte character types (`wchar_t`, `char32_t`).
+ *
+ * Values in `[0, s_len)` are served from precomputed lock-free snapshot tables;
+ * values beyond that range are forwarded directly to the underlying `ctype_conf<CharT>`
+ * on each call, with no cache and no lock.
+ *
+ * @par Thread-safety contract
+ * Because the out-of-table path calls the conf concurrently, `ctype_conf<CharT>`'s
+ * `const` methods must be safe for concurrent invocation. The default implementation
+ * satisfies this: its members are immutable after construction; `is`/`toupper`/`tolower`
+ * use `*_l` locale functions that take an explicit, immutable `locale_t`; and `narrow()`
+ * switches only the calling thread's locale via a per-thread `uselocale` guard.
+ * A user-supplied override of `ctype_conf<CharT>` must preserve this property.
+ *
+ * @par Self-consistency contract for user overrides
+ * Values inside `[0, s_len)` are served from the snapshot tables built at construction,
+ * while values outside that range go through virtual dispatch to the conf on every call.
+ * A user-derived `ctype_conf<CharT>` whose `is()`, `toupper()`, and `tolower()` are not
+ * internally consistent — for example, `is(c) & upper` returning `true` while
+ * `toupper(c) == c`, or returning a mask that disagrees with what the case-conversion
+ * methods imply — will exhibit "torn" behaviour: the inconsistency is frozen into the
+ * in-range tables at construction but is re-observed live for every out-of-range
+ * character. Overrides must be self-consistent across `is`/`toupper`/`tolower` (and
+ * across `is`/`widen`/`narrow` where the semantics demand it) so that the same
+ * character produces the same answer regardless of which branch served it.
+ * @endif
+ */
 template <typename CharT>
     requires (sizeof(CharT) > 1)
 class ctype<CharT> : public detail::ctype_ops<ctype<CharT>>
@@ -250,20 +724,58 @@ class ctype<CharT> : public detail::ctype_ops<ctype<CharT>>
     // See the matching s_len note in the sizeof(CharT)==1 specialization
     // above. Tables span [0, unsigned_char::max()+1) per-byte; CHAR_BIT == 8
     // is enforced by static_assert in ctype_details.h.
+    /** @lang{ZH} 快照表覆盖的值范围大小 `[0, s_len)`，在所有支持平台上均为 256。 @endif
+     *  @lang{EN} Size of the value range `[0, s_len)` covered by the snapshot tables;
+     *  256 on all supported platforms. @endif */
     constexpr static unsigned s_len = std::numeric_limits<unsigned char>::max() + 1;
 
-    // Unsigned counterpart of CharT, used to fold a (possibly signed) CharT
-    // into [0, 2^N) for the table-range check and indexing without sign
-    // extension. make_unsigned_t guarantees the same width as CharT, so no
-    // value is truncated regardless of how wide plain `unsigned` happens to be.
+    /** @lang{ZH}
+     * `CharT` 的无符号对应类型，用于将（可能有符号的）`CharT` 折叠到 `[0, 2^N)` 以进行
+     * 表范围检查和索引，避免符号扩展。`make_unsigned_t` 保证与 `CharT` 等宽，任何值
+     * 均不被截断。
+     * @endif
+     * @lang{EN}
+     * Unsigned counterpart of `CharT`, used to fold a (possibly signed) `CharT` into
+     * `[0, 2^N)` for the table-range check and indexing without sign extension.
+     * `make_unsigned_t` guarantees the same width as `CharT`, so no value is truncated
+     * regardless of how wide plain `unsigned` happens to be.
+     * @endif */
     using uchar_type = std::make_unsigned_t<CharT>;
 
 public:
+    /** @lang{ZH} locale 批量 facet 构造机制所用的构造规则，指定构造本 facet 所需的 `ctype_conf<CharT>`。 @endif
+     *  @lang{EN} Construction rule for the locale's batch facet-construction mechanism,
+     *  specifying that `ctype_conf<CharT>` is needed to construct this facet. @endif */
     using create_rules = facet_create_rule<ctype_conf<CharT>>;
 
+    /** @lang{ZH} 此 facet 操作的字符类型。 @endif
+     *  @lang{EN} The character type operated on by this facet. @endif */
     using char_type = CharT;
+
+    /** @lang{ZH} 字符分类属性的位掩码类型，与 `base_ft<ctype>::mask` 一致。 @endif
+     *  @lang{EN} Bitmask type for character-classification properties, consistent with
+     *  `base_ft<ctype>::mask`. @endif */
     using mask = typename ctype_conf<CharT>::mask;
 
+    /**
+     * @lang{ZH}
+     * 构造函数。保留 `p_obj` 指针，并从中为 `[0, s_len)` 区间的全部值预建五张快照表。
+     * @endif
+     *
+     * @lang{EN}
+     * Constructor. Retains the `p_obj` pointer and builds five snapshot tables for all
+     * values in `[0, s_len)` from it.
+     * @endif
+     *
+     * @param p_obj
+     * @lang{ZH} 指向 `ctype_conf<CharT>` 实例的共享指针，不得为空，且在本对象生命周期内须保持有效。 @endif
+     * @lang{EN} Shared pointer to the `ctype_conf<CharT>` instance; must not be empty
+     * and must remain valid for the lifetime of this object. @endif
+     *
+     * @throws std::runtime_error
+     * @lang{ZH} 若 `p_obj` 为空指针。 @endif
+     * @lang{EN} If `p_obj` is an empty pointer. @endif
+     */
     template <shared_ptr_to<ctype_conf<CharT>> TConfPtr>
     ctype(TConfPtr p_obj)
         : m_obj(p_obj)
@@ -286,41 +798,117 @@ public:
     ctype& operator=(ctype&&) = delete;
 
 public:
+    /**
+     * @lang{ZH}
+     * 返回字符 `c` 的分类掩码。区间内查快照表，区间外转发至 conf。
+     * @endif
+     *
+     * @lang{EN}
+     * Returns the classification mask for character `c`. Serves from the snapshot
+     * table for in-range values; forwards to the conf for out-of-range values.
+     * @endif
+     *
+     * @param c @lang{ZH} 待分类的字符。 @endif @lang{EN} The character to classify. @endif
+     * @return @lang{ZH} `c` 的分类掩码。 @endif @lang{EN} The classification mask for `c`. @endif
+     */
     mask is(CharT c) const
     {
         return do_is(c);
     }
 
+    /**
+     * @lang{ZH}
+     * 返回字符 `c` 的大写形式。区间内查快照表，区间外转发至 conf。
+     * @endif
+     *
+     * @lang{EN}
+     * Returns the uppercase form of character `c`. Serves from the snapshot table
+     * for in-range values; forwards to the conf for out-of-range values.
+     * @endif
+     *
+     * @param c @lang{ZH} 待转换的字符。 @endif @lang{EN} The character to convert. @endif
+     * @return @lang{ZH} `c` 的大写形式。 @endif @lang{EN} The uppercase form of `c`. @endif
+     */
     CharT toupper(CharT c) const
     {
         return do_toupper(c);
     }
 
+    /**
+     * @lang{ZH}
+     * 返回字符 `c` 的小写形式。区间内查快照表，区间外转发至 conf。
+     * @endif
+     *
+     * @lang{EN}
+     * Returns the lowercase form of character `c`. Serves from the snapshot table
+     * for in-range values; forwards to the conf for out-of-range values.
+     * @endif
+     *
+     * @param c @lang{ZH} 待转换的字符。 @endif @lang{EN} The character to convert. @endif
+     * @return @lang{ZH} `c` 的小写形式。 @endif @lang{EN} The lowercase form of `c`. @endif
+     */
     CharT tolower(CharT c) const
     {
         return do_tolower(c);
     }
 
-    // Default behaviour (inherited from ctype_conf<CharT>::widen at
-    // construction time): matches std::ctype<wchar_t>::widen() semantics
-    // -- only guaranteed to be correct for the basic source character
-    // set. For multi-byte locales (e.g. UTF-8), high bytes are not
-    // standalone characters and btowc() returns WEOF for them at
-    // table-build time; the corresponding entries of m_widen hold WEOF
-    // cast to CharT (a sentinel-looking but unspecified value), and
-    // callers must not widen() such bytes under this default. This caveat
-    // also applies to widen_seq() (inherited from detail::ctype_ops).
-    //
-    // This is only the default. A user may derive from ctype_conf<CharT>
-    // and override widen() to supply a different mapping; the lookup
-    // table held here is then rebuilt from that override when the
-    // owning ctype<CharT> is constructed, and the caveat above no
-    // longer applies under that derived behaviour.
+    /**
+     * @lang{ZH}
+     * 将窄字符 `c` 拓宽为 `CharT`（O(1) 快照表查询，覆盖全部 256 个输入值）。
+     *
+     * **默认行为**（继承自构造时的 `ctype_conf<CharT>::widen`）：与 `std::ctype<wchar_t>::widen()`
+     * 语义一致，仅保证对基本源字符集中的字符结果正确。对于多字节 locale（如 UTF-8），
+     * 高字节不是独立字符，`btowc()` 在建表时对其返回 `WEOF`；`m_widen` 中对应条目存储的是
+     * `WEOF` 强转为 `CharT` 的值（一个看似哨兵但实际未定义含义的值），调用方不得在此默认
+     * 行为下对此类字节调用 `widen()`（`widen_seq()` 同理）。
+     *
+     * 用户可派生 `ctype_conf<CharT>` 并重写 `widen()` 以提供不同的映射；此时此处的快照
+     * 表将在构造时从该重写重建，上述注意事项在该派生行为下不再适用。
+     * @endif
+     *
+     * @lang{EN}
+     * Widens the narrow character `c` to `CharT` (O(1) snapshot table lookup, covering
+     * all 256 input values).
+     *
+     * **Default behaviour** (inherited from `ctype_conf<CharT>::widen` at construction
+     * time): matches `std::ctype<wchar_t>::widen()` semantics — only guaranteed to be
+     * correct for the basic source character set. For multi-byte locales (e.g. UTF-8),
+     * high bytes are not standalone characters and `btowc()` returns `WEOF` for them at
+     * table-build time; the corresponding entries of `m_widen` hold `WEOF` cast to
+     * `CharT` (a sentinel-looking but unspecified value), and callers must not call
+     * `widen()` on such bytes under this default. This caveat also applies to
+     * `widen_seq()` (inherited from `detail::ctype_ops`).
+     *
+     * A user may derive from `ctype_conf<CharT>` and override `widen()` to supply a
+     * different mapping; the lookup table held here is then rebuilt from that override
+     * when the owning `ctype<CharT>` is constructed, and the caveat above no longer
+     * applies under that derived behaviour.
+     * @endif
+     *
+     * @param c @lang{ZH} 待拓宽的窄字符。 @endif @lang{EN} The narrow character to widen. @endif
+     * @return @lang{ZH} `c` 对应的 `CharT` 值。 @endif
+     * @lang{EN} The `CharT` value corresponding to `c`. @endif
+     */
     CharT widen(char c) const
     {
         return m_widen[static_cast<unsigned char>(c)];
     }
 
+    /**
+     * @lang{ZH}
+     * 将字符 `c` 窄化为 `char`。区间内查快照表，区间外转发至 conf。
+     * @endif
+     *
+     * @lang{EN}
+     * Narrows character `c` to `char`. Serves from the snapshot table for in-range
+     * values; forwards to the conf for out-of-range values.
+     * @endif
+     *
+     * @param c @lang{ZH} 待窄化的字符。 @endif @lang{EN} The character to narrow. @endif
+     * @return @lang{ZH} 包含窄化结果的 `std::optional<char>`；若无对应单字节表示则为 `nullopt`。 @endif
+     * @lang{EN} A `std::optional<char>` with the narrowed result; `nullopt` if no
+     * single-byte representation exists. @endif
+     */
     std::optional<char> narrow(CharT c) const
     {
         return do_narrow(c);
@@ -329,17 +917,30 @@ public:
     using detail::ctype_ops<ctype<CharT>>::narrow;
 
 private:
-    // For values inside the precomputed [0, s_len) range, answer from the
-    // lock-free table; otherwise defer straight to the (immutable) conf.
-    //
-    // There used to be a per-character locked LRU cache on this slow path; it
-    // was removed. Benchmarks showed it to be a net loss for this facet's
-    // real workload: large alphabets (e.g. CJK) overflow any bounded cache and
-    // thrash, so the lookup recomputes anyway while also paying the cache and
-    // mutex overhead; and a single mutex serialises the threads that may share
-    // one facet. Calling the conf directly is faster there and lock-free, so
-    // it scales with thread count. (It loses to a cache only for a tiny,
-    // highly repetitive working set -- not the case here.)
+    /**
+     * @lang{ZH}
+     * `is` 的内部实现：区间内查无锁快照表，区间外直接转发至（不可变的）conf。
+     *
+     * @note 此处曾有一个按字符加锁的 LRU 缓存用于慢路径，已移除。基准测试表明对本
+     * facet 的实际工作负载而言是净亏损：大字母表（如 CJK）会溢出任何有界缓存并导致
+     * 缓存抖动，查询依然重新计算，同时还要承担缓存和互斥锁的开销；而单个互斥锁会串行化
+     * 可能共享同一 facet 的多个线程。直接调用 conf 在该场景下更快且无锁，随线程数线性
+     * 扩展。（仅对极小、高度重复的工作集，缓存才有优势——本 facet 的实际场景并非如此。）
+     * @endif
+     *
+     * @lang{EN}
+     * Internal implementation of `is`: serves from the lock-free snapshot table for
+     * in-range values; defers straight to the (immutable) conf for out-of-range values.
+     *
+     * @note There used to be a per-character locked LRU cache on this slow path; it
+     * was removed. Benchmarks showed it to be a net loss for this facet's real workload:
+     * large alphabets (e.g. CJK) overflow any bounded cache and thrash, so the lookup
+     * recomputes anyway while also paying the cache and mutex overhead; and a single
+     * mutex serialises the threads that may share one facet. Calling the conf directly
+     * is faster there and lock-free, so it scales with thread count. (It loses to a
+     * cache only for a tiny, highly repetitive working set — not the case here.)
+     * @endif
+     */
     mask do_is(CharT c) const
     {
         if (static_cast<uchar_type>(c) < s_len)
@@ -347,6 +948,16 @@ private:
         return m_obj->is(c);
     }
 
+    /**
+     * @lang{ZH}
+     * `toupper` 的内部实现：区间内查快照表，区间外转发至 conf。
+     * @endif
+     *
+     * @lang{EN}
+     * Internal implementation of `toupper`: serves from the snapshot table for
+     * in-range values; forwards to the conf for out-of-range values.
+     * @endif
+     */
     CharT do_toupper(CharT c) const
     {
         if (static_cast<uchar_type>(c) < s_len)
@@ -354,6 +965,16 @@ private:
         return m_obj->toupper(c);
     }
 
+    /**
+     * @lang{ZH}
+     * `tolower` 的内部实现：区间内查快照表，区间外转发至 conf。
+     * @endif
+     *
+     * @lang{EN}
+     * Internal implementation of `tolower`: serves from the snapshot table for
+     * in-range values; forwards to the conf for out-of-range values.
+     * @endif
+     */
     CharT do_tolower(CharT c) const
     {
         if (static_cast<uchar_type>(c) < s_len)
@@ -361,6 +982,16 @@ private:
         return m_obj->tolower(c);
     }
 
+    /**
+     * @lang{ZH}
+     * `narrow` 的内部实现：区间内查快照表，区间外转发至 conf。
+     * @endif
+     *
+     * @lang{EN}
+     * Internal implementation of `narrow`: serves from the snapshot table for
+     * in-range values; forwards to the conf for out-of-range values.
+     * @endif
+     */
     std::optional<char> do_narrow(CharT c) const
     {
         if (static_cast<uchar_type>(c) < s_len)
@@ -369,15 +1000,42 @@ private:
     }
 
 private:
+    /** @lang{ZH} 底层 `ctype_conf<CharT>` 实例的共享指针，供超出快照范围的字符查询使用。 @endif
+     *  @lang{EN} Shared pointer to the underlying `ctype_conf<CharT>` instance, used
+     *  for characters beyond the snapshot range. @endif */
     std::shared_ptr<const ctype_conf<CharT>> m_obj;
 
+    /** @lang{ZH} 大写映射快照表，覆盖 `[0, s_len)` 区间。 @endif
+     *  @lang{EN} Uppercase mapping snapshot table covering `[0, s_len)`. @endif */
     std::array<CharT, s_len>               m_toupper;
+
+    /** @lang{ZH} 小写映射快照表，覆盖 `[0, s_len)` 区间。 @endif
+     *  @lang{EN} Lowercase mapping snapshot table covering `[0, s_len)`. @endif */
     std::array<CharT, s_len>               m_tolower;
+
+    /** @lang{ZH} 拓宽映射快照表，覆盖 `[0, s_len)` 区间。 @endif
+     *  @lang{EN} Widen mapping snapshot table covering `[0, s_len)`. @endif */
     std::array<CharT, s_len>               m_widen;
+
+    /** @lang{ZH} 窄化映射快照表，覆盖 `[0, s_len)` 区间；元素可为 `nullopt`。 @endif
+     *  @lang{EN} Narrow mapping snapshot table covering `[0, s_len)`; elements may
+     *  be `nullopt`. @endif */
     std::array<std::optional<char>, s_len> m_narrow;
+
+    /** @lang{ZH} 分类掩码快照表，覆盖 `[0, s_len)` 区间。 @endif
+     *  @lang{EN} Classification mask snapshot table covering `[0, s_len)`. @endif */
     std::array<mask, s_len>                m_table;
 };
 
+/**
+ * @lang{ZH}
+ * CTAD 推导指引：从 `shared_ptr<ctype_conf<CharT>>` 自动推导出 `ctype<CharT>`。
+ * @endif
+ *
+ * @lang{EN}
+ * CTAD deduction guide: deduces `ctype<CharT>` from a `shared_ptr<ctype_conf<CharT>>`.
+ * @endif
+ */
 template<typename TConfPtr>
 ctype(TConfPtr) -> ctype<typename TConfPtr::element_type::char_type>;
 }

--- a/include/facet/ctype_details.h
+++ b/include/facet/ctype_details.h
@@ -1,9 +1,54 @@
+/**
+ * @file ctype_details.h
+ * @lang{ZH}
+ * `ctype` facet 的内部实现细节。
+ *
+ * 本文件提供以下核心组件：
+ * - `base_ft<ctype>`：`ctype` facet 专用的基类特化，定义共享的 `mask` 类型及各字符分类掩码常量。
+ * - `ctype_conf<char>`：`char` 特化，构造时通过 POSIX `*_l` 函数为全部 256 个字节值预建
+ *   查找表，实现 O(1) 的字符分类、大小写转换与宽窄字符映射。
+ * - `ctype_conf<CharT>`（`wchar_t` / `char32_t`）：宽字符特化，构造时初始化 `wctype_t`
+ *   句柄，每次分类调用时通过 `iswctype_l`/`towupper_l`/`towlower_l` 查询 locale；
+ *   `widen` 通过预建的 256 项查找表实现 O(1) 映射。
+ * - `ctype_conf<char8_t>`：UTF-8 代码单元特化，利用 UTF-8 编码的结构保证将
+ *   [0x00, 0x7F] 区间委托给内部 `ctype_conf<char>` 处理，对 [0x80, 0xFF] 区间
+ *   采用保守策略（不分类、不转换大小写、不映射到 `char`）。
+ *
+ * @par 构建要求
+ * 本文件依赖 POSIX.1-2008（需定义 `_POSIX_C_SOURCE >= 200809L` 或 `_GNU_SOURCE`）。
+ * 所用的 `*_l` 字符分类与转换函数（`isupper_l`、`toupper_l`、`wctype_l`、`iswctype_l`、
+ * `towupper_l` 等）是 POSIX 扩展，非标准 C++。构建系统须在包含任何系统头文件前定义
+ * 相应的特性测试宏。
+ * @endif
+ *
+ * @lang{EN}
+ * Internal implementation details for the `ctype` facet.
+ *
+ * This file provides the following core components:
+ * - `base_ft<ctype>`: The `ctype`-specific base class specialization, defining the
+ *   shared `mask` type and character-classification mask constants.
+ * - `ctype_conf<char>`: The `char` specialization; builds precomputed lookup tables
+ *   for all 256 byte values at construction time using POSIX `*_l` functions,
+ *   yielding O(1) classification, case conversion, and widen/narrow operations.
+ * - `ctype_conf<CharT>` (`wchar_t` / `char32_t`): The wide-character specialization;
+ *   initializes `wctype_t` handles at construction time and dispatches each
+ *   classification call through `iswctype_l`/`towupper_l`/`towlower_l`; `widen`
+ *   uses a precomputed 256-entry table for O(1) mapping.
+ * - `ctype_conf<char8_t>`: The UTF-8 code-unit specialization; exploits the structural
+ *   guarantees of UTF-8 to delegate the [0x00, 0x7F] range to an internal
+ *   `ctype_conf<char>` and applies a conservative treatment to [0x80, 0xFF]
+ *   (no classification, no case conversion, no `char` mapping).
+ *
+ * @par Build requirement
+ * This file requires POSIX.1-2008 (`_POSIX_C_SOURCE >= 200809L` or `_GNU_SOURCE`).
+ * The `*_l` character-classification and conversion functions used here
+ * (`isupper_l`, `toupper_l`, `wctype_l`, `iswctype_l`, `towupper_l`, etc.) are
+ * POSIX extensions, not standard C++. The build system must define the appropriate
+ * feature-test macro before any system header is included.
+ * @endif
+ */
+
 #pragma once
-// Requires POSIX.1-2008 (_POSIX_C_SOURCE >= 200809L or _GNU_SOURCE).
-// The *_l character-classification and conversion functions used below
-// (isupper_l, toupper_l, wctype_l, iswctype_l, towupper_l, etc.) are
-// POSIX extensions, not standard C++. The build system must define the
-// appropriate feature-test macro before any system header is included.
 #include <common/clocale_wrapper.h>
 #include <common/defs.h>
 #include <facet/facet_common.h>
@@ -33,8 +78,51 @@ namespace IOv2
 static_assert(CHAR_BIT == 8,
     "facet/ctype tables assume an 8-bit byte; see ctype.h::s_len");
 
+/**
+ * @lang{ZH}
+ * `ctype` facet 模板的前向声明。
+ * @endif
+ *
+ * @lang{EN}
+ * Forward declaration of the `ctype` facet template.
+ * @endif
+ */
 template <typename CharT> class ctype;
 
+/**
+ * @lang{ZH}
+ * `ctype` facet 专用的基类特化。
+ *
+ * 定义所有 `ctype` 特化版本共享的 `mask` 类型及字符分类掩码常量。`mask` 为
+ * `unsigned short` 类型的位域，每一位对应一个字符分类属性。
+ *
+ * @attention 新增原语掩码位时，须同步更新以下四处：
+ * 1. 本类中的常量定义。
+ * 2. `ctype_conf<CharT>` 中对应的私有成员 `m_wmask_<name>`。
+ * 3. `ctype_conf<CharT>` 构造函数中对应的 `wctype_wrapper` 赋值语句。
+ * 4. `ctype_conf<CharT>::is()` 中对应的 `iswctype_l` 检查分支。
+ *
+ * 遗漏第 2 或第 3 步会导致 `wctype_t` 未初始化，在 `iswctype_l` 时引发未定义行为；
+ * 遗漏第 4 步会导致新位从 `is()` 结果中静默丢失。
+ * @endif
+ *
+ * @lang{EN}
+ * `ctype`-specific base class specialization.
+ *
+ * Defines the `mask` type and character-classification mask constants shared by
+ * all `ctype` specializations. `mask` is a bitfield of type `unsigned short`,
+ * where each bit corresponds to one character-classification property.
+ *
+ * @attention When adding a new primitive mask bit, update ALL of the following:
+ * 1. The constant definitions in this class.
+ * 2. The corresponding private member `m_wmask_<name>` in `ctype_conf<CharT>`.
+ * 3. The corresponding `wctype_wrapper` assignment in the `ctype_conf<CharT>` constructor.
+ * 4. The corresponding `iswctype_l` check in `ctype_conf<CharT>::is()`.
+ *
+ * Omitting step 2 or 3 leaves the `wctype_t` uninitialized — undefined behavior at
+ * `iswctype_l`. Omitting step 4 silently drops the new bit from `is()` results.
+ * @endif
+ */
 template <>
 class base_ft<ctype> : public abs_ft
 {
@@ -42,40 +130,104 @@ public:
     using abs_ft::abs_ft;
 
 public:
+    /** @lang{ZH} 字符分类属性的位掩码类型。 @endif
+     *  @lang{EN} Bitmask type for character-classification properties. @endif */
     using mask = unsigned short;
 
-    // Portable fixed mask values (implementation-independent)
-    //
-    // When adding a new primitive mask bit, update ALL of:
-    //   1) the constants below
-    //   2) ctype_conf<CharT>::m_wmask_<name>  (private member)
-    //   3) ctype_conf<CharT> constructor      (wctype_wrapper assignment)
-    //   4) ctype_conf<CharT>::is()            (iswctype_l check)
-    // Missing #2 or #3 leaves the wctype_t uninitialized — UB at iswctype_l.
-    // Missing #4 silently drops the new bit from is() results.
+    /** @lang{ZH} 大写字母（`isupper`）。 @endif
+     *  @lang{EN} Uppercase letter (`isupper`). @endif */
     constexpr static mask upper  = 0x0001;
+
+    /** @lang{ZH} 小写字母（`islower`）。 @endif
+     *  @lang{EN} Lowercase letter (`islower`). @endif */
     constexpr static mask lower  = 0x0002;
+
+    /** @lang{ZH} 字母（`isalpha`）。 @endif
+     *  @lang{EN} Alphabetic character (`isalpha`). @endif */
     constexpr static mask alpha  = 0x0004;
+
+    /** @lang{ZH} 十进制数字（`isdigit`）。 @endif
+     *  @lang{EN} Decimal digit (`isdigit`). @endif */
     constexpr static mask digit  = 0x0008;
+
+    /** @lang{ZH} 十六进制数字（`isxdigit`）。 @endif
+     *  @lang{EN} Hexadecimal digit (`isxdigit`). @endif */
     constexpr static mask xdigit = 0x0010;
+
+    /** @lang{ZH} 空白字符（`isspace`）。 @endif
+     *  @lang{EN} Whitespace character (`isspace`). @endif */
     constexpr static mask space  = 0x0020;
+
+    /** @lang{ZH} 可打印字符（`isprint`）。 @endif
+     *  @lang{EN} Printable character (`isprint`). @endif */
     constexpr static mask print  = 0x0040;
+
+    /** @lang{ZH} 控制字符（`iscntrl`）。 @endif
+     *  @lang{EN} Control character (`iscntrl`). @endif */
     constexpr static mask cntrl  = 0x0080;
+
+    /** @lang{ZH} 标点符号（`ispunct`）。 @endif
+     *  @lang{EN} Punctuation character (`ispunct`). @endif */
     constexpr static mask punct  = 0x0100;
 
+    /** @lang{ZH} 字母或数字（`alpha | digit`）。 @endif
+     *  @lang{EN} Alphanumeric character (`alpha | digit`). @endif */
     constexpr static mask alnum = alpha | digit;
+
+    /** @lang{ZH} 可见字符（`alnum | punct`）。 @endif
+     *  @lang{EN} Visible (graphical) character (`alnum | punct`). @endif */
     constexpr static mask graph = alnum | punct;
 
+    /** @lang{ZH} 所有分类位的并集。 @endif
+     *  @lang{EN} Union of all classification bits. @endif */
     constexpr static mask all = upper | lower | alpha | digit | xdigit |
         space | print | graph | cntrl | punct;
 };
 
 template <typename CharT> class ctype_conf;
 
+/**
+ * @lang{ZH}
+ * `char` 特化的 ctype 配置类。
+ *
+ * 构造时通过 POSIX `*_l` 函数为全部 256 个 `unsigned char` 值预建三张查找表：
+ * `m_table`（分类掩码）、`m_toupper_table`（大写映射）、`m_tolower_table`（小写映射）。
+ * 所有字符操作均为 O(1) 的查表操作。
+ *
+ * `widen` 为恒等映射（`char` 到 `char` 无需转换）；`narrow` 始终成功（`char` 本身即窄字符）。
+ * @endif
+ *
+ * @lang{EN}
+ * `ctype` configuration class specialization for `char`.
+ *
+ * At construction time, three lookup tables are built using POSIX `*_l` functions
+ * for all 256 `unsigned char` values: `m_table` (classification mask),
+ * `m_toupper_table` (uppercase mapping), and `m_tolower_table` (lowercase mapping).
+ * All character operations are O(1) table lookups.
+ *
+ * `widen` is the identity mapping (`char` to `char` requires no conversion);
+ * `narrow` always succeeds (`char` is itself a narrow character).
+ * @endif
+ */
 template <>
 class ctype_conf<char> : public ft_basic<ctype<char>>
 {
 public:
+    /**
+     * @lang{ZH}
+     * 构造函数。通过 POSIX `*_l` 函数为全部 256 个字节值预建分类掩码表、
+     * 大写映射表和小写映射表。
+     * @endif
+     *
+     * @lang{EN}
+     * Constructor. Builds the classification mask table, uppercase mapping table,
+     * and lowercase mapping table for all 256 byte values using POSIX `*_l` functions.
+     * @endif
+     *
+     * @param name
+     * @lang{ZH} 用于查询的 locale 名称。 @endif
+     * @lang{EN} The locale name to use for table construction. @endif
+     */
     ctype_conf(const std::string& name)
         : ft_basic<ctype<char>>()
         , m_inter_locale(name.c_str())
@@ -101,32 +253,172 @@ public:
     }
 
 public:
+    /**
+     * @lang{ZH}
+     * 返回字符 `c` 的分类掩码（O(1) 查表）。
+     * @endif
+     *
+     * @lang{EN}
+     * Returns the classification mask for character `c` (O(1) table lookup).
+     * @endif
+     *
+     * @param c
+     * @lang{ZH} 待分类的字符。 @endif
+     * @lang{EN} The character to classify. @endif
+     *
+     * @return
+     * @lang{ZH} `c` 对应的分类掩码，为 `base_ft<ctype>` 中各掩码常量的位或组合。 @endif
+     * @lang{EN} The classification mask for `c`, a bitwise OR of the mask constants
+     * in `base_ft<ctype>`. @endif
+     */
     [[nodiscard]] virtual mask is(char c) const
     {
         return m_table[static_cast<unsigned char>(c)];
     }
 
+    /**
+     * @lang{ZH}
+     * 返回字符 `c` 对应的大写形式（O(1) 查表）。
+     * @endif
+     *
+     * @lang{EN}
+     * Returns the uppercase form of character `c` (O(1) table lookup).
+     * @endif
+     *
+     * @param c
+     * @lang{ZH} 待转换的字符。 @endif
+     * @lang{EN} The character to convert. @endif
+     *
+     * @return
+     * @lang{ZH} `c` 的大写形式；若无对应大写则返回 `c` 本身。 @endif
+     * @lang{EN} The uppercase form of `c`; returns `c` unchanged if no uppercase
+     * mapping exists. @endif
+     */
     [[nodiscard]] virtual char toupper(char c) const
     {
         return static_cast<char>(m_toupper_table[static_cast<unsigned char>(c)]);
     }
 
+    /**
+     * @lang{ZH}
+     * 返回字符 `c` 对应的小写形式（O(1) 查表）。
+     * @endif
+     *
+     * @lang{EN}
+     * Returns the lowercase form of character `c` (O(1) table lookup).
+     * @endif
+     *
+     * @param c
+     * @lang{ZH} 待转换的字符。 @endif
+     * @lang{EN} The character to convert. @endif
+     *
+     * @return
+     * @lang{ZH} `c` 的小写形式；若无对应小写则返回 `c` 本身。 @endif
+     * @lang{EN} The lowercase form of `c`; returns `c` unchanged if no lowercase
+     * mapping exists. @endif
+     */
     [[nodiscard]] virtual char tolower(char c) const
     {
         return static_cast<char>(m_tolower_table[static_cast<unsigned char>(c)]);
     }
 
+    /**
+     * @lang{ZH}
+     * 将窄字符 `c` 拓宽为 `char`（恒等映射）。
+     * @endif
+     *
+     * @lang{EN}
+     * Widens the narrow character `c` to `char` (identity mapping).
+     * @endif
+     *
+     * @param c
+     * @lang{ZH} 待拓宽的字符。 @endif
+     * @lang{EN} The character to widen. @endif
+     *
+     * @return
+     * @lang{ZH} `c` 本身。 @endif
+     * @lang{EN} `c` unchanged. @endif
+     */
     [[nodiscard]] virtual char widen(char c) const { return c; }
 
+    /**
+     * @lang{ZH}
+     * 将字符 `c` 窄化为 `char`（始终成功）。
+     * @endif
+     *
+     * @lang{EN}
+     * Narrows character `c` to `char` (always succeeds).
+     * @endif
+     *
+     * @param c
+     * @lang{ZH} 待窄化的字符。 @endif
+     * @lang{EN} The character to narrow. @endif
+     *
+     * @return
+     * @lang{ZH} 包含 `c` 的 `std::optional<char>`，永不为 `std::nullopt`。 @endif
+     * @lang{EN} A `std::optional<char>` containing `c`; never `std::nullopt`. @endif
+     */
     [[nodiscard]] virtual std::optional<char> narrow(char c) const { return c; }
 
 private:
+    /** @lang{ZH} 持有构造时所用 locale 的 POSIX locale 包装对象。 @endif
+     *  @lang{EN} POSIX locale wrapper holding the locale used at construction. @endif */
     clocale_wrapper m_inter_locale;
+
+    /** @lang{ZH} 预建的大写映射表，索引为 `unsigned char` 值，元素为对应的大写 `int` 值。 @endif
+     *  @lang{EN} Precomputed uppercase mapping table; indexed by `unsigned char` value,
+     *  elements are the corresponding uppercase `int` values. @endif */
     std::array<int,  std::numeric_limits<unsigned char>::max() + 1> m_toupper_table {};
+
+    /** @lang{ZH} 预建的小写映射表，索引为 `unsigned char` 值，元素为对应的小写 `int` 值。 @endif
+     *  @lang{EN} Precomputed lowercase mapping table; indexed by `unsigned char` value,
+     *  elements are the corresponding lowercase `int` values. @endif */
     std::array<int,  std::numeric_limits<unsigned char>::max() + 1> m_tolower_table {};
+
+    /** @lang{ZH} 预建的分类掩码表，索引为 `unsigned char` 值，元素为对应的 `mask` 位域。 @endif
+     *  @lang{EN} Precomputed classification mask table; indexed by `unsigned char` value,
+     *  elements are the corresponding `mask` bitmasks. @endif */
     std::array<mask, std::numeric_limits<unsigned char>::max() + 1> m_table {};
 };
 
+/**
+ * @lang{ZH}
+ * 宽字符类型（`wchar_t` 及与 `wchar_t` 等价的 `char32_t`）的 ctype 配置类特化。
+ *
+ * 构造时通过 `wctype_l` 为每个字符分类属性初始化对应的 `wctype_t` 句柄，同时预建
+ * `m_widen` 表（通过 `btowc` 完成 256 个字节到 `CharT` 的映射）。每次字符分类、大小写
+ * 转换调用时，均通过 `iswctype_l`/`towupper_l`/`towlower_l` 实时查询 locale，不缓存
+ * 每码点结果。
+ *
+ * 对超出 `wchar_t` 表示范围的 `char32_t` 值（由 `out_of_wchar_range` 检测），`is`
+ * 返回 0，`toupper`/`tolower` 原样返回输入，`narrow` 返回 `std::nullopt`。
+ *
+ * @tparam CharT
+ * @lang{ZH}
+ * 目标宽字符类型。须为 `wchar_t`，或在 `char32_t` 与 `wchar_t` 等价的平台上为
+ * `char32_t`（由 `requires` 子句在编译期强制验证）。
+ * @endif
+ * @lang{EN}
+ * The target wide character type. Must be `wchar_t`, or `char32_t` on platforms
+ * where `char32_t` and `wchar_t` are equivalent (enforced at compile time by the
+ * `requires` clause).
+ * @endif
+ *
+ * @lang{EN}
+ * `ctype` configuration class specialization for wide character types
+ * (`wchar_t` and `char32_t` when equivalent to `wchar_t`).
+ *
+ * At construction time, `wctype_l` is called once per classification category to
+ * initialize the corresponding `wctype_t` handle, and the `m_widen` table is built
+ * via `btowc` for all 256 byte values. Each classification or case-conversion call
+ * dispatches to `iswctype_l`/`towupper_l`/`towlower_l` at call time without caching
+ * per-code-point results.
+ *
+ * For `char32_t` values outside the `wchar_t` representable range (detected by
+ * `out_of_wchar_range`): `is` returns 0, `toupper`/`tolower` return the input
+ * unchanged, and `narrow` returns `std::nullopt`.
+ * @endif
+ */
 template <typename CharT>
     requires std::is_same_v<CharT, wchar_t> ||
                 (std::is_same_v<CharT, char32_t> &&
@@ -136,6 +428,30 @@ template <typename CharT>
 class ctype_conf<CharT> : public ft_basic<ctype<CharT>>
 {
 public:
+    /**
+     * @lang{ZH}
+     * 构造函数。通过 `wctype_l` 初始化每个字符分类属性对应的 `wctype_t` 句柄，
+     * 并通过 `btowc` 预建 256 项 `m_widen` 查找表。
+     *
+     * 若任意 `wctype_l` 调用返回 0（分类名称不被 locale 支持），则抛出 `cvt_error`。
+     * @endif
+     *
+     * @lang{EN}
+     * Constructor. Initializes one `wctype_t` handle per classification category via
+     * `wctype_l`, and builds the 256-entry `m_widen` lookup table via `btowc`.
+     *
+     * Throws `cvt_error` if any `wctype_l` call returns 0 (category not supported
+     * by the locale).
+     * @endif
+     *
+     * @param name
+     * @lang{ZH} 用于查询的 locale 名称。 @endif
+     * @lang{EN} The locale name to use for table construction. @endif
+     *
+     * @throws cvt_error
+     * @lang{ZH} 若 `wctype_l` 对任意分类名称返回 0。 @endif
+     * @lang{EN} If `wctype_l` returns 0 for any classification category name. @endif
+     */
     ctype_conf(const std::string& name)
         : ft_basic<ctype<CharT>>()
         , m_inter_locale(name.c_str())
@@ -164,6 +480,31 @@ public:
         m_wmask_punct  = wctype_wrapper("punct");
     }
 
+    /**
+     * @lang{ZH}
+     * 返回宽字符 `_c` 的分类掩码，通过 `iswctype_l` 逐属性查询。
+     *
+     * 对超出 `wchar_t` 表示范围的值（`out_of_wchar_range` 返回 `true`），直接返回 0。
+     * @endif
+     *
+     * @lang{EN}
+     * Returns the classification mask for wide character `_c` by querying each
+     * attribute via `iswctype_l`.
+     *
+     * Returns 0 immediately for values outside the `wchar_t` representable range
+     * (when `out_of_wchar_range` returns `true`).
+     * @endif
+     *
+     * @param _c
+     * @lang{ZH} 待分类的宽字符。 @endif
+     * @lang{EN} The wide character to classify. @endif
+     *
+     * @return
+     * @lang{ZH} `_c` 对应的分类掩码，为 `base_ft<ctype>` 中各掩码常量的位或组合；
+     * 超出范围时返回 0。 @endif
+     * @lang{EN} The classification mask for `_c`, a bitwise OR of mask constants from
+     * `base_ft<ctype>`; 0 if the value is out of range. @endif
+     */
     [[nodiscard]] virtual base_ft<ctype>::mask is(CharT _c) const
     {
         if (out_of_wchar_range(_c)) return 0;
@@ -182,45 +523,145 @@ public:
         return res;
     }
 
+    /**
+     * @lang{ZH}
+     * 通过 `towupper_l` 返回宽字符 `c` 的大写形式。
+     *
+     * 对超出 `wchar_t` 表示范围的值，原样返回 `c`。
+     * @endif
+     *
+     * @lang{EN}
+     * Returns the uppercase form of wide character `c` via `towupper_l`.
+     *
+     * Returns `c` unchanged for values outside the `wchar_t` representable range.
+     * @endif
+     *
+     * @param c
+     * @lang{ZH} 待转换的宽字符。 @endif
+     * @lang{EN} The wide character to convert. @endif
+     *
+     * @return
+     * @lang{ZH} `c` 的大写形式；若 `c` 超出范围或无对应大写，则返回 `c` 本身。 @endif
+     * @lang{EN} The uppercase form of `c`; returns `c` unchanged if out of range
+     * or if no uppercase mapping exists. @endif
+     */
     [[nodiscard]] virtual CharT toupper(CharT c) const
     {
         if (out_of_wchar_range(c)) return c;
         return towupper_l(static_cast<wchar_t>(c), m_inter_locale.c_locale);
     }
 
+    /**
+     * @lang{ZH}
+     * 通过 `towlower_l` 返回宽字符 `c` 的小写形式。
+     *
+     * 对超出 `wchar_t` 表示范围的值，原样返回 `c`。
+     * @endif
+     *
+     * @lang{EN}
+     * Returns the lowercase form of wide character `c` via `towlower_l`.
+     *
+     * Returns `c` unchanged for values outside the `wchar_t` representable range.
+     * @endif
+     *
+     * @param c
+     * @lang{ZH} 待转换的宽字符。 @endif
+     * @lang{EN} The wide character to convert. @endif
+     *
+     * @return
+     * @lang{ZH} `c` 的小写形式；若 `c` 超出范围或无对应小写，则返回 `c` 本身。 @endif
+     * @lang{EN} The lowercase form of `c`; returns `c` unchanged if out of range
+     * or if no lowercase mapping exists. @endif
+     */
     [[nodiscard]] virtual CharT tolower(CharT c) const
     {
         if (out_of_wchar_range(c)) return c;
         return towlower_l(static_cast<wchar_t>(c), m_inter_locale.c_locale);
     }
 
-    // Matches std::ctype<wchar_t>::widen() semantics: only required to be
-    // correct for the basic source character set. For multi-byte locales
-    // (e.g. UTF-8), high bytes are not standalone characters and btowc()
-    // returns WEOF for them at table-build time; the corresponding entries
-    // in m_widen hold WEOF cast to CharT (a sentinel-looking but
-    // unspecified value). Callers must not widen() such bytes.
+    /**
+     * @lang{ZH}
+     * 将窄字符 `c` 拓宽为 `CharT`（O(1) 查表）。
+     *
+     * 语义与 `std::ctype<wchar_t>::widen()` 一致：仅保证对基本源字符集中的字符结果正确。
+     * 对于多字节 locale（如 UTF-8），高字节不是独立字符，`btowc()` 在建表时对其返回
+     * `WEOF`；因此 `m_widen` 中对应条目存储的是 `WEOF` 强转为 `CharT` 的值（一个看似
+     * 哨兵但实际未定义含义的值）。调用方不得对此类字节调用 `widen()`。
+     * @endif
+     *
+     * @lang{EN}
+     * Widens the narrow character `c` to `CharT` (O(1) table lookup).
+     *
+     * Matches `std::ctype<wchar_t>::widen()` semantics: only required to be
+     * correct for the basic source character set. For multi-byte locales
+     * (e.g. UTF-8), high bytes are not standalone characters and `btowc()`
+     * returns `WEOF` for them at table-build time; the corresponding entries
+     * in `m_widen` hold `WEOF` cast to `CharT` (a sentinel-looking but
+     * unspecified value). Callers must not call `widen()` on such bytes.
+     * @endif
+     *
+     * @param c
+     * @lang{ZH} 待拓宽的窄字符。 @endif
+     * @lang{EN} The narrow character to widen. @endif
+     *
+     * @return
+     * @lang{ZH} `c` 在当前 locale 下对应的 `CharT` 值；对高字节返回值未定义。 @endif
+     * @lang{EN} The `CharT` value corresponding to `c` in the current locale;
+     * the result is unspecified for high bytes. @endif
+     */
     [[nodiscard]] virtual CharT widen(char c) const
     {
         return static_cast<CharT>(m_widen[static_cast<unsigned char>(c)]);
     }
 
-    // Implementation note: unlike is/toupper/tolower (which call *_l
-    // functions with an explicit, immutable locale_t), wctob has no _l
-    // variant -- it reads whatever locale is currently active on the
-    // calling thread. We therefore install m_inter_locale via clocale_user
-    // for the duration of the wctob call, and restore on scope exit.
-    //
-    // Visible side effect for the window of this call: the calling
-    // thread's locale is m_inter_locale, not whatever it was on entry.
-    // Anything reached during this call -- in particular, a callback
-    // dispatched through a user-derived override of this function --
-    // that performs locale-sensitive I/O (std::ostream numeric
-    // formatting, std::format, third-party locale-aware code) will
-    // observe m_inter_locale instead of the thread's outer locale.
-    // Derivations should keep this function pure-computational and
-    // avoid locale-sensitive side effects inside the override; the same
-    // guidance the std::ctype facet conventions imply.
+    /**
+     * @lang{ZH}
+     * 将宽字符 `wc` 窄化为 `char`，通过 `wctob` 实现。
+     *
+     * 对超出 `wchar_t` 表示范围的值，返回 `std::nullopt`。对 `wctob` 返回 `EOF`
+     * 的值（无对应单字节表示），同样返回 `std::nullopt`。
+     *
+     * @note `wctob` 没有 `_l` 变体，读取的是调用线程当前激活的 locale。因此本函数
+     * 在调用 `wctob` 期间通过 `clocale_user` 临时将线程 locale 切换为 `m_inter_locale`
+     * 并在作用域结束时恢复。
+     *
+     * **可见副作用**：在此函数执行窗口内，调用线程的 locale 为 `m_inter_locale`，而非
+     * 进入时的外部 locale。此期间若有任何代码执行 locale 敏感的 IO（如 `std::ostream`
+     * 数字格式化、`std::format`、第三方 locale 感知代码），将观察到 `m_inter_locale`
+     * 而非线程原有 locale。派生类重写本函数时应保持其为纯计算操作，避免在重写内部触发
+     * locale 敏感的副作用；这与 `std::ctype` facet 约定所隐含的指导原则一致。
+     * @endif
+     *
+     * @lang{EN}
+     * Narrows wide character `wc` to `char` via `wctob`.
+     *
+     * Returns `std::nullopt` for values outside the `wchar_t` representable range,
+     * and for values for which `wctob` returns `EOF` (no single-byte representation).
+     *
+     * @note `wctob` has no `_l` variant — it reads whatever locale is currently active
+     * on the calling thread. Therefore this function temporarily installs
+     * `m_inter_locale` via `clocale_user` for the duration of the `wctob` call and
+     * restores the previous locale on scope exit.
+     *
+     * **Visible side effect**: for the window of this call, the calling thread's locale
+     * is `m_inter_locale`, not whatever it was on entry. Anything reached during this
+     * call — in particular, a callback dispatched through a user-derived override of
+     * this function — that performs locale-sensitive I/O (`std::ostream` numeric
+     * formatting, `std::format`, third-party locale-aware code) will observe
+     * `m_inter_locale` instead of the thread's outer locale. Derivations should keep
+     * this function pure-computational and avoid locale-sensitive side effects inside
+     * the override; the same guidance the `std::ctype` facet conventions imply.
+     * @endif
+     *
+     * @param wc
+     * @lang{ZH} 待窄化的宽字符。 @endif
+     * @lang{EN} The wide character to narrow. @endif
+     *
+     * @return
+     * @lang{ZH} 包含窄化结果的 `std::optional<char>`；若无对应单字节表示或值超出范围则为 `std::nullopt`。 @endif
+     * @lang{EN} A `std::optional<char>` containing the narrowed result; `std::nullopt`
+     * if no single-byte representation exists or the value is out of range. @endif
+     */
     [[nodiscard]] virtual std::optional<char> narrow(CharT wc) const
     {
         if (out_of_wchar_range(wc)) return std::nullopt;
@@ -236,45 +677,144 @@ private:
     // (reusable across facets); resolved here via unqualified lookup
     // since this class lives in the same namespace.
 
+    /** @lang{ZH} 持有构造时所用 locale 的 POSIX locale 包装对象。 @endif
+     *  @lang{EN} POSIX locale wrapper holding the locale used at construction. @endif */
     clocale_wrapper   m_inter_locale;
+
+    /** @lang{ZH} 预建的宽化查找表，索引为 `unsigned char` 值，元素为 `btowc` 返回的 `wint_t` 值。 @endif
+     *  @lang{EN} Precomputed widen lookup table; indexed by `unsigned char` value,
+     *  elements are the `wint_t` values returned by `btowc`. @endif */
     std::array<wint_t, 1 + std::numeric_limits<unsigned char>::max()> m_widen {};
 
+    /** @lang{ZH} `upper` 分类对应的 `wctype_t` 句柄。 @endif
+     *  @lang{EN} `wctype_t` handle for the `upper` classification category. @endif */
     wctype_t          m_wmask_upper;
+
+    /** @lang{ZH} `lower` 分类对应的 `wctype_t` 句柄。 @endif
+     *  @lang{EN} `wctype_t` handle for the `lower` classification category. @endif */
     wctype_t          m_wmask_lower;
+
+    /** @lang{ZH} `alpha` 分类对应的 `wctype_t` 句柄。 @endif
+     *  @lang{EN} `wctype_t` handle for the `alpha` classification category. @endif */
     wctype_t          m_wmask_alpha;
+
+    /** @lang{ZH} `digit` 分类对应的 `wctype_t` 句柄。 @endif
+     *  @lang{EN} `wctype_t` handle for the `digit` classification category. @endif */
     wctype_t          m_wmask_digit;
+
+    /** @lang{ZH} `xdigit` 分类对应的 `wctype_t` 句柄。 @endif
+     *  @lang{EN} `wctype_t` handle for the `xdigit` classification category. @endif */
     wctype_t          m_wmask_xdigit;
+
+    /** @lang{ZH} `space` 分类对应的 `wctype_t` 句柄。 @endif
+     *  @lang{EN} `wctype_t` handle for the `space` classification category. @endif */
     wctype_t          m_wmask_space;
+
+    /** @lang{ZH} `print` 分类对应的 `wctype_t` 句柄。 @endif
+     *  @lang{EN} `wctype_t` handle for the `print` classification category. @endif */
     wctype_t          m_wmask_print;
+
+    /** @lang{ZH} `cntrl` 分类对应的 `wctype_t` 句柄。 @endif
+     *  @lang{EN} `wctype_t` handle for the `cntrl` classification category. @endif */
     wctype_t          m_wmask_cntrl;
+
+    /** @lang{ZH} `punct` 分类对应的 `wctype_t` 句柄。 @endif
+     *  @lang{EN} `wctype_t` handle for the `punct` classification category. @endif */
     wctype_t          m_wmask_punct;
 };
 
-// Specialisation for UTF-8 code units (char8_t). The design rests on two
-// structural guarantees of the UTF-8 encoding: (1) no byte in [0x00, 0x7F]
-// ever appears as a leading or continuation byte of a multi-byte sequence,
-// so code units in that range are ASCII-compatible and can be classified
-// exactly like the corresponding char value in the locale; (2) every byte
-// in [0x80, 0xFF] is either a leading byte (0xC0–0xFF) or a continuation
-// byte (0x80–0xBF) of a multi-byte sequence, and therefore does not
-// represent a standalone Unicode code point.
-//
-// For [0x00, 0x7F]: all operations delegate to an internal ctype_conf<char>,
-// which builds locale-aware lookup tables for all 256 char values. Only the
-// lower half of that table is meaningful here; the high half is never used.
-//
-// For [0x80, 0xFF]: each API applies the conservative treatment documented
-// on its individual method below.
+/**
+ * @lang{ZH}
+ * UTF-8 代码单元（`char8_t`）的 ctype 配置类特化。
+ *
+ * 设计基于 UTF-8 编码的两条结构保证：
+ * 1. `[0x00, 0x7F]` 区间内的字节不会出现在多字节序列的前导字节或续字节位置，因此该
+ *    区间内的代码单元与 ASCII 完全兼容，可像对应的 `char` 值一样在 locale 下精确分类。
+ * 2. `[0x80, 0xFF]` 区间内的字节要么是多字节序列的前导字节（`0xC0–0xFF`），要么是续字节
+ *    （`0x80–0xBF`），不代表独立的 Unicode 码点。
+ *
+ * 对 `[0x00, 0x7F]`：所有操作委托给内部 `ctype_conf<char>`，后者在构造时为全部 256 个
+ * `char` 值建立 locale 感知的查找表；仅该表的低半部分在此处有意义，高半部分不被访问。
+ *
+ * 对 `[0x80, 0xFF]`：各 API 采用以下保守策略：
+ * - `is`：返回 0（非独立码点，无分类属性）。
+ * - `toupper`/`tolower`：原样返回输入（无大小写信息）。
+ * - `widen`：原样转换为 `char8_t`（`char8_t` 与 `unsigned char` 等值域，无 `WEOF` 哨兵问题）。
+ * - `narrow`：返回 `std::nullopt`（非独立码点，无对应 `char`）。
+ * @endif
+ *
+ * @lang{EN}
+ * `ctype` configuration class specialization for UTF-8 code units (`char8_t`).
+ *
+ * The design rests on two structural guarantees of the UTF-8 encoding:
+ * 1. No byte in `[0x00, 0x7F]` ever appears as a leading or continuation byte of a
+ *    multi-byte sequence, so code units in that range are ASCII-compatible and can be
+ *    classified exactly like the corresponding `char` value in the locale.
+ * 2. Every byte in `[0x80, 0xFF]` is either a leading byte (`0xC0–0xFF`) or a
+ *    continuation byte (`0x80–0xBF`) of a multi-byte sequence, and therefore does not
+ *    represent a standalone Unicode code point.
+ *
+ * For `[0x00, 0x7F]`: all operations delegate to an internal `ctype_conf<char>`,
+ * which builds locale-aware lookup tables for all 256 `char` values at construction
+ * time. Only the lower half of that table is meaningful here; the high half is never
+ * accessed.
+ *
+ * For `[0x80, 0xFF]`: each API applies the following conservative treatment:
+ * - `is`: returns 0 (not a standalone code point; no classification applies).
+ * - `toupper`/`tolower`: returns the input unchanged (no case information).
+ * - `widen`: converts trivially to `char8_t` (`char8_t` has the same range as
+ *   `unsigned char`, so every `char` maps to exactly one `char8_t` code unit with
+ *   no loss and no `WEOF` sentinel issue).
+ * - `narrow`: returns `std::nullopt` (not a standalone code point; no `char` equivalent).
+ * @endif
+ */
 template <>
 class ctype_conf<char8_t> : public ft_basic<ctype<char8_t>>
 {
 public:
+    /**
+     * @lang{ZH}
+     * 构造函数。初始化内部 `ctype_conf<char>` 以建立 locale 感知的查找表。
+     * @endif
+     *
+     * @lang{EN}
+     * Constructor. Initializes the internal `ctype_conf<char>` to build
+     * locale-aware lookup tables.
+     * @endif
+     *
+     * @param name
+     * @lang{ZH} 用于查询的 locale 名称。 @endif
+     * @lang{EN} The locale name to use for table construction. @endif
+     */
     ctype_conf(const std::string& name)
         : ft_basic<ctype<char8_t>>()
         , m_internal(name)
     {}
 
 public:
+    /**
+     * @lang{ZH}
+     * 返回 `char8_t` 代码单元 `c` 的分类掩码。
+     *
+     * 对 `[0x80, 0xFF]`（非独立码点），直接返回 0。
+     * 对 `[0x00, 0x7F]`，委托给内部 `ctype_conf<char>::is`。
+     * @endif
+     *
+     * @lang{EN}
+     * Returns the classification mask for `char8_t` code unit `c`.
+     *
+     * Returns 0 for `[0x80, 0xFF]` (not a standalone code point).
+     * Delegates to the internal `ctype_conf<char>::is` for `[0x00, 0x7F]`.
+     * @endif
+     *
+     * @param c
+     * @lang{ZH} 待分类的 UTF-8 代码单元。 @endif
+     * @lang{EN} The UTF-8 code unit to classify. @endif
+     *
+     * @return
+     * @lang{ZH} `c` 的分类掩码；对 `[0x80, 0xFF]` 返回 0。 @endif
+     * @lang{EN} The classification mask for `c`; 0 for `[0x80, 0xFF]`. @endif
+     */
     [[nodiscard]] virtual mask is(char8_t c) const
     {
         if (c & 0x80)
@@ -282,24 +822,119 @@ public:
         return m_internal.is(static_cast<char>(c));
     }
 
+    /**
+     * @lang{ZH}
+     * 返回 `char8_t` 代码单元 `c` 的大写形式。
+     *
+     * 对 `[0x80, 0xFF]`（非独立码点，无大小写信息），原样返回 `c`。
+     * 对 `[0x00, 0x7F]`，委托给内部 `ctype_conf<char>::toupper`。
+     * @endif
+     *
+     * @lang{EN}
+     * Returns the uppercase form of `char8_t` code unit `c`.
+     *
+     * Returns `c` unchanged for `[0x80, 0xFF]` (not a standalone code point;
+     * no case information). Delegates to the internal `ctype_conf<char>::toupper`
+     * for `[0x00, 0x7F]`.
+     * @endif
+     *
+     * @param c
+     * @lang{ZH} 待转换的 UTF-8 代码单元。 @endif
+     * @lang{EN} The UTF-8 code unit to convert. @endif
+     *
+     * @return
+     * @lang{ZH} `c` 的大写形式；对 `[0x80, 0xFF]` 原样返回 `c`。 @endif
+     * @lang{EN} The uppercase form of `c`; returns `c` unchanged for `[0x80, 0xFF]`. @endif
+     */
     [[nodiscard]] virtual char8_t toupper(char8_t c) const
     {
         if (c & 0x80) return c;  // not a standalone code point; no case information
         return static_cast<char8_t>(m_internal.toupper(static_cast<char>(c)));
     }
 
+    /**
+     * @lang{ZH}
+     * 返回 `char8_t` 代码单元 `c` 的小写形式。
+     *
+     * 对 `[0x80, 0xFF]`（非独立码点，无大小写信息），原样返回 `c`。
+     * 对 `[0x00, 0x7F]`，委托给内部 `ctype_conf<char>::tolower`。
+     * @endif
+     *
+     * @lang{EN}
+     * Returns the lowercase form of `char8_t` code unit `c`.
+     *
+     * Returns `c` unchanged for `[0x80, 0xFF]` (not a standalone code point;
+     * no case information). Delegates to the internal `ctype_conf<char>::tolower`
+     * for `[0x00, 0x7F]`.
+     * @endif
+     *
+     * @param c
+     * @lang{ZH} 待转换的 UTF-8 代码单元。 @endif
+     * @lang{EN} The UTF-8 code unit to convert. @endif
+     *
+     * @return
+     * @lang{ZH} `c` 的小写形式；对 `[0x80, 0xFF]` 原样返回 `c`。 @endif
+     * @lang{EN} The lowercase form of `c`; returns `c` unchanged for `[0x80, 0xFF]`. @endif
+     */
     [[nodiscard]] virtual char8_t tolower(char8_t c) const
     {
         if (c & 0x80) return c;  // not a standalone code point; no case information
         return static_cast<char8_t>(m_internal.tolower(static_cast<char>(c)));
     }
 
-    // char8_t has the same range as unsigned char, so every char value maps
-    // to exactly one char8_t code unit with no loss and no WEOF sentinel (cf.
-    // the wchar_t/char32_t specialisation, where btowc() may return WEOF for
-    // high bytes).
+    /**
+     * @lang{ZH}
+     * 将窄字符 `c` 拓宽为 `char8_t`（trivial 转换，无精度损失）。
+     *
+     * `char8_t` 与 `unsigned char` 具有相同的值域，因此每个 `char` 值都恰好映射为
+     * 一个 `char8_t` 代码单元，不存在 `WEOF` 哨兵问题（对比 `wchar_t`/`char32_t`
+     * 特化中 `btowc` 对高字节返回 `WEOF` 的情形）。
+     * @endif
+     *
+     * @lang{EN}
+     * Widens the narrow character `c` to `char8_t` (trivial conversion, no loss).
+     *
+     * `char8_t` has the same range as `unsigned char`, so every `char` value maps
+     * to exactly one `char8_t` code unit with no loss and no `WEOF` sentinel issue
+     * (cf. the `wchar_t`/`char32_t` specialization, where `btowc()` may return
+     * `WEOF` for high bytes).
+     * @endif
+     *
+     * @param c
+     * @lang{ZH} 待拓宽的窄字符。 @endif
+     * @lang{EN} The narrow character to widen. @endif
+     *
+     * @return
+     * @lang{ZH} `c` 对应的 `char8_t` 代码单元。 @endif
+     * @lang{EN} The `char8_t` code unit corresponding to `c`. @endif
+     */
     [[nodiscard]] virtual char8_t widen(char c) const { return static_cast<char8_t>(c); }
 
+    /**
+     * @lang{ZH}
+     * 将 `char8_t` 代码单元 `c` 窄化为 `char`。
+     *
+     * 对 `[0x80, 0xFF]`（非独立码点，无对应 `char`），返回 `std::nullopt`。
+     * 对 `[0x00, 0x7F]`，直接转换为 `char` 并返回（值域一致，始终成功）。
+     * @endif
+     *
+     * @lang{EN}
+     * Narrows `char8_t` code unit `c` to `char`.
+     *
+     * Returns `std::nullopt` for `[0x80, 0xFF]` (not a standalone code point;
+     * no `char` equivalent). For `[0x00, 0x7F]`, converts directly to `char`
+     * (ranges are compatible; always succeeds).
+     * @endif
+     *
+     * @param c
+     * @lang{ZH} 待窄化的 UTF-8 代码单元。 @endif
+     * @lang{EN} The UTF-8 code unit to narrow. @endif
+     *
+     * @return
+     * @lang{ZH} 包含窄化结果的 `std::optional<char>`；对 `[0x80, 0xFF]` 返回 `std::nullopt`。 @endif
+     * @lang{EN} A `std::optional<char>` containing the narrowed result; `std::nullopt`
+     * for `[0x80, 0xFF]`. @endif
+     */
     [[nodiscard]] virtual std::optional<char> narrow(char8_t c) const
     {
         if (c & 0x80) return std::nullopt;  // not a standalone code point; no char equivalent
@@ -307,6 +942,9 @@ public:
     }
 
 private:
+    /** @lang{ZH} 内部 `char` 特化实例，提供 `[0x00, 0x7F]` 区间的 locale 感知查找表。 @endif
+     *  @lang{EN} Internal `char` specialization instance providing locale-aware lookup
+     *  tables for the `[0x00, 0x7F]` range. @endif */
     ctype_conf<char> m_internal;
 };
 }

--- a/include/facet/facet_common.h
+++ b/include/facet/facet_common.h
@@ -1,3 +1,33 @@
+/**
+ * @file facet_common.h
+ * @lang{ZH}
+ * facet 基础设施的公共类型定义与工具。
+ *
+ * 本文件提供以下核心组件：
+ * - `abs_ft`：所有 facet 的抽象基类，持有运行时 facet id。
+ * - `base_ft<TFacet>`：以 facet 模板为参数的中间基类，用于建立 facet 继承层次。
+ * - `ft_basic<TFacet<CharT>>`：为 `(facet 模板, 字符类型)` 对提供静态类型键机制的具体基类。
+ * - `facet_create_rule<...>`、`facet_create_pack<...>` 及相关 traits：描述 facet 构造规则的
+ *   元编程工具，用于 locale 的批量 facet 构造。
+ * - `out_of_wchar_range`：检测字符值是否超出 `wchar_t` 表示范围的工具函数。
+ * @endif
+ *
+ * @lang{EN}
+ * Common type definitions and utilities for the facet infrastructure.
+ *
+ * This file provides the following core components:
+ * - `abs_ft`: Abstract base class for all facets, carrying the runtime facet id.
+ * - `base_ft<TFacet>`: Intermediate base class parameterized on the facet template,
+ *   used to establish the facet inheritance hierarchy.
+ * - `ft_basic<TFacet<CharT>>`: Concrete base class providing the static type-key
+ *   mechanism for a `(facet template, character type)` pair.
+ * - `facet_create_rule<...>`, `facet_create_pack<...>`, and related traits: Metaprogramming
+ *   utilities describing facet construction rules, used for batch facet construction in a locale.
+ * - `out_of_wchar_range`: Utility function to detect whether a character value is
+ *   outside the representable range of `wchar_t`.
+ * @endif
+ */
+
 #pragma once
 #include <concepts>
 #include <cstddef>
@@ -9,8 +39,41 @@
 
 namespace IOv2
 {
+/**
+ * @lang{ZH}
+ * 所有 facet 的抽象基类。
+ *
+ * 持有运行时 facet id，用于在丢失具体类型信息时（如经由 `abs_ft&`，例如 `locale::involve`）
+ * 通过运行时值将 facet 键入 locale。
+ *
+ * 该类不可复制也不可移动。
+ * @endif
+ *
+ * @lang{EN}
+ * Abstract base class for all facets.
+ *
+ * Carries the runtime facet id, which is used to key a facet into a locale by
+ * its runtime value when the concrete type is no longer known (e.g., via
+ * `abs_ft&` in `locale::involve`).
+ *
+ * This class is neither copyable nor movable.
+ * @endif
+ */
 struct abs_ft
 {
+    /**
+     * @lang{ZH}
+     * 构造函数，以运行时 facet id 初始化实例。
+     * @endif
+     *
+     * @lang{EN}
+     * Constructor; initializes the instance with the runtime facet id.
+     * @endif
+     *
+     * @param id
+     * @lang{ZH} 此 facet 实例的运行时唯一标识符。 @endif
+     * @lang{EN} The runtime unique identifier for this facet instance. @endif
+     */
     explicit abs_ft(size_t id)
         : m_id(id) {}
 
@@ -21,23 +84,67 @@ struct abs_ft
 
     virtual ~abs_ft() = default;
 
-    // Instance accessor: reads the id carried by this facet, used to key it
-    // into a locale by its runtime value when the concrete type is no longer
-    // known (an abs_ft&, e.g. locale::involve).
-    //
-    // NOTE: ft_basic introduces a *static*, same-named id() that is the
-    // per-type facet key (TF::id()); on derived facets that static hides this
-    // accessor. This is deliberate and harmless ONLY because every facet seeds
-    // m_id from its own static id() at construction, so both always return the
-    // same value. Do not break that invariant -- never construct a facet whose
-    // m_id differs from its static id() -- or the static key and this accessor
-    // would silently diverge and locale facet lookup would misbehave.
+    /**
+     * @lang{ZH}
+     * 实例访问器：读取此 facet 携带的 id。
+     *
+     * 该 id 用于在具体类型不再可知时（如 `abs_ft&`，例如 `locale::involve`），
+     * 通过运行时值将 facet 键入 locale。
+     *
+     * @note `ft_basic` 引入了一个**静态**的同名 `id()`，即每类型 facet 键（`TF::id()`）；
+     * 在派生 facet 上，该静态成员会隐藏此实例访问器。这是刻意为之且无害的，**仅因为**
+     * 每个 facet 在构造时都以自身的静态 `id()` 初始化 `m_id`，使二者始终返回相同的值。
+     * 请勿破坏此不变量——不可构造 `m_id` 与其静态 `id()` 不一致的 facet，否则静态键
+     * 与此实例访问器将静默地产生分歧，导致 locale facet 查找异常。
+     * @endif
+     *
+     * @lang{EN}
+     * Instance accessor: reads the id carried by this facet, used to key it
+     * into a locale by its runtime value when the concrete type is no longer
+     * known (an `abs_ft&`, e.g. `locale::involve`).
+     *
+     * @note `ft_basic` introduces a *static*, same-named `id()` that is the
+     * per-type facet key (`TF::id()`); on derived facets that static hides this
+     * accessor. This is deliberate and harmless ONLY because every facet seeds
+     * `m_id` from its own static `id()` at construction, so both always return the
+     * same value. Do not break that invariant -- never construct a facet whose
+     * `m_id` differs from its static `id()` -- or the static key and this accessor
+     * would silently diverge and locale facet lookup would misbehave.
+     * @endif
+     *
+     * @return
+     * @lang{ZH} 此 facet 实例的运行时 id。 @endif
+     * @lang{EN} The runtime id of this facet instance. @endif
+     */
     [[nodiscard]] size_t id() const noexcept { return m_id; }
 
 private:
+    /** @lang{ZH} 此 facet 实例的运行时唯一标识符。 @endif
+     *  @lang{EN} The runtime unique identifier for this facet instance. @endif */
     const size_t m_id;
 };
 
+/**
+ * @lang{ZH}
+ * 以 facet 模板为参数的中间基类。
+ *
+ * 作为 `abs_ft` 与具体 `ft_basic` 特化之间的桥接层，用于建立以 facet 模板
+ * 为标识的继承层次结构，使同一 facet 模板的不同字符类型特化可共享同一中间基类。
+ * @endif
+ *
+ * @lang{EN}
+ * Intermediate base class parameterized on the facet template.
+ *
+ * Acts as a bridge layer between `abs_ft` and a concrete `ft_basic`
+ * specialization, establishing an inheritance hierarchy keyed on the facet
+ * template. This allows different character-type specializations of the same
+ * facet template to share a common intermediate base.
+ * @endif
+ *
+ * @tparam TFacet
+ * @lang{ZH} facet 模板，例如 `ctype`、`collate` 等。 @endif
+ * @lang{EN} The facet template, e.g. `ctype`, `collate`, etc. @endif
+ */
 template <template<typename> class TFacet>
 class base_ft : public abs_ft
 {
@@ -47,69 +154,225 @@ public:
 
 template <typename TFacet> class ft_basic;
 
+/**
+ * @lang{ZH}
+ * 为 `(facet 模板, 字符类型)` 对提供静态类型键机制的具体基类。
+ *
+ * 每个 `ft_basic<TFacet<CharT>>` 特化维护一个每类型唯一的 `s_id` 静态变量，
+ * 静态成员函数 `id()` 返回其地址作为稳定的编译期 facet 键。构造函数自动以此值
+ * 初始化 `abs_ft::m_id`，保证静态键与实例访问器始终一致。
+ * @endif
+ *
+ * @lang{EN}
+ * Concrete base class providing the static type-key mechanism for a
+ * `(facet template, character type)` pair.
+ *
+ * Each `ft_basic<TFacet<CharT>>` specialization maintains a per-type unique
+ * `s_id` static variable; the static member function `id()` returns its address
+ * as a stable, compile-time facet key. The constructor automatically seeds
+ * `abs_ft::m_id` with this value, ensuring the static key and the instance
+ * accessor always agree.
+ * @endif
+ *
+ * @tparam TFacet
+ * @lang{ZH} 完整的 facet 类型，形如 `SomeFacet<CharT>`。 @endif
+ * @lang{EN} The full facet type, e.g. `SomeFacet<CharT>`. @endif
+ */
 template <template<typename> class TFacet, typename CharT>
 class ft_basic<TFacet<CharT>> : public base_ft<TFacet>
 {
     static_assert(sizeof(void*) <= sizeof(size_t));
 public:
+    /** @lang{ZH} 此 facet 特化所绑定的字符类型。 @endif
+     *  @lang{EN} The character type bound to this facet specialization. @endif */
     using char_type = CharT;
 public:
+    /**
+     * @lang{ZH}
+     * 转发构造函数。以此类型的静态 `id()` 值初始化 `abs_ft::m_id`，并将其余参数
+     * 转发给 `base_ft<TFacet>`。
+     * @endif
+     *
+     * @lang{EN}
+     * Forwarding constructor. Seeds `abs_ft::m_id` with this type's static `id()`
+     * value and forwards the remaining arguments to `base_ft<TFacet>`.
+     * @endif
+     */
     template <typename... T>
         requires std::constructible_from<base_ft<TFacet>, size_t, T...>
     ft_basic(T&&... args)
         : base_ft<TFacet>(id(), std::forward<T>(args)...) {}
 
-    // Static per-type facet key: a stable, unique id for this
-    // (facet template, char type) pair, taken from the address of the per-type
-    // s_id. This is the compile-time key used to locate facets by type
-    // (TF::id()). The constructor above seeds abs_ft::m_id with this value, so
-    // it stays in agreement with the abs_ft::id() instance accessor; see the
-    // note on abs_ft::id() for why the shared name is intentional and safe.
+    /**
+     * @lang{ZH}
+     * 静态每类型 facet 键：返回此 `(facet 模板, 字符类型)` 对稳定且唯一的 id，
+     * 取自每类型 `s_id` 变量的地址。此值为编译期键，用于按类型定位 facet（`TF::id()`）。
+     * 构造函数以此值初始化 `abs_ft::m_id`，保证其与 `abs_ft::id()` 实例访问器
+     * 始终保持一致；参见 `abs_ft::id()` 上的说明以了解共名的理由。
+     * @endif
+     *
+     * @lang{EN}
+     * Static per-type facet key: a stable, unique id for this
+     * `(facet template, char type)` pair, taken from the address of the per-type
+     * `s_id`. This is the compile-time key used to locate facets by type
+     * (`TF::id()`). The constructor seeds `abs_ft::m_id` with this value, keeping
+     * it in agreement with the `abs_ft::id()` instance accessor; see the note on
+     * `abs_ft::id()` for why the shared name is intentional and safe.
+     * @endif
+     *
+     * @return
+     * @lang{ZH} 此 facet 类型唯一的运行时 id 值。 @endif
+     * @lang{EN} The unique runtime id value for this facet type. @endif
+     */
     static size_t id() noexcept { return std::bit_cast<size_t>(&s_id); }
 private:
-    // REQUIRES default symbol visibility across DSOs that share facet
-    // instances. Because id() returns &s_id, cross-DSO facet identity
-    // depends on the dynamic linker merging all copies of s_id to a
-    // single runtime address. The following deployment patterns silently
-    // break this and yield per-DSO ids for what should be the same facet:
-    //   - Building any TU that instantiates ft_basic<...> with
-    //     -fvisibility=hidden without re-exporting s_id.
-    //   - Linking a DSO with -Bsymbolic / -Bsymbolic-functions, which
-    //     binds internal references to the DSO-local copy.
-    //   - dlopen()ing a plugin with RTLD_LOCAL (the default).
-    //   - Sharing facet instances across Windows DLL boundaries (PE has
-    //     no equivalent of ELF weak-symbol unification; templates are
-    //     re-instantiated per DLL).
-    // If any of the above is needed, switch id() to a value-based
-    // identity (e.g. hash of typeid(TFacet).name()) rather than an
-    // address.
+    /**
+     * @lang{ZH}
+     * 每类型唯一标识符变量。`id()` 返回其地址，因此跨 DSO 的 facet 标识依赖动态
+     * 链接器将所有副本合并为单一运行时地址。以下部署模式会静默地破坏此机制，导致本应
+     * 相同的 facet 在不同 DSO 中得到不同的 id：
+     * - 编译任何实例化 `ft_basic<...>` 的翻译单元时使用 `-fvisibility=hidden` 而不重新
+     *   导出 `s_id`。
+     * - 链接 DSO 时使用 `-Bsymbolic` / `-Bsymbolic-functions`，导致内部引用绑定至 DSO
+     *   本地副本。
+     * - 使用 `RTLD_LOCAL`（默认值）`dlopen()` 插件。
+     * - 跨 Windows DLL 边界共享 facet 实例（PE 没有 ELF 弱符号统一机制，模板在每个 DLL
+     *   中独立实例化）。
+     *
+     * 若有上述任一需求，应将 `id()` 改为基于值的标识（如 `typeid(TFacet).name()` 的哈希），
+     * 而非地址。
+     * @endif
+     *
+     * @lang{EN}
+     * Per-type unique identity variable. Because `id()` returns `&s_id`, cross-DSO
+     * facet identity depends on the dynamic linker merging all copies of `s_id` to a
+     * single runtime address. The following deployment patterns silently break this
+     * and yield per-DSO ids for what should be the same facet:
+     * - Building any TU that instantiates `ft_basic<...>` with `-fvisibility=hidden`
+     *   without re-exporting `s_id`.
+     * - Linking a DSO with `-Bsymbolic` / `-Bsymbolic-functions`, which binds
+     *   internal references to the DSO-local copy.
+     * - `dlopen()`ing a plugin with `RTLD_LOCAL` (the default).
+     * - Sharing facet instances across Windows DLL boundaries (PE has no equivalent
+     *   of ELF weak-symbol unification; templates are re-instantiated per DLL).
+     *
+     * If any of the above is needed, switch `id()` to a value-based identity
+     * (e.g. hash of `typeid(TFacet).name()`) rather than an address.
+     * @endif
+     */
     inline static const void* s_id = nullptr;
 };
 
+/**
+ * @lang{ZH}
+ * 描述单条 facet 构造规则的标签类型。
+ *
+ * 模板参数列表编码了构造该 facet 所需的类型信息，供 locale 的批量 facet
+ * 构造机制在编译期解析。
+ * @endif
+ *
+ * @lang{EN}
+ * Tag type describing a single facet construction rule.
+ *
+ * The template argument list encodes the type information needed to construct
+ * the facet, for use by the locale's batch facet-construction mechanism at
+ * compile time.
+ * @endif
+ */
 template <typename...>
 struct facet_create_rule;
 
+/**
+ * @lang{ZH}
+ * 若干条 facet 构造规则组成的有序包。
+ *
+ * locale 的批量构造机制按包内规则的顺序依次实例化各 facet，直至包为空。
+ * @endif
+ *
+ * @lang{EN}
+ * An ordered pack of facet construction rules.
+ *
+ * The locale's batch-construction mechanism instantiates each facet in order
+ * until the pack is empty.
+ * @endif
+ */
 template <typename...>
 struct facet_create_pack;
 
+/**
+ * @lang{ZH}
+ * 类型特征：判断 `T` 是否为包含至少一个类型参数的 `facet_create_rule` 特化。
+ * @endif
+ *
+ * @lang{EN}
+ * Type trait: `true` if `T` is a `facet_create_rule` specialization with at least
+ * one type argument.
+ * @endif
+ *
+ * @tparam T
+ * @lang{ZH} 待检测的类型。 @endif
+ * @lang{EN} The type to inspect. @endif
+ */
 template <typename T>
 constexpr static bool is_nonempty_facet_create_rule = false;
 
 template <typename... T>
 constexpr static bool is_nonempty_facet_create_rule<facet_create_rule<T...>> = (sizeof...(T) != 0);
 
+/**
+ * @lang{ZH}
+ * 类型特征：判断 `T` 是否为包含至少一个元素的 `facet_create_pack` 特化。
+ * @endif
+ *
+ * @lang{EN}
+ * Type trait: `true` if `T` is a `facet_create_pack` specialization with at least
+ * one element.
+ * @endif
+ *
+ * @tparam T
+ * @lang{ZH} 待检测的类型。 @endif
+ * @lang{EN} The type to inspect. @endif
+ */
 template <typename T>
 constexpr static bool is_nonempty_facet_create_pack = false;
 
 template <typename... T>
 constexpr static bool is_nonempty_facet_create_pack<facet_create_pack<T...>> = (sizeof...(T) != 0);
 
+/**
+ * @lang{ZH}
+ * 类型特征：获取 `facet_create_pack` 特化中的规则数量；对非 pack 类型返回 0。
+ * @endif
+ *
+ * @lang{EN}
+ * Type trait: the number of rules in a `facet_create_pack` specialization;
+ * returns 0 for non-pack types.
+ * @endif
+ *
+ * @tparam T
+ * @lang{ZH} 待检测的类型。 @endif
+ * @lang{EN} The type to inspect. @endif
+ */
 template <typename T>
 constexpr static size_t facet_create_pack_size = 0;
 
 template <typename... T>
 constexpr static size_t facet_create_pack_size<facet_create_pack<T...>> = sizeof...(T);
 
+/**
+ * @lang{ZH}
+ * 提取非空 `facet_create_pack` 中第一个规则的类型，以 `type` 成员类型给出。
+ * @endif
+ *
+ * @lang{EN}
+ * Extracts the type of the first rule in a non-empty `facet_create_pack`,
+ * exposed as the member type `type`.
+ * @endif
+ *
+ * @tparam T
+ * @lang{ZH} 非空的 `facet_create_pack` 特化。 @endif
+ * @lang{EN} A non-empty `facet_create_pack` specialization. @endif
+ */
 template <typename T>
     requires (facet_create_pack_size<T> > 0)
 struct facet_create_pack_head;
@@ -120,6 +383,20 @@ struct facet_create_pack_head<facet_create_pack<H, T...>>
     using type = H;
 };
 
+/**
+ * @lang{ZH}
+ * 移除非空 `facet_create_pack` 的第一个规则后剩余的包，以 `type` 成员类型给出。
+ * @endif
+ *
+ * @lang{EN}
+ * The remaining pack after removing the first rule of a non-empty
+ * `facet_create_pack`, exposed as the member type `type`.
+ * @endif
+ *
+ * @tparam T
+ * @lang{ZH} 非空的 `facet_create_pack` 特化。 @endif
+ * @lang{EN} A non-empty `facet_create_pack` specialization. @endif
+ */
 template <typename T>
     requires (facet_create_pack_size<T> > 0)
 struct facet_create_pack_tail;
@@ -130,33 +407,83 @@ struct facet_create_pack_tail<facet_create_pack<H, T...>>
     using type = facet_create_pack<T...>;
 };
 
-// Returns true if `c` has no wchar_t representation. Used to guard the
-// C `*_l` wide-character functions (iswctype_l, towupper_l, towlower_l,
-// wctob, ...) at any facet's API boundary, since the C standard says
-// their behaviour is implementation-defined for inputs that are not
-// representable as a wchar_t.
-//
-// Only non-trivial for CharT == char32_t on platforms where char32_t
-// covers a strictly wider range than wchar_t (e.g. Linux: signed
-// 32-bit wchar_t with WCHAR_MAX = 0x7FFFFFFF, vs unsigned 32-bit
-// char32_t). For every other character type (wchar_t, char, char8_t,
-// char16_t) the input is always representable as wchar_t on every
-// supported platform, and the function is statically a no-op.
-//
-// Precise boundary for char32_t on Linux: this function returns true
-// exactly for the upper half of the char32_t range, [0x80000000,
-// 0xFFFFFFFF], because WCHAR_MAX == 0x7FFFFFFF there. The entire valid
-// Unicode code-point space U+0000..U+10FFFF lies well below this cutoff,
-// so the guard never rejects legal Unicode; it only filters out
-// non-Unicode bit patterns that a caller may have reinterpreted as
-// char32_t. Callers that intentionally pass arbitrary 32-bit integers
-// through a char32_t channel should not rely on out_of_wchar_range as a
-// Unicode-validity check.
-//
-// CharT is constrained to the five standard C++ character types so
-// that misuse with non-character integral or floating types (where
-// the wchar_t-range question is meaningless) fails at compile time
-// instead of silently returning false.
+/**
+ * @lang{ZH}
+ * 检测字符值是否超出 `wchar_t` 的可表示范围。
+ *
+ * 用于在任何 facet 的 API 边界处保护 C 库的 `*_l` 宽字符函数
+ * （`iswctype_l`、`towupper_l`、`towlower_l`、`wctob` 等），因为 C 标准规定，
+ * 对不能以 `wchar_t` 表示的输入，这些函数的行为是由实现定义的。
+ *
+ * 仅对 `CharT == char32_t` 且平台上 `char32_t` 覆盖范围严格大于 `wchar_t` 的情况
+ * 有实际意义（例如 Linux：`wchar_t` 为有符号 32 位，`WCHAR_MAX = 0x7FFFFFFF`；
+ * `char32_t` 为无符号 32 位）。对其他所有字符类型（`wchar_t`、`char`、`char8_t`、
+ * `char16_t`），在所有支持的平台上输入始终可以 `wchar_t` 表示，因此此函数静态地
+ * 等同于无操作。
+ *
+ * **`char32_t` 在 Linux 上的精确边界**：本函数恰好对 `char32_t` 值域的上半部分
+ * `[0x80000000, 0xFFFFFFFF]` 返回 `true`，因为那里 `WCHAR_MAX == 0x7FFFFFFF`。
+ * 整个有效 Unicode 码点空间 U+0000..U+10FFFF 远低于此截止值，因此本守卫从不拒绝
+ * 合法 Unicode；它仅过滤调用方可能被重新解释为 `char32_t` 的非 Unicode 位模式。
+ * 有意通过 `char32_t` 通道传递任意 32 位整数的调用方不应将 `out_of_wchar_range`
+ * 作为 Unicode 有效性检查使用。
+ *
+ * `CharT` 被约束为五种标准 C++ 字符类型，以确保对非字符整型或浮点类型的误用
+ * 在编译期报错，而非静默返回 `false`。
+ * @endif
+ *
+ * @lang{EN}
+ * Returns `true` if `c` has no `wchar_t` representation. Used to guard the
+ * C `*_l` wide-character functions (`iswctype_l`, `towupper_l`, `towlower_l`,
+ * `wctob`, ...) at any facet's API boundary, since the C standard says
+ * their behaviour is implementation-defined for inputs that are not
+ * representable as a `wchar_t`.
+ *
+ * Only non-trivial for `CharT == char32_t` on platforms where `char32_t`
+ * covers a strictly wider range than `wchar_t` (e.g. Linux: signed
+ * 32-bit `wchar_t` with `WCHAR_MAX = 0x7FFFFFFF`, vs unsigned 32-bit
+ * `char32_t`). For every other character type (`wchar_t`, `char`, `char8_t`,
+ * `char16_t`) the input is always representable as `wchar_t` on every
+ * supported platform, and the function is statically a no-op.
+ *
+ * **Precise boundary for `char32_t` on Linux**: this function returns `true`
+ * exactly for the upper half of the `char32_t` range, `[0x80000000, 0xFFFFFFFF]`,
+ * because `WCHAR_MAX == 0x7FFFFFFF` there. The entire valid Unicode code-point
+ * space U+0000..U+10FFFF lies well below this cutoff, so the guard never rejects
+ * legal Unicode; it only filters out non-Unicode bit patterns that a caller may
+ * have reinterpreted as `char32_t`. Callers that intentionally pass arbitrary
+ * 32-bit integers through a `char32_t` channel should not rely on
+ * `out_of_wchar_range` as a Unicode-validity check.
+ *
+ * `CharT` is constrained to the five standard C++ character types so
+ * that misuse with non-character integral or floating types (where
+ * the `wchar_t`-range question is meaningless) fails at compile time
+ * instead of silently returning `false`.
+ * @endif
+ *
+ * @tparam CharT
+ * @lang{ZH}
+ * 字符类型，须为 `char`、`wchar_t`、`char8_t`、`char16_t` 或 `char32_t` 之一。
+ * @endif
+ * @lang{EN}
+ * The character type; must be one of `char`, `wchar_t`, `char8_t`, `char16_t`,
+ * or `char32_t`.
+ * @endif
+ *
+ * @param c
+ * @lang{ZH} 要检测的字符值。 @endif
+ * @lang{EN} The character value to test. @endif
+ *
+ * @return
+ * @lang{ZH}
+ * 若 `c` 无法以 `wchar_t` 表示则返回 `true`；否则返回 `false`。
+ * 对 `char32_t` 之外的所有字符类型始终返回 `false`。
+ * @endif
+ * @lang{EN}
+ * `true` if `c` cannot be represented as `wchar_t`; `false` otherwise.
+ * Always returns `false` for every character type other than `char32_t`.
+ * @endif
+ */
 template <typename CharT>
     requires std::is_same_v<CharT, char>     ||
              std::is_same_v<CharT, wchar_t>  ||

--- a/include/facet/facet_helper.h
+++ b/include/facet/facet_helper.h
@@ -1,3 +1,36 @@
+/**
+ * @file facet_helper.h
+ * @lang{ZH}
+ * facet 实现层共用的内部辅助工具集。
+ *
+ * 本文件提供以下辅助函数，供各 facet 具体实现（如 `numpunct`、`moneypunct` 等）内部使用：
+ * - `string_to_char_convert`：将窄字符串的首字符转换为 `char`，用于读取 `lconv` /
+ *   `nl_langinfo()` 中表示单个用户可见字符的字段。
+ * - `string_to_widechar_convert`：将窄字符串的首字符转换为宽字符 `CharT`，适用场景同上。
+ * - `add_grouping`：在字符序列中按分组规则插入分隔符，用于数字格式化输出。
+ * - `adjust_grouping`：将原始 POSIX 风格的分组向量规范化为内部约定格式。
+ * - `verify_grouping`：验证已解析的分组序列是否符合 `numpunct::grouping` 的规定。
+ * @endif
+ *
+ * @lang{EN}
+ * Internal utility helpers shared across facet implementations.
+ *
+ * This file provides the following helper functions for use by concrete facet
+ * implementations (e.g. `numpunct`, `moneypunct`):
+ * - `string_to_char_convert`: Converts the first character of a narrow string to
+ *   `char`, for reading `lconv` / `nl_langinfo()` fields that represent a single
+ *   user-visible character.
+ * - `string_to_widechar_convert`: Converts the first character of a narrow string to
+ *   a wide character `CharT`; applicable in the same contexts.
+ * - `add_grouping`: Inserts grouping separators into a character sequence for
+ *   formatted numeric output.
+ * - `adjust_grouping`: Normalizes a raw POSIX-style grouping vector to the internal
+ *   convention.
+ * - `verify_grouping`: Validates a parsed grouping sequence against the
+ *   `numpunct::grouping` specification.
+ * @endif
+ */
+
 #pragma once
 #include <common/clocale_wrapper.h>
 #include <cvt/cvt_facilities.h>
@@ -16,21 +49,57 @@
 
 namespace IOv2::FacetHelper
 {
-    // Convert the first character of a (possibly multibyte) narrow string
-    // `narrow` to a `char` in the given locale, returning '\0' if `narrow`
-    // is empty or conversion is not representable.
-    //
-    // Suitable for fields read out of `lconv` / `nl_langinfo()` that
-    // semantically represent a single user-visible character (e.g.
-    // decimal_point, thousands_sep, mon_decimal_point, mon_thousands_sep).
-    //
-    // Why `const std::string&` and not `const char*`: `lconv*` and
-    // `nl_langinfo()` pointers may be invalidated by any setlocale() /
-    // uselocale() call. The conversion below transitively performs such
-    // calls (via detail::to_wstring), so the input must be a caller-owned
-    // snapshot rather than a borrowed pointer into the libc-owned locale
-    // data. Taking std::string makes this contract unmissable at every
-    // call site.
+    /**
+     * @lang{ZH}
+     * 将（可能是多字节的）窄字符串 `narrow` 的第一个字符转换为给定 locale 下的 `char`，
+     * 若 `narrow` 为空或转换结果不可表示则返回 `'\0'`。
+     *
+     * 适用于从 `lconv` / `nl_langinfo()` 读出的、语义上表示单个用户可见字符的字段
+     * （例如 `decimal_point`、`thousands_sep`、`mon_decimal_point`、`mon_thousands_sep`）。
+     *
+     * @par 为何使用 `const std::string&` 而非 `const char*`
+     * `lconv*` 和 `nl_langinfo()` 返回的指针可能被任何 `setlocale()` / `uselocale()` 调用所失效。
+     * 下方转换过程会经由 `detail::to_wstring` 间接执行此类调用，因此输入必须是调用方
+     * 持有的快照，而非指向 libc 所有 locale 数据的借用指针。
+     * 使用 `std::string` 使这一契约在每个调用处都无法忽视。
+     * @endif
+     *
+     * @lang{EN}
+     * Convert the first character of a (possibly multibyte) narrow string
+     * `narrow` to a `char` in the given locale, returning `'\0'` if `narrow`
+     * is empty or conversion is not representable.
+     *
+     * Suitable for fields read out of `lconv` / `nl_langinfo()` that
+     * semantically represent a single user-visible character (e.g.
+     * `decimal_point`, `thousands_sep`, `mon_decimal_point`, `mon_thousands_sep`).
+     *
+     * @par Why `const std::string&` and not `const char*`
+     * `lconv*` and `nl_langinfo()` pointers may be invalidated by any `setlocale()` /
+     * `uselocale()` call. The conversion below transitively performs such
+     * calls (via `detail::to_wstring`), so the input must be a caller-owned
+     * snapshot rather than a borrowed pointer into the libc-owned locale
+     * data. Taking `std::string` makes this contract unmissable at every
+     * call site.
+     * @endif
+     *
+     * @param narrow
+     * @lang{ZH} 待转换的（可能是多字节的）窄字符串。 @endif
+     * @lang{EN} The (possibly multibyte) narrow string to convert. @endif
+     *
+     * @param locale_name
+     * @lang{ZH} 执行转换所使用的 locale 名称。 @endif
+     * @lang{EN} The locale name under which to perform the conversion. @endif
+     *
+     * @return
+     * @lang{ZH}
+     * `narrow` 在给定 locale 下首字符对应的 `char`；若 `narrow` 为空或转换结果不可表示
+     * 则返回 `'\0'`。
+     * @endif
+     * @lang{EN}
+     * The first character of `narrow` converted to `char` in the given locale;
+     * `'\0'` if `narrow` is empty or the conversion is not representable.
+     * @endif
+     */
     inline char string_to_char_convert(const std::string& narrow,
                                        const std::string& locale_name)
     {
@@ -54,33 +123,92 @@ namespace IOv2::FacetHelper
         return c == EOF ? '\0' : static_cast<char>(c);
     }
 
-    // Convert the first character of a (possibly multibyte) narrow string
-    // `narrow` to a wide character `CharT` in the given locale, returning
-    // `default_char` when `narrow` is empty or conversion produces no
-    // characters.
-    //
-    // Suitable for fields read out of `lconv` / `nl_langinfo()` that
-    // semantically represent a single user-visible character (e.g.
-    // decimal_point, thousands_sep, mon_decimal_point, mon_thousands_sep).
-    //
-    // `default_char` contract: returned verbatim on the empty-input and
-    // empty-conversion paths; this function does NOT validate that
-    // `default_char` is itself representable, well-formed, or otherwise
-    // meaningful under `locale_name`. Callers are responsible for choosing a
-    // sensible fallback (typically a plain ASCII-range value such as L' ',
-    // L'.', U' ', or U'.'). Note the asymmetry with `string_to_char_convert`,
-    // which uses a hard-coded `'\0'` fallback and accepts no caller default:
-    // here the fallback is a parameter precisely so callers can pick a
-    // locale-appropriate substitute, but the price is that validation is
-    // their responsibility, not ours.
-    //
-    // Why `const std::string&` and not `const char*`: `lconv*` and
-    // `nl_langinfo()` pointers may be invalidated by any setlocale() /
-    // uselocale() call. The conversion below transitively performs such
-    // calls (via detail::to_wstring/to_u32string), so the input must be a
-    // caller-owned snapshot rather than a borrowed pointer into the
-    // libc-owned locale data. Taking std::string makes this contract
-    // unmissable at every call site.
+    /**
+     * @lang{ZH}
+     * 将（可能是多字节的）窄字符串 `narrow` 的第一个字符转换为给定 locale 下的宽字符
+     * `CharT`，若 `narrow` 为空或转换结果不含字符则返回 `default_char`。
+     *
+     * 适用于从 `lconv` / `nl_langinfo()` 读出的、语义上表示单个用户可见字符的字段
+     * （例如 `decimal_point`、`thousands_sep`、`mon_decimal_point`、`mon_thousands_sep`）。
+     *
+     * @par `default_char` 契约
+     * 在输入为空或转换结果为空的路径上原样返回；本函数**不**验证 `default_char` 本身
+     * 在 `locale_name` 下是否可表示、格式是否正确或是否有意义。调用方负责选择合理的
+     * 回退值（通常为 ASCII 范围内的普通字符，如 `L' '`、`L'.'`、`U' '`、`U'.'`）。
+     * 注意与 `string_to_char_convert` 的不对称性：后者使用硬编码的 `'\0'` 回退且不接受
+     * 调用方自定义；本函数将回退值作为参数，目的是让调用方可以选择适合 locale 的替代字符，
+     * 但代价是验证责任由调用方自行承担。
+     *
+     * @par 为何使用 `const std::string&` 而非 `const char*`
+     * `lconv*` 和 `nl_langinfo()` 返回的指针可能被任何 `setlocale()` / `uselocale()` 调用
+     * 所失效。下方转换过程会经由 `detail::to_wstring`/`to_u32string` 间接执行此类调用，
+     * 因此输入必须是调用方持有的快照，而非指向 libc 所有 locale 数据的借用指针。
+     * @endif
+     *
+     * @lang{EN}
+     * Convert the first character of a (possibly multibyte) narrow string
+     * `narrow` to a wide character `CharT` in the given locale, returning
+     * `default_char` when `narrow` is empty or conversion produces no
+     * characters.
+     *
+     * Suitable for fields read out of `lconv` / `nl_langinfo()` that
+     * semantically represent a single user-visible character (e.g.
+     * `decimal_point`, `thousands_sep`, `mon_decimal_point`, `mon_thousands_sep`).
+     *
+     * @par `default_char` contract
+     * Returned verbatim on the empty-input and empty-conversion paths; this
+     * function does NOT validate that `default_char` is itself representable,
+     * well-formed, or otherwise meaningful under `locale_name`. Callers are
+     * responsible for choosing a sensible fallback (typically a plain ASCII-range
+     * value such as `L' '`, `L'.'`, `U' '`, or `U'.'`). Note the asymmetry with
+     * `string_to_char_convert`, which uses a hard-coded `'\0'` fallback and accepts
+     * no caller default: here the fallback is a parameter precisely so callers can
+     * pick a locale-appropriate substitute, but the price is that validation is
+     * their responsibility, not ours.
+     *
+     * @par Why `const std::string&` and not `const char*`
+     * `lconv*` and `nl_langinfo()` pointers may be invalidated by any `setlocale()` /
+     * `uselocale()` call. The conversion below transitively performs such calls
+     * (via `detail::to_wstring`/`to_u32string`), so the input must be a
+     * caller-owned snapshot rather than a borrowed pointer into the
+     * libc-owned locale data. Taking `std::string` makes this contract
+     * unmissable at every call site.
+     * @endif
+     *
+     * @tparam CharT
+     * @lang{ZH}
+     * 目标宽字符类型。须为 `wchar_t`，或在 `char32_t` 与 `wchar_t` 等价的平台上为
+     * `char32_t`（由 `requires` 子句在编译期强制验证）。
+     * @endif
+     * @lang{EN}
+     * The target wide character type. Must be `wchar_t`, or `char32_t` on platforms
+     * where `char32_t` and `wchar_t` are equivalent (enforced at compile time by the
+     * `requires` clause).
+     * @endif
+     *
+     * @param narrow
+     * @lang{ZH} 待转换的（可能是多字节的）窄字符串。 @endif
+     * @lang{EN} The (possibly multibyte) narrow string to convert. @endif
+     *
+     * @param locale_name
+     * @lang{ZH} 执行转换所使用的 locale 名称。 @endif
+     * @lang{EN} The locale name under which to perform the conversion. @endif
+     *
+     * @param default_char
+     * @lang{ZH} 当 `narrow` 为空或转换结果不含字符时返回的回退值。 @endif
+     * @lang{EN} The fallback value returned when `narrow` is empty or conversion
+     * produces no characters. @endif
+     *
+     * @return
+     * @lang{ZH}
+     * `narrow` 在给定 locale 下首字符对应的 `CharT`；若 `narrow` 为空或转换结果不含
+     * 字符则返回 `default_char`。
+     * @endif
+     * @lang{EN}
+     * The first character of `narrow` converted to `CharT` in the given locale;
+     * `default_char` if `narrow` is empty or conversion produces no characters.
+     * @endif
+     */
     template <typename CharT>
         requires std::is_same_v<CharT, wchar_t> ||
             (std::is_same_v<CharT, char32_t> &&
@@ -104,17 +232,71 @@ namespace IOv2::FacetHelper
         }
     }
 
-    // Internal helper function.
-    //
-    // Preconditions:
-    //   - `grouping` is non-empty. [asserted in debug builds]
-    //   - `[first, last)` is a valid range, i.e. `first <= last`. Passing
-    //     `first > last` causes the inner copy loop to never terminate and
-    //     write past the output buffer. [asserted in debug builds]
-    //   - `s` points to an output buffer with sufficient capacity to hold
-    //     `(last - first)` characters plus one separator per non-leading
-    //     group; callers are responsible for sizing the buffer.
-    //     [not validated]
+    /**
+     * @lang{ZH}
+     * 在字符序列 `[first, last)` 中按 `grouping` 规则插入分组分隔符 `sep`，将结果写入
+     * 以 `s` 为起点的输出缓冲区，并返回写入结束位置的指针。
+     *
+     * @par 前置条件
+     * - `grouping` 非空（Debug 模式下通过 `assert` 验证）。
+     * - `[first, last)` 为合法区间，即 `first <= last`（Debug 模式下通过 `assert` 验证；
+     *   若 `first > last`，内部复制循环将永不终止并越界写入输出缓冲区）。
+     * - `s` 指向的输出缓冲区容量足以容纳 `(last - first)` 个字符加上每个非前导分组对应
+     *   的一个分隔符；缓冲区大小由调用方负责保证（不做运行时验证）。
+     * @endif
+     *
+     * @lang{EN}
+     * Insert grouping separators `sep` into the character sequence `[first, last)`
+     * according to `grouping`, write the result into the output buffer starting at
+     * `s`, and return a pointer one past the last element written.
+     *
+     * @par Preconditions
+     * - `grouping` is non-empty. [asserted in debug builds]
+     * - `[first, last)` is a valid range, i.e. `first <= last`. Passing
+     *   `first > last` causes the inner copy loop to never terminate and
+     *   write past the output buffer. [asserted in debug builds]
+     * - `s` points to an output buffer with sufficient capacity to hold
+     *   `(last - first)` characters plus one separator per non-leading
+     *   group; callers are responsible for sizing the buffer.
+     *   [not validated]
+     * @endif
+     *
+     * @tparam CharT
+     * @lang{ZH} 序列元素及分隔符的字符类型。 @endif
+     * @lang{EN} The character type of the sequence elements and separator. @endif
+     *
+     * @param s
+     * @lang{ZH} 指向输出缓冲区起始位置的指针。 @endif
+     * @lang{EN} Pointer to the start of the output buffer. @endif
+     *
+     * @param sep
+     * @lang{ZH} 插入到各分组之间的分隔符字符。 @endif
+     * @lang{EN} The separator character to insert between groups. @endif
+     *
+     * @param grouping
+     * @lang{ZH}
+     * 使用 `adjust_grouping()` 建立的内部 `uint8_t` 约定表示的分组规格：
+     * 1–255 为显式分组大小，0 为唯一停止哨兵，最后一个 1–255 元素对所有后续分组隐式重复。
+     * @endif
+     * @lang{EN}
+     * The grouping specification using the internal `uint8_t` convention established
+     * by `adjust_grouping()`: 1–255 are explicit group sizes, 0 is the sole stop
+     * sentinel, and the last 1–255 element is implicitly repeated for all remaining
+     * groups.
+     * @endif
+     *
+     * @param first
+     * @lang{ZH} 输入字符序列的起始指针。 @endif
+     * @lang{EN} Pointer to the start of the input character sequence. @endif
+     *
+     * @param last
+     * @lang{ZH} 输入字符序列的末尾指针（独占上界）。 @endif
+     * @lang{EN} Pointer to one past the end of the input character sequence. @endif
+     *
+     * @return
+     * @lang{ZH} 指向写入输出缓冲区最后一个元素之后位置的指针。 @endif
+     * @lang{EN} Pointer to one past the last element written into `s`. @endif
+     */
     template <typename CharT>
     inline CharT* add_grouping(CharT* s, CharT sep, const std::vector<uint8_t>& grouping,
                                const CharT* first, const CharT* last)
@@ -154,28 +336,53 @@ namespace IOv2::FacetHelper
         return s;
     }
 
-    // Normalise a raw POSIX-style grouping vector to the internal convention,
-    // or discard it if it carries no usable constraint.
-    //
-    // Internal convention (uint8_t, platform-independent):
-    //   1–255 — explicit group size.
-    //   0     — stop: no further grouping after this point (the ONLY sentinel).
-    //   The LAST element (if in 1–255) is implicitly repeated for all
-    //   remaining groups. If the last element is 0, the explicit stop wins.
-    //
-    // Conversions applied to raw POSIX input:
-    //   - POSIX "0 = repeat previous": the 0 and everything after it is
-    //     dropped. POSIX [N1, ..., Nk, 0, ...] becomes [N1, ..., Nk] in our
-    //     convention, because last-element implicit repeat already covers
-    //     that semantic exactly.
-    //   - POSIX CHAR_MAX (= stop): rewritten to internal 0. CHAR_MAX is 127
-    //     on signed-char platforms and 255 on unsigned-char platforms;
-    //     callers do not need to know the platform's char signedness after
-    //     this step.
-    //
-    // Order matters: stripping POSIX "0 = repeat" MUST happen before
-    // CHAR_MAX → 0 rewrite, otherwise our newly-introduced internal stop
-    // would be mistaken for a POSIX repeat-previous marker and dropped.
+    /**
+     * @lang{ZH}
+     * 将原始 POSIX 风格的分组向量原地规范化为内部约定格式；若向量不含可用约束则将其清空。
+     *
+     * @par 内部约定（`uint8_t`，平台无关）
+     * - 1–255：显式分组大小。
+     * - 0：停止标志——此点之后不再分组（**唯一**哨兵值）。
+     * - 若最后一个元素为 1–255，则对所有后续分组隐式重复；若最后一个元素为 0，则显式停止优先。
+     *
+     * @par 对原始 POSIX 输入所做的转换
+     * - **POSIX "0 = 重复前一分组"**：将 0 及其后的所有元素丢弃。POSIX 格式
+     *   `[N1, ..., Nk, 0, ...]` 在本约定中变为 `[N1, ..., Nk]`，因为最后一个元素的
+     *   隐式重复语义已完全覆盖该情形。
+     * - **POSIX `CHAR_MAX`（= 停止）**：改写为内部 0。`CHAR_MAX` 在有符号 `char` 平台上
+     *   为 127，在无符号 `char` 平台上为 255；经此步骤后调用方无需关心平台的 `char` 符号性。
+     *
+     * @note **顺序至关重要**：必须先去除 POSIX "0 = 重复" 标记，再执行 `CHAR_MAX → 0` 改写，
+     * 否则新引入的内部停止哨兵会被误认为 POSIX 重复标记而被丢弃。
+     * @endif
+     *
+     * @lang{EN}
+     * Normalise a raw POSIX-style grouping vector in-place to the internal convention,
+     * or clear it if it carries no usable constraint.
+     *
+     * @par Internal convention (`uint8_t`, platform-independent)
+     * - 1–255: explicit group size.
+     * - 0: stop — no further grouping after this point (the ONLY sentinel).
+     * - The LAST element (if in 1–255) is implicitly repeated for all remaining groups.
+     *   If the last element is 0, the explicit stop wins.
+     *
+     * @par Conversions applied to raw POSIX input
+     * - **POSIX "0 = repeat previous"**: the 0 and everything after it is dropped.
+     *   POSIX `[N1, ..., Nk, 0, ...]` becomes `[N1, ..., Nk]` in our convention,
+     *   because last-element implicit repeat already covers that semantic exactly.
+     * - **POSIX `CHAR_MAX` (= stop)**: rewritten to internal 0. `CHAR_MAX` is 127
+     *   on signed-char platforms and 255 on unsigned-char platforms; callers do not
+     *   need to know the platform's char signedness after this step.
+     *
+     * @note **Order matters**: stripping POSIX "0 = repeat" MUST happen before
+     * the `CHAR_MAX → 0` rewrite, otherwise the newly-introduced internal stop
+     * sentinel would be mistaken for a POSIX repeat-previous marker and dropped.
+     * @endif
+     *
+     * @param grouping
+     * @lang{ZH} 待原地规范化的原始 POSIX 分组向量。 @endif
+     * @lang{EN} The raw POSIX grouping vector to normalize in place. @endif
+     */
     inline void adjust_grouping(std::vector<uint8_t>& grouping)
     {
         // Step 1: POSIX "0 = repeat previous" → drop the 0 and the tail.
@@ -207,19 +414,52 @@ namespace IOv2::FacetHelper
         }
     }
 
-    // Internal helper function. Callers are responsible for ensuring that both
-    // grouping and grouping_tmp are non-empty; non-emptiness is validated only
-    // by assert() in debug builds, release builds rely on the caller. Violating
-    // the precondition in release causes `size() - 1` to underflow to SIZE_MAX
-    // and subsequent indexing to read out of bounds. Callers guarantee grouping
-    // is non-empty because grouping_tmp is only populated inside
-    // !grouping.empty() branches, so the non-emptiness of grouping_tmp implies
-    // the non-emptiness of grouping.
-    //
-    // grouping uses the internal uint8_t convention established by
-    // adjust_grouping(): 1–255 are explicit group sizes, 0 is the sole
-    // "stop" sentinel, and the last 1–255 element is implicitly repeated
-    // for all remaining groups.
+    /**
+     * @lang{ZH}
+     * 验证已解析的分组序列 `grouping_tmp` 是否符合 `numpunct::grouping` 所规定的
+     * `grouping` 约束。
+     *
+     * @par 前置条件
+     * `grouping` 和 `grouping_tmp` 均非空；仅在 Debug 模式下通过 `assert` 验证，Release
+     * 模式下由调用方保证。违反该前置条件将导致 `size() - 1` 下溢为 `SIZE_MAX`，后续索引
+     * 越界读取。调用方可保证非空性，因为 `grouping_tmp` 仅在 `!grouping.empty()` 分支内
+     * 填充，故 `grouping_tmp` 非空蕴含 `grouping` 非空。
+     *
+     * `grouping` 使用由 `adjust_grouping()` 建立的内部 `uint8_t` 约定：1–255 为显式分组
+     * 大小，0 为唯一停止哨兵，最后一个 1–255 元素对所有后续分组隐式重复。
+     * @endif
+     *
+     * @lang{EN}
+     * Verify whether the parsed grouping sequence `grouping_tmp` conforms to the
+     * `numpunct::grouping` constraint specified by `grouping`.
+     *
+     * @par Preconditions
+     * Both `grouping` and `grouping_tmp` must be non-empty; non-emptiness is validated
+     * only by `assert()` in debug builds; release builds rely on the caller. Violating
+     * the precondition in release causes `size() - 1` to underflow to `SIZE_MAX` and
+     * subsequent indexing to read out of bounds. Callers guarantee non-emptiness because
+     * `grouping_tmp` is only populated inside `!grouping.empty()` branches, so the
+     * non-emptiness of `grouping_tmp` implies the non-emptiness of `grouping`.
+     *
+     * `grouping` uses the internal `uint8_t` convention established by
+     * `adjust_grouping()`: 1–255 are explicit group sizes, 0 is the sole stop
+     * sentinel, and the last 1–255 element is implicitly repeated for all remaining
+     * groups.
+     * @endif
+     *
+     * @param grouping
+     * @lang{ZH} 参考分组规格（来自 `numpunct::grouping`），使用内部 `uint8_t` 约定。 @endif
+     * @lang{EN} The reference grouping specification (from `numpunct::grouping`),
+     * using the internal `uint8_t` convention. @endif
+     *
+     * @param grouping_tmp
+     * @lang{ZH} 解析过程中实际观测到的各分组大小序列。 @endif
+     * @lang{EN} The grouping sizes actually observed during parsing. @endif
+     *
+     * @return
+     * @lang{ZH} 若 `grouping_tmp` 符合 `grouping` 的约束则返回 `true`；否则返回 `false`。 @endif
+     * @lang{EN} `true` if `grouping_tmp` conforms to `grouping`; `false` otherwise. @endif
+     */
     inline bool verify_grouping(const std::vector<uint8_t>& grouping,
                                 const std::vector<uint8_t>& grouping_tmp)
     {


### PR DESCRIPTION
Add @lang{ZH}/@lang{EN} bilingual Doxygen documentation to four facet headers, following the same commenting convention established in include/cvt/abs_cvt.h.

- facet_common.h: document abs_ft, base_ft, ft_basic, facet_create_rule/ pack/size traits, facet_create_pack_head/tail, and out_of_wchar_range. Convert all existing // block comments to /** */ Doxygen format while preserving content.

- facet_helper.h: document string_to_char_convert, string_to_widechar_ convert, add_grouping, adjust_grouping, and verify_grouping, including @par sections for design rationale, preconditions, and internal conventions. Convert all existing // block comments.

- ctype_details.h: document base_ft<ctype> and its mask constants, ctype_conf<char>, ctype_conf<wchar_t/char32_t>, and ctype_conf<char8_t>, including @attention for mask-bit update checklist, @note for wctob locale side-effect, and @tparam for constrained templates.

- ctype.h: document detail::ctype_ops and its nine methods, both ctype<CharT> specialisations with @par sections for asymmetry/thread- safety/self-consistency contracts, and the CTAD deduction guide. Convert the LRU cache removal rationale to a @note on do_is.