### PR TITLE
fix(facet): add missing direct includes and drop ignored-qualifier cast

### DIFF
--- a/include/facet/collate.h
+++ b/include/facet/collate.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <common/metafunctions.h>
 #include <facet/collate_details.h>
+#include <facet/facet_common.h>
 
 #include <algorithm>
 #include <compare>

--- a/include/facet/collate_details.h
+++ b/include/facet/collate_details.h
@@ -11,6 +11,7 @@
 #include <cwchar>
 #include <string>
 #include <string_view>
+#include <type_traits>
 #include <vector>
 
 namespace IOv2

--- a/include/facet/numeric.h
+++ b/include/facet/numeric.h
@@ -1,6 +1,8 @@
 #pragma once
+#include <common/clocale_wrapper.h>
 #include <common/metafunctions.h>
 #include <facet/ctype.h>
+#include <facet/facet_common.h>
 #include <facet/facet_helper.h>
 #include <facet/numeric_details.h>
 #include <io/io_base.h>
@@ -87,7 +89,7 @@ public:
         const auto flags = io.flags();
         if ((flags & ios_defs::boolalpha) == 0)
         {
-            return insert_int(s, io, static_cast<const long>(v));
+            return insert_int(s, io, static_cast<long>(v));
         }
 
         const auto& name = v ? m_true_name : m_false_name;


### PR DESCRIPTION
IWYU fixes: each header now directly includes what it uses rather than relying on transitive includes that could silently break on refactoring.

- collate_details.h: add <type_traits> (uses std::is_same_v)
- collate.h:         add <facet/facet_common.h> (uses facet_create_rule)
- numeric.h:         add <common/clocale_wrapper.h> (uses clocale_wrapper /
                     clocale_user) and <facet/facet_common.h> (uses
                     facet_create_rule / facet_create_pack)

Also remove the meaningless top-level const from the static_cast in numeric::put(bool): static_cast<const long>(v) — the qualifier is ignored on a prvalue cast result (-Wignored-qualifiers), making it dead/misleading code; changed to static_cast<long>(v).