### PR TITLE
fix(facet): harden collate/numeric against xfrm failure and degenerate locales

### DIFF
--- a/include/facet/collate_details.h
+++ b/include/facet/collate_details.h
@@ -9,6 +9,7 @@
 #include <compare>
 #include <cstring>
 #include <cwchar>
+#include <string_view>
 #include <vector>
 
 namespace IOv2
@@ -19,6 +20,11 @@ template <typename CharT> class collate_conf;
 template <typename CharT>
 class collate_conf : public ft_basic<collate<CharT>>
 {
+    // strxfrm / wcsxfrm signal failure by returning (size_t)-1. Using that
+    // value as a buffer size would wrap on `+ 1` and silently produce a
+    // zero-sized buffer that subsequent writes overflow.
+    static constexpr size_t xfrm_failed = static_cast<size_t>(-1);
+
 public:
     collate_conf(const std::string& name)
         : ft_basic<collate<CharT>>()
@@ -36,8 +42,7 @@ public:
         while ((low1 != high1) && (low2 != high2))
         {
             const CharT* cl1 = low1;
-            auto ch1 = std::find(low1, high1, static_cast<CharT>(0));
-            if (ch1 == high1)
+            if (auto ch1 = std::find(low1, high1, static_cast<CharT>(0)); ch1 == high1)
             {
                 auto data_len = high1 - low1;
                 buf1.resize(data_len + 1 + SIMD_PADDING_BYTES / sizeof(CharT));
@@ -45,14 +50,12 @@ public:
                 buf1[data_len] = static_cast<CharT>(0);
                 extra_eos1 = true;
                 cl1 = buf1.data();
-                ch1 = buf1.data() + data_len + 1;
                 low1 = high1;
             }
             else low1 = ch1 + 1;
 
             const CharT* cl2 = low2;
-            auto ch2 = std::find(low2, high2, static_cast<CharT>(0));
-            if (ch2 == high2)
+            if (auto ch2 = std::find(low2, high2, static_cast<CharT>(0)); ch2 == high2)
             {
                 auto data_len = high2 - low2;
                 buf2.resize(data_len + 1 + SIMD_PADDING_BYTES / sizeof(CharT));
@@ -60,7 +63,6 @@ public:
                 buf2[data_len] = static_cast<CharT>(0);
                 extra_eos2 = true;
                 cl2 = buf2.data();
-                ch2 = buf2.data() + data_len + 1;
                 low2 = high2;
             }
             else low2 = ch2 + 1;
@@ -77,8 +79,14 @@ public:
                                          reinterpret_cast<const wchar_t*>(cl2));
                 else if constexpr (std::is_same_v<CharT, char8_t>)
                 {
-                    auto ws1 = detail::to_u32string(cl1);
-                    auto ws2 = detail::to_u32string(cl2);
+                    // Pass an explicit-length u8string_view to lock the
+                    // per-segment "cur is a null-terminated copy" contract
+                    // at the call site, so future changes to to_u32string's
+                    // overload set cannot silently cross segment boundaries.
+                    auto ws1 = detail::to_u32string(
+                        std::u8string_view{cl1, std::char_traits<char8_t>::length(cl1)});
+                    auto ws2 = detail::to_u32string(
+                        std::u8string_view{cl2, std::char_traits<char8_t>::length(cl2)});
                     c_res = std::wcscoll(reinterpret_cast<const wchar_t*>(ws1.c_str()),
                                          reinterpret_cast<const wchar_t*>(ws2.c_str()));
                 }
@@ -121,22 +129,33 @@ public:
                 ++res;  // for the terminal character
             }
 
+            size_t seg_len = 0;
             if constexpr (std::is_same_v<CharT, char>)
-                res += strxfrm(nullptr, cur, 0);
+                seg_len = strxfrm(nullptr, cur, 0);
             else if constexpr (std::is_same_v<CharT, wchar_t>)
-                res += wcsxfrm(nullptr, cur, 0);
+                seg_len = wcsxfrm(nullptr, cur, 0);
             else if constexpr (wchar_t_is_utf32)
             {
                 if constexpr (std::is_same_v<CharT, char32_t>)
-                    res += wcsxfrm(nullptr, reinterpret_cast<const wchar_t*>(cur), 0);
+                    seg_len = wcsxfrm(nullptr, reinterpret_cast<const wchar_t*>(cur), 0);
                 else if constexpr (std::is_same_v<CharT, char8_t>)
                 {
-                    auto ws = detail::to_u32string(cur);
-                    res += wcsxfrm(nullptr, reinterpret_cast<const wchar_t*>(ws.c_str()), 0) * 6;
+                    // See compare(): explicit-length u8string_view pins the
+                    // segment contract at the call site.
+                    auto ws = detail::to_u32string(
+                        std::u8string_view{cur, std::char_traits<char8_t>::length(cur)});
+                    seg_len = wcsxfrm(nullptr, reinterpret_cast<const wchar_t*>(ws.c_str()), 0);
+                    if (seg_len == xfrm_failed)
+                        throw cvt_error("collate_conf::transform_length: wcsxfrm failed");
+                    seg_len *= 6;
                 }
             }
             else
                 static_assert(dependent_false_v<CharT>, "collate_conf::transform_length is not implemented.");
+
+            if (seg_len == xfrm_failed)
+                throw cvt_error("collate_conf::transform_length: strxfrm/wcsxfrm failed");
+            res += seg_len;
         }
 
         return res;
@@ -176,12 +195,19 @@ public:
             if constexpr (std::is_same_v<CharT, char8_t> &&
                           wchar_t_is_utf32)
             {
-                auto ws = detail::to_u32string(cur);
+                // See compare(): explicit-length u8string_view pins the
+                // segment contract at the call site.
+                auto ws = detail::to_u32string(
+                    std::u8string_view{cur, std::char_traits<char8_t>::length(cur)});
                 auto trans_len = wcsxfrm(nullptr, reinterpret_cast<const wchar_t*>(ws.c_str()), 0);
+                if (trans_len == xfrm_failed)
+                    throw cvt_error("collate_conf::transform: wcsxfrm failed");
                 buf32.resize(trans_len + 1);
                 auto cur_trans = wcsxfrm(reinterpret_cast<wchar_t*>(buf32.data()),
                                          reinterpret_cast<const wchar_t*>(ws.c_str()),
                                          static_cast<unsigned>(-1));
+                if (cur_trans == xfrm_failed)
+                    throw cvt_error("collate_conf::transform: wcsxfrm failed");
                 buf32[cur_trans] = 0;
 
                 auto char8s = detail::to_u8string(buf32.data());
@@ -217,6 +243,8 @@ public:
                 else
                     static_assert(dependent_false_v<CharT>, "collate_conf::transform is not implemented.");
 
+                if (trans_len == xfrm_failed)
+                    throw cvt_error("collate_conf::transform: strxfrm/wcsxfrm failed");
                 buf2.resize(trans_len + 1);
 
                 size_t cur_trans = 0;
@@ -230,6 +258,8 @@ public:
                 else
                     static_assert(dependent_false_v<CharT>, "collate_conf::transform is not implemented.");
 
+                if (cur_trans == xfrm_failed)
+                    throw cvt_error("collate_conf::transform: strxfrm/wcsxfrm failed");
                 if (mx_len != 0)
                     cur_trans = std::min(cur_trans, mx_len - trans_count);
                 dest = std::copy(buf2.data(), buf2.data() + cur_trans, dest);
@@ -245,6 +275,14 @@ public:
         return trans_count;
     }
 private:
+    // m_inter_locale is shared across compare / transform_length / transform,
+    // all of which are const. Each call constructs a clocale_user that calls
+    // uselocale(m_inter_locale.c_locale) to swap the calling thread's locale.
+    // POSIX does not explicitly guarantee that the same locale_t may be
+    // passed to uselocale() concurrently from multiple threads; IOv2 relies
+    // on the de-facto thread-safety provided by glibc and macOS libc on the
+    // target platforms (Linux / macOS). Porting to platforms with stricter
+    // semantics requires reevaluating this assumption.
     clocale_wrapper   m_inter_locale;
 };
 }

--- a/include/facet/numeric.h
+++ b/include/facet/numeric.h
@@ -6,6 +6,7 @@
 #include <io/io_base.h>
 
 #include <algorithm>
+#include <cassert>
 #include <cstddef>
 #include <cstdint>
 #include <cstdio>
@@ -55,6 +56,21 @@ public:
         constexpr std::string_view out_atoms = "-+xX0123456789abcdef0123456789ABCDEF";
         static_assert(out_atoms.size() == std::extent_v<decltype(m_out_atoms)>);
         m_ctype->widen_seq(out_atoms.data(), out_atoms.data() + out_atoms.size(), m_out_atoms);
+
+        if constexpr (std::is_same_v<CharT, wchar_t> ||
+                      std::is_same_v<CharT, char32_t>)
+        {
+            assert(atoms_pairwise_distinct(m_in_atoms,
+                                           std::extent_v<decltype(m_in_atoms)>));
+            // m_out_atoms intentionally aliases "0..9" at [4..13] and
+            // [20..29] (lowercase / uppercase hex digit slots). Build a
+            // 26-position view that skips that overlap before checking
+            // distinctness on the semantically distinct output positions.
+            CharT out_view[26];
+            std::copy(m_out_atoms,      m_out_atoms + 20, out_view);
+            std::copy(m_out_atoms + 30, m_out_atoms + 36, out_view + 20);
+            assert(atoms_pairwise_distinct(out_view, 26));
+        }
     }
 
 public:
@@ -298,13 +314,17 @@ private:
             }
         }
 
-        if (len < 0 || static_cast<size_t>(len) >= cs_size)
+        // len == 0 is also treated as failure: every well-formed numeric
+        // print (including 0, "inf", "nan") emits at least one character,
+        // and the downstream path assumes vec_ws(len) has at least one
+        // element before dereferencing vec_ws.data().
+        if (len <= 0 || static_cast<size_t>(len) >= cs_size)
             throw stream_error("numeric::put fail: floating-point conversion failed");
 
         const char* cs = vec_cs.data();
 
         // [22.2.2.2.2] Stage 2, convert to char_type, using correct
-        // numpunct.decimal_point() values for '.' and adding grouping.
+        // numeric_conf.decimal_point() values for '.' and adding grouping.
         std::vector<CharT> vec_ws(len);
         CharT* ws = vec_ws.data();
         m_ctype->widen_seq(cs, cs + len, ws);
@@ -419,7 +439,7 @@ private:
                 *--cs = m_out_atoms[s_ox + uppercase];
                 // '0'
                 *--cs = m_out_atoms[s_odigits];
-                    len += 2;
+                len += 2;
             }
         }
 
@@ -930,6 +950,27 @@ private:
             res = false;
         }
         return res;
+    }
+
+    // Verify ctype::widen is injective on the digit / sign / base / scientific
+    // atom set. extract_int / extract_float compare incoming wide characters
+    // against entries in m_in_atoms (directly or via std::find) and assume
+    // distinct narrow source characters widen to distinct wide values; a
+    // collision (e.g. widen('a') == widen('A') in an exotic locale) would
+    // make certain digits unreachable on the input side, and insert_int /
+    // insert_float would emit indistinguishable glyphs for semantically
+    // different positions on the output side. The standard library silently
+    // assumes injectivity on this 26-character set; IOv2 catches violations
+    // at construction time in debug / coverage / sanitizer builds via the
+    // asserts in the constructor. A future unit test can exercise the
+    // failure branch by deriving from ctype<CharT> and overriding widen_seq
+    // to be intentionally non-injective.
+    static bool atoms_pairwise_distinct(const CharT* p, size_t n)
+    {
+        for (size_t i = 0; i < n; ++i)
+            for (size_t j = i + 1; j < n; ++j)
+                if (p[i] == p[j]) return false;
+        return true;
     }
 
 private:

--- a/include/facet/numeric_details.h
+++ b/include/facet/numeric_details.h
@@ -48,12 +48,22 @@ public:
             if (lc->thousands_sep) ts_raw  = lc->thousands_sep;
             if (lc->grouping)      grp_raw = lc->grouping;
 
-            if (auto* p = nl_langinfo(YESSTR)) { yes_raw = p; yes_set = true; }
-            if (auto* p = nl_langinfo(NOSTR))  { no_raw  = p; no_set  = true; }
+            // Treat empty YESSTR/NOSTR the same as a missing key: an empty
+            // m_true_name / m_false_name would make numeric::get(bool&) fail
+            // unconditionally (zero-length prefix never matches) and let
+            // numeric::put(bool) write nothing but padding.
+            if (auto* p = nl_langinfo(YESSTR); p && *p) { yes_raw = p; yes_set = true; }
+            if (auto* p = nl_langinfo(NOSTR);  p && *p) { no_raw  = p; no_set  = true; }
         }
 
         m_decimal_point = FacetHelper::string_to_char_convert(dp_raw, name);
         m_thousands_sep = FacetHelper::string_to_char_convert(ts_raw, name);
+
+        // string_to_char_convert hard-codes '\0' as its failure sentinel. A
+        // decimal point of '\0' would later be mistaken for an in-stream
+        // null byte during parsing; fall back to '.' so the contract that
+        // m_decimal_point is a real, distinguishable character is preserved.
+        if (m_decimal_point == '\0') m_decimal_point = '.';
 
         if (m_thousands_sep != '\0' && !grp_raw.empty())
         {
@@ -135,14 +145,26 @@ public:
             if (lc->thousands_sep) ts_raw  = lc->thousands_sep;
             if (lc->grouping)      grp_raw = lc->grouping;
 
-            if (auto* p = nl_langinfo(YESSTR)) { yes_raw = p; yes_set = true; }
-            if (auto* p = nl_langinfo(NOSTR))  { no_raw  = p; no_set  = true; }
+            // Treat empty YESSTR/NOSTR the same as a missing key: an empty
+            // m_true_name / m_false_name would make numeric::get(bool&) fail
+            // unconditionally (zero-length prefix never matches) and let
+            // numeric::put(bool) write nothing but padding.
+            if (auto* p = nl_langinfo(YESSTR); p && *p) { yes_raw = p; yes_set = true; }
+            if (auto* p = nl_langinfo(NOSTR);  p && *p) { no_raw  = p; no_set  = true; }
         }
 
         m_decimal_point = FacetHelper::string_to_widechar_convert<CharT>(
             dp_raw, name, static_cast<CharT>('.'));
         m_thousands_sep = FacetHelper::string_to_widechar_convert<CharT>(
             ts_raw, name, static_cast<CharT>('\0'));
+
+        // string_to_widechar_convert only substitutes default_char on the
+        // empty-input / empty-conversion paths; a successful conversion
+        // that yields CharT('\0') is passed through. Treat that case the
+        // same way and fall back to '.', so m_decimal_point is always a
+        // real, distinguishable character.
+        if (m_decimal_point == static_cast<CharT>('\0'))
+            m_decimal_point = static_cast<CharT>('.');
 
         if (m_thousands_sep != static_cast<CharT>('\0') && !grp_raw.empty())
         {
@@ -224,7 +246,11 @@ public:
         {
             const auto input = numeric_temp.decimal_point();
             auto output = detail::to_u8string(input);
-            m_decimal_point = (output.size() != 1) ? u8'.' : output[0];
+            // Fall back to u8'.' when the UTF-8 encoding is not a single
+            // byte OR when it is a single u8'\0' byte. The latter would be
+            // indistinguishable from an in-stream null byte during parsing.
+            m_decimal_point = (output.size() != 1 || output[0] == u8'\0')
+                                  ? u8'.' : output[0];
         }
 
         {
@@ -237,6 +263,18 @@ public:
         m_false_name = detail::to_u8string(numeric_temp.falsename());
 
         m_grouping = numeric_temp.grouping();
+
+        // After the single-byte fallbacks above, m_thousands_sep may have
+        // collapsed onto u8',' while m_decimal_point also resolved to u8','
+        // (e.g. a locale where decimal_point is ',' and thousands_sep is a
+        // multi-byte UTF-8 codepoint such as U+202F NARROW NO-BREAK SPACE).
+        // When the two separators coincide, downstream extract_int /
+        // extract_float would compare each input byte against both fields
+        // with the same value, making grouping detection ambiguous. Drop
+        // grouping in that case so parsing falls back to the no-grouping
+        // path instead of misclassifying digits.
+        if (m_thousands_sep == m_decimal_point)
+            m_grouping.clear();
     }
 
 public:


### PR DESCRIPTION


collate_details.h:
- Add xfrm_failed sentinel; detect and throw on strxfrm/wcsxfrm == (size_t)-1 in transform_length and transform to avoid buffer-size wrap.
- Pin to_u32string calls to explicit-length u8string_view to enforce the per-segment null-terminated-copy contract at each call site.
- Remove dead ch1/ch2 pointer assignments after buffer setup; tighten if-init statements.
- Add comment documenting the de-facto thread-safety assumption for m_inter_locale on glibc/macOS.

numeric.h:
- Add atoms_pairwise_distinct debug assertion in constructor: catches locales where ctype::widen is non-injective on the digit/sign atom set, which would make certain digits unreachable or emit indistinguishable glyphs.
- Change len < 0 to len <= 0 in floating-point put path: zero-length snprintf output is always a failure, and the downstream path dereferences vec_ws.data() unconditionally.
- Fix numpunct comment typo -> numeric_conf; fix len += 2 indentation.

numeric_details.h:
- Treat empty YESSTR/NOSTR the same as absent: a zero-length m_true_name/m_false_name makes bool I/O silently broken.
- Fall back to '.' when string_to_char_convert or string_to_widechar_convert yields '\0' for decimal_point, preventing null-byte confusion in parsing.
- After single-byte fallbacks, clear grouping when m_thousands_sep collides with m_decimal_point to avoid ambiguous digit classification.