### PR TITLE
fix(facet): harden numeric/collate facets and dedup platform guard

### DIFF
--- a/include/common/metafunctions.h
+++ b/include/common/metafunctions.h
@@ -79,6 +79,36 @@ namespace IOv2
 
     /**
      * @lang{ZH}
+     * 判断当前平台的 wchar_t 是否为 UTF-32 编码单元。
+     *
+     * 当且仅当 wchar_t 与 char32_t 等宽、且二者对同一字符的编码一致时为 true
+     * （借助两个中文字符在编译期校验）。在 glibc/Linux 上为 true；在 wchar_t
+     * 为 16 位 UTF-16 的平台（如 MSVC）上为 false。
+     *
+     * 涉及 char32_t / char8_t 的宽字符处理路径依赖此前提：它们把数据当作 wchar_t
+     * 序列交给 wcsxfrm / wcscoll 等 C 库函数，从而复用 wchar_t 的本地化能力。
+     * @endif
+     *
+     * @lang{EN}
+     * Whether this platform's wchar_t is a UTF-32 code unit.
+     *
+     * True iff wchar_t has the same width as char32_t and the two agree on the
+     * encoding of the same character (verified at compile time via two CJK
+     * characters). True on glibc/Linux; false where wchar_t is a 16-bit UTF-16
+     * code unit (e.g. MSVC).
+     *
+     * char32_t / char8_t wide-character paths rely on this assumption: they
+     * hand the data to C library functions such as wcsxfrm / wcscoll as if it
+     * were a wchar_t sequence, thereby reusing wchar_t's localization facilities.
+     * @endif
+     */
+    inline constexpr bool wchar_t_is_utf32 =
+        (sizeof(char32_t) == sizeof(wchar_t)) &&
+        (static_cast<wchar_t>(U'李') == L'李') &&
+        (static_cast<char32_t>(L'伟') == U'伟');
+
+    /**
+     * @lang{ZH}
      * shared_ptr_to 概念的实现辅助结构。
      * @endif
      *

--- a/include/cvt/code_cvt.h
+++ b/include/cvt/code_cvt.h
@@ -26,6 +26,7 @@
 #pragma once
 #include <common/clocale_wrapper.h>
 #include <common/defs.h>
+#include <common/metafunctions.h>
 #include <cvt/abs_cvt.h>
 #include <cvt/cvt_concepts.h>
 
@@ -93,9 +94,7 @@ struct codecvt_kernel;
 template <typename TInt>
     requires std::is_same_v<TInt, wchar_t> ||
                 (std::is_same_v<TInt, char32_t> &&
-                 (sizeof(char32_t) == sizeof(wchar_t)) &&
-                 (static_cast<wchar_t>(U'李') == L'李') &&
-                 (static_cast<char32_t>(L'伟') == U'伟'))
+                 wchar_t_is_utf32)
 struct codecvt_kernel<char, TInt>
 {
     static_assert(MB_LEN_MAX <= std::numeric_limits<unsigned>::max(),
@@ -400,9 +399,7 @@ private:
 template <typename TInt>
     requires std::is_same_v<TInt, char32_t> ||
                 (std::is_same_v<TInt, wchar_t> &&
-                 (sizeof(char32_t) == sizeof(wchar_t)) &&
-                 (static_cast<wchar_t>(U'李') == L'李') &&
-                 (static_cast<char32_t>(L'伟') == U'伟'))
+                 wchar_t_is_utf32)
 struct codecvt_kernel<char8_t, TInt>
 {
     codecvt_kernel() = default;
@@ -1207,9 +1204,7 @@ class code_cvt_creator;
 template <typename TInt>
     requires std::is_same_v<TInt, wchar_t> ||
                 (std::is_same_v<TInt, char32_t> &&
-                 (sizeof(char32_t) == sizeof(wchar_t)) &&
-                 (static_cast<wchar_t>(U'李') == L'李') &&
-                 (static_cast<char32_t>(L'伟') == U'伟'))
+                 wchar_t_is_utf32)
 class code_cvt_creator<char, TInt>
 {
 public:
@@ -1279,9 +1274,7 @@ private:
 template <typename TInt>
     requires std::is_same_v<TInt, char32_t> ||
                 (std::is_same_v<TInt, wchar_t> &&
-                 (sizeof(char32_t) == sizeof(wchar_t)) &&
-                 (static_cast<wchar_t>(U'李') == L'李') &&
-                 (static_cast<char32_t>(L'伟') == U'伟'))
+                 wchar_t_is_utf32)
 class code_cvt_creator<char8_t, TInt>
 {
 public:

--- a/include/facet/collate.h
+++ b/include/facet/collate.h
@@ -1,8 +1,8 @@
 #pragma once
-#include <memory>
-
 #include <common/metafunctions.h>
 #include <facet/collate_details.h>
+
+#include <memory>
 
 namespace IOv2
 {
@@ -24,14 +24,13 @@ public:
     {
         return m_obj->compare(low1, high1, low2, high2);
     }
-    
+
     template <typename TIter>
         requires (!std::is_convertible_v<TIter, const CharT*>)
     std::strong_ordering compare(const CharT* low1, const CharT* high1, TIter low2, TIter high2) const
     {
-        std::vector<CharT> buf1;
         std::vector<CharT> buf2; buf2.reserve(64);
-        
+
         while ((low1 != high1) && (low2 != high2))
         {
             std::strong_ordering c_res = std::strong_ordering::equal;
@@ -53,12 +52,12 @@ public:
             if (c_res != std::strong_ordering::equal)
                 return c_res;
         }
-        
+
         if (low1 != high1) return std::strong_ordering::greater;
         if (low2 != high2) return std::strong_ordering::less;
         return std::strong_ordering::equal;
     }
-    
+
     template <typename TIter>
         requires (!std::is_convertible_v<TIter, const CharT*>)
     std::strong_ordering compare(TIter low1, TIter high1, const CharT* low2, const CharT* high2) const
@@ -68,42 +67,42 @@ public:
         if (res == std::strong_ordering::less) return std::strong_ordering::greater;
         return res;
     }
-    
+
     template <typename TIter1, typename TIter2>
         requires (!(std::is_convertible_v<TIter1, const CharT*> || std::is_convertible_v<TIter2, const CharT*>))
     std::strong_ordering compare(TIter1 low1, TIter1 high1, TIter2 low2, TIter2 high2) const
     {
         std::vector<CharT> buf1; buf1.reserve(64);
         std::vector<CharT> buf2; buf2.reserve(64);
-        
+
         while ((low1 != high1) && (low2 != high2))
         {
             low1 = data_to_vec(low1, high1, buf1);
             low2 = data_to_vec(low2, high2, buf2);
-            
+
             auto c_res = m_obj->compare(buf1.data(), buf1.data() + buf1.size(), buf2.data(), buf2.data() + buf2.size());
-            
+
             if (c_res != std::strong_ordering::equal)
                 return c_res;
         }
-        
+
         if (low1 != high1) return std::strong_ordering::greater;
         if (low2 != high2) return std::strong_ordering::less;
         return std::strong_ordering::equal;
     }
-    
+
     size_t transform_length(const CharT* low, const CharT* high) const
     {
         return m_obj->transform_length(low, high);
     }
-    
+
     template <typename TIter>
         requires (!std::is_convertible_v<TIter, const CharT*>)
     size_t transform_length(TIter low, TIter high) const
     {
         size_t res = 0;
         std::vector<CharT> buf; buf.reserve(64);
-        
+
         while (low != high)
         {
             low = data_to_vec(low, high, buf);
@@ -111,13 +110,13 @@ public:
         }
         return res;
     }
-    
+
     std::pair<CharT*, size_t> transform(const CharT* low, const CharT* high, CharT* dest, size_t mx_len = 0) const
     {
         auto s = m_obj->transform(low, high, dest, mx_len);
         return std::pair{dest + s, s};
     }
-    
+
     template <typename TIter>
         requires (!std::is_convertible_v<TIter, const CharT*>)
     std::pair <CharT*, size_t> transform(TIter low, TIter high, CharT* dest, size_t mx_len = 0) const
@@ -129,7 +128,7 @@ public:
         {
             low = data_to_vec(low, high, buf);
             size_t cur_trans = 0;
-            
+
             if (mx_len == 0)
                 cur_trans = m_obj->transform(buf.data(), buf.data() + buf.size(), dest);
             else
@@ -139,7 +138,7 @@ public:
         }
         return std::pair(dest, trans_count);
     }
-    
+
     template <typename TIter>
         requires (!std::is_convertible_v<TIter, CharT*>)
     std::pair<TIter, size_t> transform(const CharT* low, const CharT* high, TIter dest, size_t mx_len = 0) const
@@ -182,7 +181,7 @@ public:
         }
         return std::pair(dest, trans_count);
     }
-    
+
     template <typename TIterIn, typename TIterOut>
         requires (!(std::is_convertible_v<TIterIn, const CharT*> || std::is_convertible_v<TIterOut, CharT*>))
     std::pair <TIterOut, size_t> transform(TIterIn low, TIterIn high, TIterOut dest, size_t mx_len = 0) const
@@ -190,15 +189,15 @@ public:
         size_t trans_count = 0;
         std::vector<CharT> buf; buf.reserve(64);
         std::vector<CharT> buf2;
-        
+
         while ((low != high) && ((mx_len == 0) || (trans_count < mx_len)))
         {
             low = data_to_vec(low, high, buf);
-            
+
             size_t cur_trans = m_obj->transform_length(buf.data(), buf.data() + buf.size());
             buf2.resize(cur_trans);
             buf2.resize(m_obj->transform(buf.data(), buf.data() + buf.size(), buf2.data(), buf2.size()));
-            
+
             if (mx_len == 0)
             {
                 dest = std::copy(buf2.begin(), buf2.end(), dest);

--- a/include/facet/collate_details.h
+++ b/include/facet/collate_details.h
@@ -1,15 +1,15 @@
 #pragma once
-#include <langinfo.h>
-
-#include <algorithm>
-#include <cstring>
-#include <vector>
-
 #include <common/clocale_wrapper.h>
 #include <common/defs.h>
 #include <common/metafunctions.h>
 #include <cvt/cvt_facilities.h>
 #include <facet/facet_common.h>
+
+#include <algorithm>
+#include <cstring>
+#include <vector>
+
+#include <langinfo.h>
 
 namespace IOv2
 {
@@ -30,9 +30,9 @@ public:
     {
         std::vector<CharT> buf1; bool extra_eos1 = false;
         std::vector<CharT> buf2; bool extra_eos2 = false;
-        
+
         clocale_user guard(m_inter_locale);
-        
+
         while ((low1 != high1) && (low2 != high2))
         {
             const CharT* cl1 = low1;
@@ -49,7 +49,7 @@ public:
                 low1 = high1;
             }
             else low1 = ch1 + 1;
-            
+
             const CharT* cl2 = low2;
             auto ch2 = std::find(low2, high2, static_cast<CharT>(0));
             if (ch2 == high2)
@@ -64,15 +64,13 @@ public:
                 low2 = high2;
             }
             else low2 = ch2 + 1;
-            
+
             int c_res = 0;
             if constexpr (std::is_same_v<CharT, char>)
                 c_res = std::strcoll(cl1, cl2);
             else if constexpr (std::is_same_v<CharT, wchar_t>)
                 c_res = std::wcscoll(cl1, cl2);
-            else if constexpr ((sizeof(char32_t) == sizeof(wchar_t)) && 
-                               (static_cast<wchar_t>(U'李') == L'李') &&
-                               (static_cast<char32_t>(L'伟') == U'伟'))
+            else if constexpr (wchar_t_is_utf32)
             {
                 if constexpr (std::is_same_v<CharT, char32_t>)
                     c_res = std::wcscoll(reinterpret_cast<const wchar_t*>(cl1),
@@ -91,7 +89,7 @@ public:
             if (c_res < 0) return std::strong_ordering::less;
             if (c_res > 0) return std::strong_ordering::greater;
         }
-        
+
         if (low1 != high1) return std::strong_ordering::greater;
         if (low2 != high2) return std::strong_ordering::less;
         if (extra_eos1 && !extra_eos2) return std::strong_ordering::less;
@@ -103,7 +101,7 @@ public:
     {
         size_t res = 0;
         std::vector<CharT> buf;
-        
+
         clocale_user guard(m_inter_locale);
         while (low != high)
         {
@@ -127,9 +125,7 @@ public:
                 res += strxfrm(nullptr, cur, 0);
             else if constexpr (std::is_same_v<CharT, wchar_t>)
                 res += wcsxfrm(nullptr, cur, 0);
-            else if constexpr ((sizeof(char32_t) == sizeof(wchar_t)) && 
-                               (static_cast<wchar_t>(U'李') == L'李') &&
-                               (static_cast<char32_t>(L'伟') == U'伟'))
+            else if constexpr (wchar_t_is_utf32)
             {
                 if constexpr (std::is_same_v<CharT, char32_t>)
                     res += wcsxfrm(nullptr, reinterpret_cast<const wchar_t*>(cur), 0);
@@ -145,13 +141,13 @@ public:
 
         return res;
     };
-    
+
     virtual size_t transform(const CharT* low, const CharT* high, CharT* dest, size_t mx_len = 0) const
     {
         size_t trans_count = 0;
         std::vector<CharT> buf;
         bool extra_eos = false;
-        
+
         clocale_user guard(m_inter_locale);
         while ((low != high) && ((mx_len == 0) || (trans_count < mx_len)))
         {
@@ -169,20 +165,18 @@ public:
             else
                 low = next + 1;
 
-            if constexpr (std::is_same_v<CharT, char8_t> && 
-                          (sizeof(char32_t) == sizeof(wchar_t)) && 
-                          (static_cast<wchar_t>(U'李') == L'李') &&
-                          (static_cast<char32_t>(L'伟') == U'伟'))
+            if constexpr (std::is_same_v<CharT, char8_t> &&
+                          wchar_t_is_utf32)
             {
                 auto ws = detail::to_u32string(cur);
                 auto trans_len = wcsxfrm(nullptr, reinterpret_cast<const wchar_t*>(ws.c_str()), 0);
                 std::vector<char32_t> buf2;
                 buf2.resize(trans_len + 1);
-                auto cur_trans = wcsxfrm(reinterpret_cast<wchar_t*>(buf2.data()), 
+                auto cur_trans = wcsxfrm(reinterpret_cast<wchar_t*>(buf2.data()),
                                          reinterpret_cast<const wchar_t*>(ws.c_str()),
                                          static_cast<unsigned>(-1));
                 buf2[cur_trans] = 0;
-                
+
                 auto char8s = detail::to_u8string(buf2.data());
                 if (mx_len == 0)
                 {
@@ -203,14 +197,12 @@ public:
                     cur_trans = strxfrm(dest, cur, static_cast<unsigned>(-1));
                 else if constexpr (std::is_same_v<CharT, wchar_t>)
                     cur_trans = wcsxfrm(dest, cur, static_cast<unsigned>(-1));
-                else if constexpr ((std::is_same_v<CharT, char32_t> && 
-                                   (sizeof(char32_t) == sizeof(wchar_t)) && 
-                                   (static_cast<wchar_t>(U'李') == L'李') &&
-                                   (static_cast<char32_t>(L'伟') == U'伟')))
+                else if constexpr ((std::is_same_v<CharT, char32_t> &&
+                                   wchar_t_is_utf32))
                     cur_trans = wcsxfrm(reinterpret_cast<wchar_t*>(dest), reinterpret_cast<const wchar_t*>(cur), static_cast<unsigned>(-1));
                 else
                     static_assert(dependent_false_v<CharT>, "collate_conf::transform is not implemented.");
-                    
+
                 dest += cur_trans;
                 trans_count += cur_trans;
             }
@@ -221,14 +213,12 @@ public:
                     trans_len = strxfrm(nullptr, cur, 0);
                 else if constexpr (std::is_same_v<CharT, wchar_t>)
                     trans_len = wcsxfrm(nullptr, cur, 0);
-                else if constexpr ((std::is_same_v<CharT, char32_t> && 
-                                   (sizeof(char32_t) == sizeof(wchar_t)) && 
-                                   (static_cast<wchar_t>(U'李') == L'李') &&
-                                   (static_cast<char32_t>(L'伟') == U'伟')))
+                else if constexpr ((std::is_same_v<CharT, char32_t> &&
+                                   wchar_t_is_utf32))
                     trans_len = wcsxfrm(nullptr, reinterpret_cast<const wchar_t*>(cur), 0);
                 else
                     static_assert(dependent_false_v<CharT>, "collate_conf::transform is not implemented.");
-                    
+
                 std::vector<CharT> buf2;
                 buf2.resize(trans_len + 1);
 
@@ -237,14 +227,12 @@ public:
                     cur_trans = strxfrm(buf2.data(), cur, static_cast<unsigned>(-1));
                 else if constexpr (std::is_same_v<CharT, wchar_t>)
                     cur_trans = wcsxfrm(buf2.data(), cur, static_cast<unsigned>(-1));
-                else if constexpr ((std::is_same_v<CharT, char32_t> && 
-                                   (sizeof(char32_t) == sizeof(wchar_t)) && 
-                                   (static_cast<wchar_t>(U'李') == L'李') &&
-                                   (static_cast<char32_t>(L'伟') == U'伟')))
+                else if constexpr ((std::is_same_v<CharT, char32_t> &&
+                                   wchar_t_is_utf32))
                     cur_trans = wcsxfrm(reinterpret_cast<wchar_t*>(buf2.data()), reinterpret_cast<const wchar_t*>(cur), static_cast<unsigned>(-1));
                 else
                     static_assert(dependent_false_v<CharT>, "collate_conf::transform is not implemented.");
-                    
+
                 cur_trans = std::min(cur_trans, mx_len - trans_count);
                 dest = std::copy(buf2.data(), buf2.data() + cur_trans, dest);
                 trans_count += cur_trans;

--- a/include/facet/ctype_details.h
+++ b/include/facet/ctype_details.h
@@ -51,11 +51,11 @@
 #pragma once
 #include <common/clocale_wrapper.h>
 #include <common/defs.h>
+#include <common/metafunctions.h>
 #include <facet/facet_common.h>
 
 #include <array>
 
-#include <cctype>
 #include <climits>
 #include <cstddef>
 #include <cstdio>
@@ -422,9 +422,7 @@ private:
 template <typename CharT>
     requires std::is_same_v<CharT, wchar_t> ||
                 (std::is_same_v<CharT, char32_t> &&
-                 (sizeof(char32_t) == sizeof(wchar_t)) &&
-                 (static_cast<wchar_t>(U'李') == L'李') &&
-                 (static_cast<char32_t>(L'伟') == U'伟'))
+                 wchar_t_is_utf32)
 class ctype_conf<CharT> : public ft_basic<ctype<CharT>>
 {
 public:

--- a/include/facet/facet_helper.h
+++ b/include/facet/facet_helper.h
@@ -33,6 +33,7 @@
 
 #pragma once
 #include <common/clocale_wrapper.h>
+#include <common/metafunctions.h>
 #include <cvt/cvt_facilities.h>
 
 #include <algorithm>
@@ -212,9 +213,7 @@ namespace IOv2::FacetHelper
     template <typename CharT>
         requires std::is_same_v<CharT, wchar_t> ||
             (std::is_same_v<CharT, char32_t> &&
-                (sizeof(char32_t) == sizeof(wchar_t)) &&
-                (static_cast<wchar_t>(U'李') == L'李') &&
-                (static_cast<char32_t>(L'伟') == U'伟'))
+                wchar_t_is_utf32)
     inline CharT string_to_widechar_convert(const std::string& narrow,
                                             const std::string& locale_name,
                                             CharT default_char)

--- a/include/facet/messages_details.h
+++ b/include/facet/messages_details.h
@@ -282,9 +282,7 @@ private:
 template <typename CharT>
     requires std::is_same_v<CharT, char32_t> || 
                 (std::is_same_v<CharT, wchar_t> && 
-                 (sizeof(char32_t) == sizeof(wchar_t)) && 
-                 (static_cast<wchar_t>(U'李') == L'李') &&
-                 (static_cast<char32_t>(L'伟') == U'伟'))
+                 wchar_t_is_utf32)
 class messages_conf<CharT> : public ft_basic<messages<CharT>>
 {
     using TString = std::basic_string<CharT>;
@@ -350,9 +348,7 @@ private:
     {
         try
         {
-            if constexpr ((sizeof(char32_t) == sizeof(wchar_t)) && 
-                          (static_cast<wchar_t>(U'李') == L'李') &&
-                          (static_cast<char32_t>(L'伟') == U'伟'))
+            if constexpr (wchar_t_is_utf32)
             {
                 if (lang.empty())
                     throw stream_error("messages_conf init fail: no language available");

--- a/include/facet/monetary_details.h
+++ b/include/facet/monetary_details.h
@@ -4,6 +4,7 @@
 #include <string>
 #include <vector>
 #include <common/clocale_wrapper.h>
+#include <common/metafunctions.h>
 #include <cvt/cvt_facilities.h>
 #include <facet/facet_common.h>
 #include <facet/facet_helper.h>
@@ -317,9 +318,7 @@ private:
 template <typename CharT>
     requires std::is_same_v<CharT, wchar_t> || 
                 (std::is_same_v<CharT, char32_t> && 
-                 (sizeof(char32_t) == sizeof(wchar_t)) && 
-                 (static_cast<wchar_t>(U'李') == L'李') &&
-                 (static_cast<char32_t>(L'伟') == U'伟'))
+                 wchar_t_is_utf32)
 class monetary_conf<CharT> : public ft_basic<monetary<CharT>>
 {
 public:

--- a/include/facet/numeric.h
+++ b/include/facet/numeric.h
@@ -1,11 +1,12 @@
 #pragma once
-#include <iterator>
-#include <memory>
 #include <common/metafunctions.h>
 #include <facet/ctype.h>
 #include <facet/facet_helper.h>
 #include <facet/numeric_details.h>
 #include <io/io_base.h>
+
+#include <iterator>
+#include <memory>
 #include <type_traits>
 
 namespace IOv2
@@ -21,7 +22,7 @@ public:
               shared_ptr_to<ctype<CharT>> TCtypePtr>
     numeric(TConfPtr p_obj, TCtypePtr p_ctype) : m_ctype(p_ctype)
     {
-        if (!p_obj) throw std::runtime_error("shared_ptr is empty");
+        if (!p_obj || !p_ctype) throw std::runtime_error("shared_ptr is empty");
         m_decimal_point = p_obj->decimal_point();
         m_thousands_sep = p_obj->thousands_sep();
         m_true_name = p_obj->truename();
@@ -56,7 +57,7 @@ public:
         {
             return insert_int(s, io, static_cast<const long>(v));
         }
-        
+
         const auto& name = v ? m_true_name : m_false_name;
         size_t len = name.size();
 
@@ -64,7 +65,6 @@ public:
         if (w > static_cast<decltype(w)>(len))
         {
             const auto plen = w - len;
-            std::vector<char_type> ps(plen, io.fill());
             io.width(0);
 
             if ((flags & ios_defs::adjustfield) == ios_defs::left)
@@ -79,11 +79,11 @@ public:
             }
             return s;
         }
-        
+
         io.width(0);
         return std::copy(name.begin(), name.end(), s);
     }
-    
+
     template <typename TIter, typename TValue>
         requires (std::is_integral_v<TValue> && (!std::is_same_v<TValue, bool>))
     TIter put(TIter s, ios_base<char_type>& io, TValue v) const { return insert_int(s, io, v); }
@@ -113,7 +113,7 @@ public:
         io.flags(flags);
         return s;
     }
-    
+
     template <typename TIter, std::sentinel_for<TIter> TSent>
     TIter get(TIter beg, TSent end, ios_base<char_type>& io, bool& v) const
     {
@@ -189,7 +189,7 @@ public:
         if (!success) throw stream_error("numeric::get fail: parse boolean fail");
         return beg;
     }
-    
+
     template <typename TIter, std::sentinel_for<TIter> TSent, typename TValue>
         requires (std::is_integral_v<TValue> && (!std::is_same_v<TValue, bool>))
     TIter get(TIter beg, TSent end, ios_base<char_type>& io, TValue& v) const
@@ -249,12 +249,12 @@ private:
 
         const ios_defs::fmtflags fltfield = io.flags() & ios_defs::floatfield;
 
-        // Initial buffer size estimate (GCC style). 
+        // Initial buffer size estimate (GCC style).
         // For non-fixed fields, max_digits * 3 is a safe heuristic.
         size_t cs_size = static_cast<size_t>(max_digits) * 3 + 32;
         if (fltfield == ios_defs::fixed)
             cs_size = static_cast<size_t>(std::numeric_limits<TValue>::max_exponent10) + static_cast<size_t>(prec) + 32;
-        
+
         // Cap initial allocation to a reasonable size (e.g., 2048) to avoid huge initial pressure.
         if (cs_size > 2048) cs_size = 2048;
 
@@ -347,7 +347,7 @@ private:
         // Write resulting, fully-formatted string to output iterator.
         return std::copy(ws, ws + len, s);
     }
-    
+
     template <typename TIter, typename TValue>
     TIter insert_int(TIter s, ios_base<char_type>& io, TValue v) const
     {
@@ -427,7 +427,7 @@ private:
         // Write resulting, fully-formatted string to output iterator.
         return std::copy(cs, cs + len, s);
     }
-    
+
     template <typename TValue>
     int int_to_char(CharT* bufend, TValue v, ios_defs::fmtflags flags, bool dec) const
     {
@@ -511,7 +511,7 @@ private:
         std::fill_n(news, plen, fill);
         std::copy(olds + mod, olds + oldlen, news + plen);
     }
-    
+
     void _S_format_float(ios_defs::fmtflags flags, char* fptr, char mod) const noexcept
     {
         *fptr++ = '%';
@@ -542,7 +542,7 @@ private:
             *fptr++ = (flags & ios_defs::uppercase) ? 'G' : 'g';
         *fptr = '\0';
     }
-    
+
     void group_float(const std::vector<uint8_t>& grouping, char_type sep, const char_type* p, char_type* new_buf, char_type* cs, int& len) const
     {
         // _GLIBCXX_RESOLVE_LIB_DEFECTS
@@ -560,7 +560,7 @@ private:
         }
         len = newlen;
     }
-    
+
     template <typename TIter, std::sentinel_for<TIter> TSent, typename TValue>
     std::pair<bool, TIter> extract_int(TIter beg, TSent end, ios_base<char_type>& io, TValue& v) const
     {
@@ -881,7 +881,7 @@ private:
     }
 
     template <typename TValue>
-    bool convert_to_v(const char* s, TValue& v) const noexcept
+    bool convert_to_v(const char* s, TValue& v) const
     {
         bool res = true;
         char* sanity;
@@ -923,7 +923,7 @@ private:
     std::basic_string<CharT>  m_true_name;
     std::basic_string<CharT>  m_false_name;
     std::vector<uint8_t>      m_grouping;
-    
+
 private:
     char_type m_in_atoms[26];
     char_type m_out_atoms[36];
@@ -937,7 +937,7 @@ private:
     static constexpr int s_oe           = s_odigits + 14;
     static constexpr int s_oA           = s_oudigits + 10;
     static constexpr int s_oE           = s_oudigits + 14;
-    
+
     static constexpr int s_iminus       = 0;
     static constexpr int s_iplus        = 1;
     static constexpr int s_ix           = 2;

--- a/include/facet/numeric_details.h
+++ b/include/facet/numeric_details.h
@@ -1,12 +1,14 @@
 #pragma once
-#include <langinfo.h>
+#include <common/clocale_wrapper.h>
+#include <common/metafunctions.h>
+#include <cvt/cvt_facilities.h>
+#include <facet/facet_common.h>
+#include <facet/facet_helper.h>
+
 #include <string>
 #include <vector>
 
-#include <facet/facet_common.h>
-#include <facet/facet_helper.h>
-#include <common/clocale_wrapper.h>
-#include <cvt/cvt_facilities.h>
+#include <langinfo.h>
 
 namespace IOv2
 {
@@ -68,14 +70,14 @@ public:
         if (no_set)  m_false_name = no_raw;
         else         m_false_name = "false";
     }
-    
+
 public:
     virtual char decimal_point() const { return m_decimal_point; }
     virtual char thousands_sep() const { return m_thousands_sep; }
     virtual const std::string& truename() const { return m_true_name; }
     virtual const std::string& falsename() const { return m_false_name; }
     virtual const std::vector<uint8_t>& grouping() const { return m_grouping; }
-    
+
 private:
     char m_decimal_point;
     char m_thousands_sep;
@@ -85,16 +87,14 @@ private:
 };
 
 template <typename CharT>
-    requires std::is_same_v<CharT, wchar_t> || 
-                (std::is_same_v<CharT, char32_t> && 
-                 (sizeof(char32_t) == sizeof(wchar_t)) && 
-                 (static_cast<wchar_t>(U'李') == L'李') &&
-                 (static_cast<char32_t>(L'伟') == U'伟'))
+    requires std::is_same_v<CharT, wchar_t> ||
+                (std::is_same_v<CharT, char32_t> &&
+                 wchar_t_is_utf32)
 class numeric_conf<CharT> : public ft_basic<numeric<CharT>>
 {
 public:
     using char_type = CharT;
-    
+
 public:
     numeric_conf(const std::string& name)
         : ft_basic<numeric<CharT>>()
@@ -178,14 +178,14 @@ public:
                 m_false_name = detail::to_u32string(no_raw.c_str(), name);
         }
     }
-    
+
 public:
     virtual CharT decimal_point() const { return m_decimal_point; }
     virtual CharT thousands_sep() const { return m_thousands_sep; }
     virtual const std::basic_string<CharT>& truename() const { return m_true_name; }
     virtual const std::basic_string<CharT>& falsename() const { return m_false_name; }
     virtual const std::vector<uint8_t>& grouping() const { return m_grouping; }
-    
+
 private:
     CharT m_decimal_point;
     CharT m_thousands_sep;
@@ -197,9 +197,14 @@ private:
 template <>
 class numeric_conf<char8_t> : public ft_basic<numeric<char8_t>>
 {
+    static_assert(wchar_t_is_utf32,
+        "numeric_conf<char8_t> delegates to numeric_conf<char32_t>, which "
+        "requires wchar_t to be a 32-bit UTF-32 code unit. This platform "
+        "(e.g. wchar_t is 16-bit UTF-16) does not satisfy that assumption.");
+
 public:
     using char_type = char8_t;
-    
+
 public:
     numeric_conf(const std::string& name)
         : ft_basic<numeric<char8_t>>()
@@ -231,14 +236,14 @@ public:
 
         m_grouping = numeric_temp.grouping();
     }
-    
+
 public:
     virtual char8_t decimal_point() const { return m_decimal_point; }
     virtual char8_t thousands_sep() const { return m_thousands_sep; }
     virtual const std::basic_string<char8_t>& truename() const { return m_true_name; }
     virtual const std::basic_string<char8_t>& falsename() const { return m_false_name; }
     virtual const std::vector<uint8_t>& grouping() const { return m_grouping; }
-    
+
 private:
     char8_t m_decimal_point;
     char8_t m_thousands_sep;

--- a/include/facet/timeio_details.h
+++ b/include/facet/timeio_details.h
@@ -8,7 +8,7 @@
 #include <ctime>
 #include <limits>
 #include <string>
-#include <stdexcept>
+#include <common/metafunctions.h>
 #include <common/prefix_tree.h>
 #include <cvt/cvt_facilities.h>
 #include <facet/facet_common.h>
@@ -348,9 +348,7 @@ private:
 template <typename CharT>
     requires std::is_same_v<CharT, wchar_t> || 
             (std::is_same_v<CharT, char32_t> && 
-            (sizeof(char32_t) == sizeof(wchar_t)) && 
-            (static_cast<wchar_t>(U'李') == L'李') &&
-            (static_cast<char32_t>(L'伟') == U'伟'))
+            wchar_t_is_utf32)
 class timeio_conf<CharT> : public ft_basic<timeio<CharT>>
 {
     using era_entry = typename ft_basic<timeio<CharT>>::era_entry;


### PR DESCRIPTION
Correctness fixes:
- numeric: check p_ctype for null in the constructor (only p_obj was guarded), avoiding a null deref in widen_seq.
- numeric: drop noexcept from convert_to_v, whose body constructs clocale_wrapper("C") and can throw on locale-creation failure (would otherwise std::terminate).
- numeric_details: guard numeric_conf<char8_t> with a clear static_assert(wchar_t_is_utf32, ...) instead of failing on an incomplete numeric_conf<char32_t> on non-UTF-32-wchar_t platforms.

Refactor / cleanup:
- metafunctions: add wchar_t_is_utf32 constant and replace the duplicated (sizeof + CJK-encoding) platform checks across facet/ and cvt/ with it.
- Normalise include grouping/order (local -> C++ -> C, alphabetical), strip trailing whitespace, and ensure final newlines.
- Remove dead locals (numeric put(bool) ps, collate compare buf1) and unused includes (ctype_details cctype, timeio_details stdexcept).