### PR TITLE
docs: add bilingual Doxygen comments to collate and numeric facets

### DIFF
--- a/include/facet/collate.h
+++ b/include/facet/collate.h
@@ -1,3 +1,18 @@
+/**
+ * @file collate.h
+ * @lang{ZH}
+ * 定义了 `collate<CharT>` facet 类，提供基于 locale 的字符串比较与排序键变换功能。
+ * 该类封装了 `collate_conf<CharT>` 的共享实例，并通过多个重载接口同时支持
+ * 原始指针范围和泛型迭代器范围两种输入输出形式。
+ * @endif
+ *
+ * @lang{EN}
+ * Defines the `collate<CharT>` facet class, providing locale-aware string comparison
+ * and collation-key transformation. The class wraps a shared instance of
+ * `collate_conf<CharT>` and exposes multiple overloads that accept both raw-pointer
+ * ranges and generic-iterator ranges as input and output.
+ * @endif
+ */
 #pragma once
 #include <common/metafunctions.h>
 #include <facet/collate_details.h>
@@ -12,25 +27,136 @@
 
 namespace IOv2
 {
+/**
+ * @lang{ZH}
+ * @brief 基于 locale 的字符串排序 facet。
+ *
+ * 封装 `collate_conf<CharT>` 的共享实例，提供对原始指针范围和泛型迭代器范围
+ * 均适用的 `compare()`、`transform_length()` 和 `transform()` 接口。
+ * 字符序列以空字符（`\0`）为段分隔符，各段独立处理。
+ *
+ * @tparam CharT 字符类型，支持 `char`、`wchar_t`、`char8_t` 和 `char32_t`（仅限 UTF-32 平台）。
+ * @endif
+ *
+ * @lang{EN}
+ * @brief A locale-aware string collation facet.
+ *
+ * Wraps a shared instance of `collate_conf<CharT>` and exposes `compare()`,
+ * `transform_length()`, and `transform()` interfaces that accept both raw-pointer
+ * ranges and generic-iterator ranges. Character sequences are processed segment
+ * by segment, with null characters (`\0`) acting as segment delimiters.
+ *
+ * @tparam CharT The character type. Supports `char`, `wchar_t`, `char8_t`, and
+ *               `char32_t` (only on platforms where `wchar_t` is UTF-32).
+ * @endif
+ */
 template <typename CharT>
 class collate
 {
 public:
+    /**
+     * @lang{ZH}
+     * @brief 关联的配置对象创建规则类型。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief The creation-rule type for the associated configuration object.
+     * @endif
+     */
     using create_rules = facet_create_rule<collate_conf<CharT>>;
 
+    /**
+     * @lang{ZH}
+     * @brief 字符类型。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief The character type.
+     * @endif
+     */
     using char_type = CharT;
 
+    /**
+     * @lang{ZH}
+     * @brief 构造函数，绑定到指定的 `collate_conf` 配置对象。
+     *
+     * @tparam TConfPtr 满足 `shared_ptr_to<collate_conf<CharT>>` 约束的共享指针类型。
+     * @param p_obj 指向配置对象的共享指针，不得为空。
+     * @throw std::runtime_error 若 `p_obj` 为空。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Constructor that binds to the specified `collate_conf` configuration object.
+     *
+     * @tparam TConfPtr A shared pointer type satisfying the `shared_ptr_to<collate_conf<CharT>>` constraint.
+     * @param p_obj A shared pointer to the configuration object; must not be null.
+     * @throw std::runtime_error If `p_obj` is null.
+     * @endif
+     */
     template <shared_ptr_to<collate_conf<CharT>> TConfPtr>
     collate(TConfPtr p_obj)
         : m_obj(p_obj)
     { if (!m_obj) throw std::runtime_error("shared_ptr is empty"); }
 
 public:
+    /**
+     * @lang{ZH}
+     * @brief 比较两个原始指针范围所表示的字符序列的排列顺序。
+     *
+     * 直接委托给底层 `collate_conf` 实现。
+     *
+     * @param low1 第一个序列的起始指针。
+     * @param high1 第一个序列的结束指针（不包含）。
+     * @param low2 第二个序列的起始指针。
+     * @param high2 第二个序列的结束指针（不包含）。
+     * @return 表示两序列排列关系的 `std::strong_ordering` 值。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Compares the collation order of two character sequences represented as raw pointer ranges.
+     *
+     * Delegates directly to the underlying `collate_conf` implementation.
+     *
+     * @param low1 Pointer to the start of the first sequence.
+     * @param high1 Pointer to one past the end of the first sequence.
+     * @param low2 Pointer to the start of the second sequence.
+     * @param high2 Pointer to one past the end of the second sequence.
+     * @return A `std::strong_ordering` value indicating the collation relationship.
+     * @endif
+     */
     std::strong_ordering compare(const CharT* low1, const CharT* high1, const CharT* low2, const CharT* high2) const
     {
         return m_obj->compare(low1, high1, low2, high2);
     }
 
+    /**
+     * @lang{ZH}
+     * @brief 比较一个原始指针范围与一个泛型迭代器范围的排列顺序。
+     *
+     * 将迭代器一侧逐段物化到缓冲区后，与指针一侧逐段进行比较。
+     *
+     * @tparam TIter 不可隐式转换为 `const CharT*` 的迭代器类型。
+     * @param low1 第一个序列（指针范围）的起始指针。
+     * @param high1 第一个序列（指针范围）的结束指针（不包含）。
+     * @param low2 第二个序列（迭代器范围）的起始迭代器。
+     * @param high2 第二个序列（迭代器范围）的结束迭代器。
+     * @return 表示两序列排列关系的 `std::strong_ordering` 值。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Compares the collation order of a raw-pointer range against a generic-iterator range.
+     *
+     * The iterator side is materialized segment by segment into a buffer before
+     * comparison against the pointer side.
+     *
+     * @tparam TIter An iterator type not implicitly convertible to `const CharT*`.
+     * @param low1 Start pointer of the first (pointer) range.
+     * @param high1 One-past-the-end pointer of the first (pointer) range.
+     * @param low2 Start iterator of the second (iterator) range.
+     * @param high2 End iterator of the second (iterator) range.
+     * @return A `std::strong_ordering` value indicating the collation relationship.
+     * @endif
+     */
     template <typename TIter>
         requires (!std::is_convertible_v<TIter, const CharT*>)
     std::strong_ordering compare(const CharT* low1, const CharT* high1, TIter low2, TIter high2) const
@@ -64,6 +190,34 @@ public:
         return std::strong_ordering::equal;
     }
 
+    /**
+     * @lang{ZH}
+     * @brief 比较一个泛型迭代器范围与一个原始指针范围的排列顺序。
+     *
+     * 通过交换参数顺序委托给指针/迭代器重载，并将结果取反以还原正确的大小关系。
+     *
+     * @tparam TIter 不可隐式转换为 `const CharT*` 的迭代器类型。
+     * @param low1 第一个序列（迭代器范围）的起始迭代器。
+     * @param high1 第一个序列（迭代器范围）的结束迭代器。
+     * @param low2 第二个序列（指针范围）的起始指针。
+     * @param high2 第二个序列（指针范围）的结束指针（不包含）。
+     * @return 表示两序列排列关系的 `std::strong_ordering` 值。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Compares the collation order of a generic-iterator range against a raw-pointer range.
+     *
+     * Delegates to the pointer/iterator overload with swapped arguments and inverts
+     * the result to restore the correct ordering relationship.
+     *
+     * @tparam TIter An iterator type not implicitly convertible to `const CharT*`.
+     * @param low1 Start iterator of the first (iterator) range.
+     * @param high1 End iterator of the first (iterator) range.
+     * @param low2 Start pointer of the second (pointer) range.
+     * @param high2 One-past-the-end pointer of the second (pointer) range.
+     * @return A `std::strong_ordering` value indicating the collation relationship.
+     * @endif
+     */
     template <typename TIter>
         requires (!std::is_convertible_v<TIter, const CharT*>)
     std::strong_ordering compare(TIter low1, TIter high1, const CharT* low2, const CharT* high2) const
@@ -74,6 +228,36 @@ public:
         return res;
     }
 
+    /**
+     * @lang{ZH}
+     * @brief 比较两个泛型迭代器范围的排列顺序。
+     *
+     * 两侧均逐段物化到各自的缓冲区后再进行比较。
+     *
+     * @tparam TIter1 第一个范围的迭代器类型，不可隐式转换为 `const CharT*`。
+     * @tparam TIter2 第二个范围的迭代器类型，不可隐式转换为 `const CharT*`。
+     * @param low1 第一个序列的起始迭代器。
+     * @param high1 第一个序列的结束迭代器。
+     * @param low2 第二个序列的起始迭代器。
+     * @param high2 第二个序列的结束迭代器。
+     * @return 表示两序列排列关系的 `std::strong_ordering` 值。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Compares the collation order of two generic-iterator ranges.
+     *
+     * Both sides are materialized segment by segment into their own buffers
+     * before comparison.
+     *
+     * @tparam TIter1 The iterator type for the first range; not implicitly convertible to `const CharT*`.
+     * @tparam TIter2 The iterator type for the second range; not implicitly convertible to `const CharT*`.
+     * @param low1 Start iterator of the first sequence.
+     * @param high1 End iterator of the first sequence.
+     * @param low2 Start iterator of the second sequence.
+     * @param high2 End iterator of the second sequence.
+     * @return A `std::strong_ordering` value indicating the collation relationship.
+     * @endif
+     */
     template <typename TIter1, typename TIter2>
         requires (!(std::is_convertible_v<TIter1, const CharT*> || std::is_convertible_v<TIter2, const CharT*>))
     std::strong_ordering compare(TIter1 low1, TIter1 high1, TIter2 low2, TIter2 high2) const
@@ -97,11 +281,56 @@ public:
         return std::strong_ordering::equal;
     }
 
+    /**
+     * @lang{ZH}
+     * @brief 计算原始指针范围的排序键变换所需的存储长度。
+     *
+     * 直接委托给底层 `collate_conf` 实现。
+     *
+     * @param low 字符序列的起始指针。
+     * @param high 字符序列的结束指针（不包含）。
+     * @return 存储完整排序键所需的字符数。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Computes the storage length required to transform the raw-pointer range into a collation key.
+     *
+     * Delegates directly to the underlying `collate_conf` implementation.
+     *
+     * @param low Pointer to the start of the character sequence.
+     * @param high Pointer to one past the end of the character sequence.
+     * @return The number of characters required to store the complete collation key.
+     * @endif
+     */
     size_t transform_length(const CharT* low, const CharT* high) const
     {
         return m_obj->transform_length(low, high);
     }
 
+    /**
+     * @lang{ZH}
+     * @brief 计算泛型迭代器范围的排序键变换所需的存储长度。
+     *
+     * 将输入逐段物化到缓冲区后，累加各段的变换长度并返回总和。
+     *
+     * @tparam TIter 不可隐式转换为 `const CharT*` 的迭代器类型。
+     * @param low 字符序列的起始迭代器。
+     * @param high 字符序列的结束迭代器。
+     * @return 存储完整排序键所需的字符数。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Computes the storage length required to transform a generic-iterator range into a collation key.
+     *
+     * The input is materialized segment by segment into a buffer, and the
+     * transformed lengths of all segments are accumulated and returned.
+     *
+     * @tparam TIter An iterator type not implicitly convertible to `const CharT*`.
+     * @param low Start iterator of the character sequence.
+     * @param high End iterator of the character sequence.
+     * @return The number of characters required to store the complete collation key.
+     * @endif
+     */
     template <typename TIter>
         requires (!std::is_convertible_v<TIter, const CharT*>)
     size_t transform_length(TIter low, TIter high) const
@@ -117,12 +346,65 @@ public:
         return res;
     }
 
+    /**
+     * @lang{ZH}
+     * @brief 将原始指针输入范围变换为排序键，写入原始指针目标缓冲区。
+     *
+     * 直接委托给底层 `collate_conf` 实现。
+     *
+     * @param low 字符序列的起始指针。
+     * @param high 字符序列的结束指针（不包含）。
+     * @param dest 写入排序键的目标缓冲区。
+     * @param mx_len 最多写入的字符数；传入 `0` 表示不限制。
+     * @return 包含写入终点指针与实际写入字符数的 `pair`。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Transforms a raw-pointer input range into a collation key, writing to a raw-pointer destination buffer.
+     *
+     * Delegates directly to the underlying `collate_conf` implementation.
+     *
+     * @param low Pointer to the start of the character sequence.
+     * @param high Pointer to one past the end of the character sequence.
+     * @param dest Destination buffer where the collation key is written.
+     * @param mx_len Maximum number of characters to write; pass `0` for unlimited.
+     * @return A pair of the past-the-end destination pointer and the number of characters written.
+     * @endif
+     */
     std::pair<CharT*, size_t> transform(const CharT* low, const CharT* high, CharT* dest, size_t mx_len = 0) const
     {
         auto s = m_obj->transform(low, high, dest, mx_len);
         return std::pair{dest + s, s};
     }
 
+    /**
+     * @lang{ZH}
+     * @brief 将泛型迭代器输入范围变换为排序键，写入原始指针目标缓冲区。
+     *
+     * 将输入逐段物化到缓冲区后，依次调用底层变换并写入目标地址。
+     *
+     * @tparam TIter 不可隐式转换为 `const CharT*` 的迭代器类型。
+     * @param low 字符序列的起始迭代器。
+     * @param high 字符序列的结束迭代器。
+     * @param dest 写入排序键的目标缓冲区。
+     * @param mx_len 最多写入的字符数；传入 `0` 表示不限制。
+     * @return 包含写入终点指针与实际写入字符数的 `pair`。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Transforms a generic-iterator input range into a collation key, writing to a raw-pointer destination buffer.
+     *
+     * The input is materialized segment by segment into a buffer, and the
+     * underlying transformation is invoked for each segment in turn.
+     *
+     * @tparam TIter An iterator type not implicitly convertible to `const CharT*`.
+     * @param low Start iterator of the character sequence.
+     * @param high End iterator of the character sequence.
+     * @param dest Destination buffer where the collation key is written.
+     * @param mx_len Maximum number of characters to write; pass `0` for unlimited.
+     * @return A pair of the past-the-end destination pointer and the number of characters written.
+     * @endif
+     */
     template <typename TIter>
         requires (!std::is_convertible_v<TIter, const CharT*>)
     std::pair<CharT*, size_t> transform(TIter low, TIter high, CharT* dest, size_t mx_len = 0) const
@@ -145,6 +427,36 @@ public:
         return std::pair(dest, trans_count);
     }
 
+    /**
+     * @lang{ZH}
+     * @brief 将原始指针输入范围变换为排序键，通过泛型输出迭代器写出。
+     *
+     * 各段先变换到暂存缓冲区，再通过 `std::copy` 写入目标迭代器，
+     * 避免在不支持随机访问的迭代器上直接写入。
+     *
+     * @tparam TIter 不可隐式转换为 `CharT*` 的输出迭代器类型。
+     * @param low 字符序列的起始指针。
+     * @param high 字符序列的结束指针（不包含）。
+     * @param dest 写入排序键的目标输出迭代器。
+     * @param mx_len 最多写入的字符数；传入 `0` 表示不限制。
+     * @return 包含写入后目标迭代器位置与实际写入字符数的 `pair`。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Transforms a raw-pointer input range into a collation key, writing through a generic output iterator.
+     *
+     * Each segment is first transformed into a staging buffer, then copied to
+     * the destination iterator via `std::copy`, avoiding direct writes on
+     * iterators that do not support random access.
+     *
+     * @tparam TIter An output iterator type not implicitly convertible to `CharT*`.
+     * @param low Pointer to the start of the character sequence.
+     * @param high Pointer to one past the end of the character sequence.
+     * @param dest Output iterator to which the collation key is written.
+     * @param mx_len Maximum number of characters to write; pass `0` for unlimited.
+     * @return A pair of the updated destination iterator and the number of characters written.
+     * @endif
+     */
     template <typename TIter>
         requires (!std::is_convertible_v<TIter, CharT*>)
     std::pair<TIter, size_t> transform(const CharT* low, const CharT* high, TIter dest, size_t mx_len = 0) const
@@ -188,6 +500,36 @@ public:
         return std::pair(dest, trans_count);
     }
 
+    /**
+     * @lang{ZH}
+     * @brief 将泛型迭代器输入范围变换为排序键，通过泛型输出迭代器写出。
+     *
+     * 输入逐段物化到缓冲区，各段分别变换到暂存缓冲区后再写入目标迭代器。
+     *
+     * @tparam TIterIn 不可隐式转换为 `const CharT*` 的输入迭代器类型。
+     * @tparam TIterOut 不可隐式转换为 `CharT*` 的输出迭代器类型。
+     * @param low 字符序列的起始迭代器。
+     * @param high 字符序列的结束迭代器。
+     * @param dest 写入排序键的目标输出迭代器。
+     * @param mx_len 最多写入的字符数；传入 `0` 表示不限制。
+     * @return 包含写入后目标迭代器位置与实际写入字符数的 `pair`。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Transforms a generic-iterator input range into a collation key, writing through a generic output iterator.
+     *
+     * The input is materialized segment by segment into a buffer. Each segment is
+     * transformed into a staging buffer before being copied to the destination iterator.
+     *
+     * @tparam TIterIn An input iterator type not implicitly convertible to `const CharT*`.
+     * @tparam TIterOut An output iterator type not implicitly convertible to `CharT*`.
+     * @param low Start iterator of the character sequence.
+     * @param high End iterator of the character sequence.
+     * @param dest Output iterator to which the collation key is written.
+     * @param mx_len Maximum number of characters to write; pass `0` for unlimited.
+     * @return A pair of the updated destination iterator and the number of characters written.
+     * @endif
+     */
     template <typename TIterIn, typename TIterOut>
         requires (!(std::is_convertible_v<TIterIn, const CharT*> || std::is_convertible_v<TIterOut, CharT*>))
     std::pair<TIterOut, size_t> transform(TIterIn low, TIterIn high, TIterOut dest, size_t mx_len = 0) const
@@ -221,6 +563,34 @@ public:
     }
 
 private:
+    /**
+     * @lang{ZH}
+     * @brief 从迭代器范围读取一个段到 `buf`，并返回下一段的起始迭代器。
+     *
+     * 从 `low` 开始依次读取字符并追加到 `buf`，直到遇到空字符（包含该空字符）或到达 `high` 为止。
+     * 若未遇到空字符，则将剩余所有字符读入 `buf`。
+     *
+     * @tparam TIter 输入迭代器类型。
+     * @param low 当前段的起始迭代器。
+     * @param high 输入范围的结束迭代器。
+     * @param buf 用于接收本段数据的缓冲区；调用前会被清空。
+     * @return 下一段起始位置的迭代器，即本段结束后的位置。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Reads one segment from an iterator range into `buf` and returns the iterator to the next segment.
+     *
+     * Characters are appended to `buf` starting from `low` until a null character is
+     * encountered (inclusive) or `high` is reached. If no null character is found,
+     * all remaining characters are consumed into `buf`.
+     *
+     * @tparam TIter The input iterator type.
+     * @param low Start iterator of the current segment.
+     * @param high End iterator of the input range.
+     * @param buf Buffer that receives the segment data; cleared before use.
+     * @return Iterator to the start of the next segment, i.e., the position after this segment ends.
+     * @endif
+     */
     template <typename TIter>
     static TIter data_to_vec(TIter low, TIter high, std::vector<CharT>& buf)
     {
@@ -235,6 +605,15 @@ private:
     }
 
 private:
+    /**
+     * @lang{ZH}
+     * @brief 指向配置对象的共享只读指针，驱动所有比较与变换操作。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Shared read-only pointer to the configuration object driving all comparison and transformation operations.
+     * @endif
+     */
     std::shared_ptr<const collate_conf<CharT>> m_obj;
 };
 

--- a/include/facet/collate_details.h
+++ b/include/facet/collate_details.h
@@ -1,3 +1,18 @@
+/**
+ * @file collate_details.h
+ * @lang{ZH}
+ * 定义了 `collate_conf` 类，这是 `collate<CharT>` facet 的底层实现。
+ * 该类封装了 C 标准库的 `strcoll`/`strxfrm` 与宽字符 `wcscoll`/`wcsxfrm` 操作，
+ * 提供基于 locale 的字符串比较与排序键变换功能。
+ * @endif
+ *
+ * @lang{EN}
+ * Defines the `collate_conf` class, the underlying implementation for the `collate<CharT>` facet.
+ * This class wraps the C standard library's `strcoll`/`strxfrm` and wide-character
+ * `wcscoll`/`wcsxfrm` operations to provide locale-aware string comparison and
+ * collation-key transformation.
+ * @endif
+ */
 #pragma once
 #include <common/clocale_wrapper.h>
 #include <common/defs.h>
@@ -20,31 +35,94 @@ namespace IOv2
 template <typename CharT> class collate;
 template <typename CharT> class collate_conf;
 
+/**
+ * @lang{ZH}
+ * @brief `collate<CharT>` facet 的底层实现类。
+ *
+ * 通过 C 标准库的 `strcoll`/`strxfrm` 和宽字符 `wcscoll`/`wcsxfrm`
+ * 实现基于 locale 的字符串比较与排序键变换。
+ * 字符序列以空字符（`\0`）为段分隔符，各段依次独立处理。
+ *
+ * @note 此类不是线程安全的，多线程并发由更高层次的代码处理。
+ *
+ * @tparam CharT 字符类型，支持 `char`、`wchar_t`、`char8_t` 和 `char32_t`（仅限 UTF-32 平台）。
+ * @endif
+ *
+ * @lang{EN}
+ * @brief Underlying implementation class for the `collate<CharT>` facet.
+ *
+ * Implements locale-aware string comparison and collation-key transformation
+ * via the C standard library's `strcoll`/`strxfrm` and wide-character
+ * `wcscoll`/`wcsxfrm`. Character sequences are processed segment by segment,
+ * with null characters (`\0`) acting as segment delimiters.
+ *
+ * @note This class is not thread-safe; multi-threading is handled at a higher level.
+ *
+ * @tparam CharT The character type. Supports `char`, `wchar_t`, `char8_t`, and
+ *               `char32_t` (only on platforms where `wchar_t` is UTF-32).
+ * @endif
+ */
 template <typename CharT>
 class collate_conf : public ft_basic<collate<CharT>>
 {
-    // strxfrm / wcsxfrm signal failure by returning (size_t)-1. Using that
-    // value as a buffer size would wrap on `+ 1` and silently produce a
-    // zero-sized buffer that subsequent writes overflow.
+    /**
+     * @lang{ZH}
+     * @brief `strxfrm`/`wcsxfrm` 失败时的返回值哨兵。
+     *
+     * `strxfrm`/`wcsxfrm` 通过返回 `(size_t)-1` 来表示失败。
+     * 若将此值用作缓冲区大小，对其加 1 会发生回绕，
+     * 产生大小为零的缓冲区，后续写操作将越界。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Sentinel value returned by `strxfrm`/`wcsxfrm` on failure.
+     *
+     * `strxfrm`/`wcsxfrm` signal failure by returning `(size_t)-1`. Using that
+     * value as a buffer size would wrap on `+ 1` and silently produce a
+     * zero-sized buffer that subsequent writes overflow.
+     * @endif
+     */
     static constexpr size_t xfrm_failed = static_cast<size_t>(-1);
 
 public:
+    /**
+     * @lang{ZH}
+     * @brief 构造函数，初始化 `collate_conf` 并绑定到指定的 locale。
+     *
+     * 当 `CharT` 为 `char8_t` 时，额外验证 `m_inter_locale` 的 LC_CTYPE 编码集是否为 UTF-8。
+     * `collate<char8_t>` 内部经由窄字符 `strcoll`/`strxfrm` 路径处理，
+     * 这两个函数只有在 LC_CTYPE 编码集为 UTF-8 时才能正确解析 UTF-8 字节输入。
+     * 验证方法是用已知码点对 locale 自身的多字节解码器（`mbrtoc32`）进行探测——
+     * `mbrtoc32` 与 `strcoll`/`strxfrm` 使用相同的 LC_CTYPE 编码集，
+     * 且由于 `m_inter_locale` 以 `LC_ALL_MASK` 从单一名称构造，其 CTYPE 与
+     * COLLATE 编码集一致，故探测结果可代表两者的实际编码。
+     *
+     * @param name locale 名称字符串（例如 `"zh_CN.UTF-8"`）。
+     * @throw cvt_error 若 `CharT` 为 `char8_t` 且 inter locale 的编码集不是 UTF-8。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Constructor that initializes `collate_conf` and binds it to the specified locale.
+     *
+     * When `CharT` is `char8_t`, additionally verifies that the LC_CTYPE codeset of
+     * `m_inter_locale` is UTF-8. `collate<char8_t>` routes internally through the narrow
+     * `strcoll`/`strxfrm` path, which correctly parses UTF-8 byte input only when the
+     * LC_CTYPE codeset is UTF-8. Verification is performed by probing the locale's own
+     * multibyte decoder (`mbrtoc32`) with known code points — `mbrtoc32` uses the same
+     * LC_CTYPE codeset as `strcoll`/`strxfrm`, and because `m_inter_locale` is built from
+     * a single name with `LC_ALL_MASK`, its CTYPE and COLLATE codesets are the same,
+     * so agreement here means `strcoll`/`strxfrm` agree.
+     *
+     * @param name The locale name string (e.g., `"zh_CN.UTF-8"`).
+     * @throw cvt_error If `CharT` is `char8_t` and the inter locale's codeset is not UTF-8.
+     * @endif
+     */
     collate_conf(const std::string& name)
         : ft_basic<collate<CharT>>()
         , m_inter_locale(name.c_str())
     {
         if constexpr (std::is_same_v<CharT, char8_t>)
         {
-            // collate<char8_t> routes through the narrow strcoll/strxfrm path,
-            // which interprets its input as UTF-8 only when the inter locale's
-            // LC_CTYPE codeset is UTF-8. The codeset name from
-            // nl_langinfo(CODESET) is implementation-defined, so rather than
-            // string-matching it we probe the locale's own multibyte decoder on
-            // known code points: mbrtoc32 exercises the same LC_CTYPE codeset
-            // that strcoll/strxfrm use to parse their byte input, and because
-            // m_inter_locale is built from a single name with LC_ALL_MASK its
-            // CTYPE and COLLATE codesets are the same. Agreement here therefore
-            // means strcoll/strxfrm agree.
             struct Probe { const char* mb; size_t len; char32_t cp; };
             static constexpr std::array<Probe, 3> probes = {{
                 {"\xC3\xA9",         2, U'é'},      // U+00E9  e-acute
@@ -64,6 +142,37 @@ public:
     }
 
 public:
+    /**
+     * @lang{ZH}
+     * @brief 比较两个字符序列的排列顺序。
+     *
+     * 使用当前 locale 的 `strcoll`/`wcscoll` 逐段比较两个字符序列。
+     * 序列以空字符（`\0`）为分隔符拆分为多个段，各段依次比较。
+     * 若所有段均相等，则根据序列末尾是否存在额外的空字符来决定最终顺序。
+     *
+     * @param low1 第一个序列的起始指针。
+     * @param high1 第一个序列的结束指针（不包含）。
+     * @param low2 第二个序列的起始指针。
+     * @param high2 第二个序列的结束指针（不包含）。
+     * @return 表示两序列排列关系的 `std::strong_ordering` 值。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Compares the collation order of two character sequences.
+     *
+     * Compares two character sequences segment by segment using the locale's
+     * `strcoll`/`wcscoll`. Each sequence is split into segments delimited by
+     * null characters (`\0`), and segments are compared in order. If all
+     * segments are equal, the final ordering is determined by whether an
+     * extra null character is present at the end of either sequence.
+     *
+     * @param low1 Pointer to the start of the first sequence.
+     * @param high1 Pointer to one past the end of the first sequence.
+     * @param low2 Pointer to the start of the second sequence.
+     * @param high2 Pointer to one past the end of the second sequence.
+     * @return A `std::strong_ordering` value indicating the collation relationship.
+     * @endif
+     */
     virtual std::strong_ordering compare(const CharT* low1, const CharT* high1,
                                          const CharT* low2, const CharT* high2) const
     {
@@ -130,6 +239,35 @@ public:
         return std::strong_ordering::equal;
     }
 
+    /**
+     * @lang{ZH}
+     * @brief 计算排序键变换后所需的存储长度。
+     *
+     * 对字符序列中每个以空字符分隔的段，调用 `strxfrm`/`wcsxfrm`（传入空目标缓冲区）
+     * 以获取各段变换后的长度，并将各段长度及段间分隔符累加后返回总长度。
+     * 该返回值可用作 `transform()` 所需目标缓冲区的容量。
+     *
+     * @param low 字符序列的起始指针。
+     * @param high 字符序列的结束指针（不包含）。
+     * @return 存储完整排序键所需的字符数。
+     * @throw cvt_error 若 `strxfrm`/`wcsxfrm` 报告失败。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Computes the storage length required for the collation-key transformation.
+     *
+     * For each null-delimited segment in the character sequence, calls
+     * `strxfrm`/`wcsxfrm` with a null destination buffer to obtain the transformed
+     * length of that segment. The total length, including inter-segment separators,
+     * is accumulated and returned. The result can be used as the capacity for the
+     * destination buffer passed to `transform()`.
+     *
+     * @param low Pointer to the start of the character sequence.
+     * @param high Pointer to one past the end of the character sequence.
+     * @return The number of characters required to store the complete collation key.
+     * @throw cvt_error If `strxfrm`/`wcsxfrm` reports failure.
+     * @endif
+     */
     virtual size_t transform_length(const CharT* low, const CharT* high) const
     {
         size_t res = 0;
@@ -179,13 +317,44 @@ public:
         return res;
     }
 
+    /**
+     * @lang{ZH}
+     * @brief 将字符序列变换为不透明的排序键。
+     *
+     * 对字符序列中每个以空字符分隔的段，调用 `strxfrm`/`wcsxfrm` 将其变换为排序权重，
+     * 并将结果写入 `dest`。输出的字节是保序的排序权重——对结果执行 `strcmp`/`wcscmp`
+     * 等价于对原始输入执行 `strcoll`/`wcscoll`——并非可读的字符序列，也不应被解码。
+     * 各段之间以空字符 `'\0'` 分隔以保持段间结构。
+     *
+     * @param low 字符序列的起始指针。
+     * @param high 字符序列的结束指针（不包含）。
+     * @param dest 写入排序键的目标缓冲区。
+     * @param mx_len 最多写入的字符数；传入 `0` 表示不限制。
+     * @return 实际写入 `dest` 的字符数。
+     * @throw cvt_error 若 `strxfrm`/`wcsxfrm` 报告失败。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Transforms a character sequence into an opaque collation key.
+     *
+     * For each null-delimited segment in the character sequence, calls
+     * `strxfrm`/`wcsxfrm` to produce order-preserving sort weights, and writes
+     * the result into `dest`. The output bytes are collation weights — comparing
+     * the result with `strcmp`/`wcscmp` reproduces the `strcoll`/`wcscoll` order
+     * on the original input — and are not a readable or valid character sequence;
+     * they must never be decoded. Segments are separated by null characters `'\0'`
+     * to preserve inter-segment structure.
+     *
+     * @param low Pointer to the start of the character sequence.
+     * @param high Pointer to one past the end of the character sequence.
+     * @param dest Destination buffer where the collation key is written.
+     * @param mx_len Maximum number of characters to write; pass `0` for unlimited.
+     * @return The number of characters actually written to `dest`.
+     * @throw cvt_error If `strxfrm`/`wcsxfrm` reports failure.
+     * @endif
+     */
     virtual size_t transform(const CharT* low, const CharT* high, CharT* dest, size_t mx_len = 0) const
     {
-        // transform() emits an opaque collation key, not text: the output bytes
-        // are order-preserving sort weights — strcmp/wcscmp on the result
-        // reproduces strcoll/wcscoll on the input — and are NOT a readable or
-        // valid char/UTF sequence. The key is only ever compared bytewise,
-        // never decoded back to characters.
         size_t trans_count = 0;
         // All buffers are hoisted out of the loop so resize() reuses their
         // capacity instead of reallocating per segment.
@@ -272,14 +441,30 @@ public:
         return trans_count;
     }
 private:
-    // m_inter_locale is shared across compare / transform_length / transform,
-    // all of which are const. Each call constructs a clocale_user that calls
-    // uselocale(m_inter_locale.c_locale) to swap the calling thread's locale.
-    // POSIX does not explicitly guarantee that the same locale_t may be
-    // passed to uselocale() concurrently from multiple threads; IOv2 relies
-    // on the de-facto thread-safety provided by glibc and macOS libc on the
-    // target platforms (Linux / macOS). Porting to platforms with stricter
-    // semantics requires reevaluating this assumption.
+    /**
+     * @lang{ZH}
+     * @brief 封装了底层 C locale 的 RAII 包装器，用于驱动 `strcoll`/`strxfrm` 等操作。
+     *
+     * 由 `compare()`、`transform_length()` 和 `transform()` 共享，这三个函数均为 `const`。
+     * 每次调用均构造一个 `clocale_user`，通过 `uselocale(m_inter_locale.c_locale)`
+     * 切换调用线程的 locale。POSIX 未明确保证同一 `locale_t` 可被多个线程并发传递给
+     * `uselocale()`；IOv2 依赖 glibc 和 macOS libc 在目标平台（Linux/macOS）上提供的
+     * 事实上的线程安全性。移植到语义更严格的平台时需重新评估此假设。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief RAII wrapper encapsulating the underlying C locale used by `strcoll`/`strxfrm` and related calls.
+     *
+     * Shared across `compare()`, `transform_length()`, and `transform()`,
+     * all of which are `const`. Each call constructs a `clocale_user` that calls
+     * `uselocale(m_inter_locale.c_locale)` to swap the calling thread's locale.
+     * POSIX does not explicitly guarantee that the same `locale_t` may be
+     * passed to `uselocale()` concurrently from multiple threads; IOv2 relies
+     * on the de-facto thread-safety provided by glibc and macOS libc on the
+     * target platforms (Linux / macOS). Porting to platforms with stricter
+     * semantics requires reevaluating this assumption.
+     * @endif
+     */
     clocale_wrapper   m_inter_locale;
 };
 }

--- a/include/facet/numeric.h
+++ b/include/facet/numeric.h
@@ -1,3 +1,16 @@
+/**
+ * @file numeric.h
+ * @lang{ZH}
+ * 定义了 `numeric<CharT>` facet 类，提供基于 locale 的数值格式化（输出）与解析（输入）功能。
+ * 涵盖整数、浮点数、布尔值和指针类型，支持分组、基数、符号、对齐和精度等格式化控制。
+ * @endif
+ *
+ * @lang{EN}
+ * Defines the `numeric<CharT>` facet class, providing locale-aware numeric formatting
+ * (output) and parsing (input). Covers integer, floating-point, boolean, and pointer
+ * types, with support for grouping, base, sign, alignment, and precision formatting controls.
+ * @endif
+ */
 #pragma once
 #include <common/clocale_wrapper.h>
 #include <common/metafunctions.h>
@@ -26,13 +39,87 @@
 
 namespace IOv2
 {
+/**
+ * @lang{ZH}
+ * @brief 基于 locale 的数值格式化与解析 facet。
+ *
+ * 封装了 `numeric_conf<CharT>` 提供的 locale 参数（小数点、千位分隔符、分组规则、布尔名称）
+ * 和 `ctype<CharT>` 提供的字符扩宽能力，通过 `put()` 系列重载将数值格式化为字符序列，
+ * 通过 `get()` 系列重载从字符流中解析数值。
+ *
+ * @tparam CharT 字符类型。
+ * @endif
+ *
+ * @lang{EN}
+ * @brief A locale-aware numeric formatting and parsing facet.
+ *
+ * Encapsulates locale parameters from `numeric_conf<CharT>` (decimal point, thousands
+ * separator, grouping rules, boolean names) and character-widening from `ctype<CharT>`.
+ * Numeric values are formatted into character sequences via `put()` overloads, and
+ * parsed from character streams via `get()` overloads.
+ *
+ * @tparam CharT The character type.
+ * @endif
+ */
 template <typename CharT>
 class numeric
 {
 public:
+    /**
+     * @lang{ZH}
+     * @brief 关联的配置对象创建规则类型。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief The creation-rule type for the associated configuration objects.
+     * @endif
+     */
     using create_rules = facet_create_rule<facet_create_pack<numeric_conf<CharT>, ctype<CharT>>>;
+
+    /**
+     * @lang{ZH}
+     * @brief 字符类型。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief The character type.
+     * @endif
+     */
     using char_type = CharT;
 
+    /**
+     * @lang{ZH}
+     * @brief 构造函数，初始化所有 locale 相关参数并预先扩宽输入/输出原子字符集。
+     *
+     * 从 `numeric_conf` 中复制小数点、千位分隔符、分组规则和布尔名称，
+     * 然后通过 `ctype::widen_seq` 将两组 ASCII 原子字符集扩宽为目标字符类型，
+     * 分别填充 `m_in_atoms`（用于解析）和 `m_out_atoms`（用于格式化）。
+     * 在 `wchar_t` 和 `char32_t` 类型下，还会在 debug/sanitizer 构建中断言
+     * 扩宽结果的单射性。
+     *
+     * @tparam TConfPtr 满足 `shared_ptr_to<numeric_conf<CharT>>` 约束的共享指针类型。
+     * @tparam TCtypePtr 满足 `shared_ptr_to<ctype<CharT>>` 约束的共享指针类型。
+     * @param p_obj 指向 `numeric_conf` 配置对象的共享指针，不得为空。
+     * @param p_ctype 指向 `ctype` 配置对象的共享指针，不得为空。
+     * @throw std::runtime_error 若任一指针为空。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Constructor that initializes all locale-related parameters and pre-widens the input/output atom character sets.
+     *
+     * Copies the decimal point, thousands separator, grouping rules, and boolean names
+     * from `numeric_conf`, then widens two ASCII atom character sets to the target
+     * character type via `ctype::widen_seq`, populating `m_in_atoms` (for parsing)
+     * and `m_out_atoms` (for formatting). On `wchar_t` and `char32_t`, also asserts
+     * the injectivity of the widened results in debug/sanitizer builds.
+     *
+     * @tparam TConfPtr A shared pointer type satisfying `shared_ptr_to<numeric_conf<CharT>>`.
+     * @tparam TCtypePtr A shared pointer type satisfying `shared_ptr_to<ctype<CharT>>`.
+     * @param p_obj Shared pointer to the `numeric_conf` configuration object; must not be null.
+     * @param p_ctype Shared pointer to the `ctype` configuration object; must not be null.
+     * @throw std::runtime_error If either pointer is null.
+     * @endif
+     */
     template <shared_ptr_to<numeric_conf<CharT>> TConfPtr,
               shared_ptr_to<ctype<CharT>> TCtypePtr>
     numeric(TConfPtr p_obj, TCtypePtr p_ctype) : m_ctype(p_ctype)
@@ -76,13 +163,111 @@ public:
     }
 
 public:
+    /**
+     * @lang{ZH}
+     * @brief 返回此 locale 的小数点字符。
+     * @return 小数点字符。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the decimal point character for this locale.
+     * @return The decimal point character.
+     * @endif
+     */
     CharT decimal_point() const noexcept { return m_decimal_point; }
+
+    /**
+     * @lang{ZH}
+     * @brief 返回此 locale 的千位分隔符字符。
+     *
+     * 若返回值为 `CharT('\0')`，表示不使用分隔符，此时 `grouping()` 必为空。
+     * @return 千位分隔符字符，或 `CharT('\0')`（不使用分隔符时）。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the thousands separator character for this locale.
+     *
+     * A return value of `CharT('\0')` indicates that no separator is used,
+     * in which case `grouping()` is always empty.
+     * @return The thousands separator character, or `CharT('\0')` if none is used.
+     * @endif
+     */
     CharT thousands_sep() const noexcept { return m_thousands_sep; }
+
+    /**
+     * @lang{ZH}
+     * @brief 返回此 locale 中 `true` 的文本表示。
+     * @return `true` 的文本字符串。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the textual representation of `true` for this locale.
+     * @return The text string for `true`.
+     * @endif
+     */
     const std::basic_string<CharT>& truename() const noexcept { return m_true_name; }
+
+    /**
+     * @lang{ZH}
+     * @brief 返回此 locale 中 `false` 的文本表示。
+     * @return `false` 的文本字符串。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the textual representation of `false` for this locale.
+     * @return The text string for `false`.
+     * @endif
+     */
     const std::basic_string<CharT>& falsename() const noexcept { return m_false_name; }
+
+    /**
+     * @lang{ZH}
+     * @brief 返回数字分组规则（内部规范化格式）。
+     *
+     * 向量中每个元素表示一个数字组的位数。若向量为空，则表示不进行分组。
+     * @return 数字分组规则向量；为空时表示不分组。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the digit grouping specification in the internal normalized form.
+     *
+     * Each element in the vector specifies the number of digits in one group.
+     * An empty vector indicates that no grouping is applied.
+     * @return The digit grouping vector; empty means no grouping.
+     * @endif
+     */
     [[nodiscard]] const std::vector<uint8_t>& grouping() const noexcept { return m_grouping; }
 
 public:
+    /**
+     * @lang{ZH}
+     * @brief 将布尔值格式化并写入输出迭代器。
+     *
+     * 若 `boolalpha` 标志未设置，则以整数（0/1）形式格式化，委托给 `insert_int`。
+     * 若设置了 `boolalpha`，则使用 locale 的 `truename()`/`falsename()` 文本，
+     * 并按 `width()` 和对齐方式插入填充字符。
+     *
+     * @tparam TIter 输出迭代器类型。
+     * @param s 输出迭代器，写入格式化结果。
+     * @param io 提供格式标志、宽度和填充字符的流对象。
+     * @param v 要格式化的布尔值。
+     * @return 写入结束后的输出迭代器。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Formats a boolean value and writes it to the output iterator.
+     *
+     * Without `boolalpha`, formats as integer 0 or 1 by delegating to `insert_int`.
+     * With `boolalpha`, uses the locale's `truename()`/`falsename()` text with width
+     * and alignment padding applied.
+     *
+     * @tparam TIter The output iterator type.
+     * @param s Output iterator to receive the formatted result.
+     * @param io Stream object providing format flags, width, and fill character.
+     * @param v The boolean value to format.
+     * @return The output iterator after writing.
+     * @endif
+     */
     template <typename TIter>
     TIter put(TIter s, ios_base<char_type>& io, bool v) const
     {
@@ -118,10 +303,60 @@ public:
         return std::copy(name.begin(), name.end(), s);
     }
 
+    /**
+     * @lang{ZH}
+     * @brief 将整数值格式化并写入输出迭代器，委托给 `insert_int`。
+     *
+     * @tparam TIter 输出迭代器类型。
+     * @tparam TValue 整数类型（非 `bool`）。
+     * @param s 输出迭代器，写入格式化结果。
+     * @param io 提供格式标志、宽度和填充字符的流对象。
+     * @param v 要格式化的整数值。
+     * @return 写入结束后的输出迭代器。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Formats an integer value and writes it to the output iterator; delegates to `insert_int`.
+     *
+     * @tparam TIter The output iterator type.
+     * @tparam TValue The integer type (not `bool`).
+     * @param s Output iterator to receive the formatted result.
+     * @param io Stream object providing format flags, width, and fill character.
+     * @param v The integer value to format.
+     * @return The output iterator after writing.
+     * @endif
+     */
     template <typename TIter, typename TValue>
         requires (std::is_integral_v<TValue> && (!std::is_same_v<TValue, bool>))
     TIter put(TIter s, ios_base<char_type>& io, TValue v) const { return insert_int(s, io, v); }
 
+    /**
+     * @lang{ZH}
+     * @brief 将浮点值格式化并写入输出迭代器，委托给 `insert_float`。
+     *
+     * `long double` 使用 `'L'` 修饰符；其他浮点类型使用空修饰符。
+     *
+     * @tparam TIter 输出迭代器类型。
+     * @tparam TValue 浮点类型。
+     * @param s 输出迭代器，写入格式化结果。
+     * @param io 提供格式标志、宽度、精度和填充字符的流对象。
+     * @param v 要格式化的浮点值。
+     * @return 写入结束后的输出迭代器。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Formats a floating-point value and writes it to the output iterator; delegates to `insert_float`.
+     *
+     * Uses the `'L'` modifier for `long double`; uses an empty modifier for other floating-point types.
+     *
+     * @tparam TIter The output iterator type.
+     * @tparam TValue The floating-point type.
+     * @param s Output iterator to receive the formatted result.
+     * @param io Stream object providing format flags, width, precision, and fill character.
+     * @param v The floating-point value to format.
+     * @return The output iterator after writing.
+     * @endif
+     */
     template <typename TIter, typename TValue>
         requires (std::is_floating_point_v<TValue>)
     TIter put(TIter s, ios_base<char_type>& io, TValue v) const
@@ -132,6 +367,34 @@ public:
             return insert_float(s, io, v, char());
     }
 
+    /**
+     * @lang{ZH}
+     * @brief 将指针值以十六进制格式化并写入输出迭代器。
+     *
+     * 临时将流标志设为 `hex | showbase`（通过 `fmtflags_guard` 保证恢复），
+     * 然后将指针值转型为与平台指针大小匹配的无符号整数类型，委托给 `insert_int` 格式化。
+     *
+     * @tparam TIter 输出迭代器类型。
+     * @param s 输出迭代器，写入格式化结果。
+     * @param io 提供格式标志、宽度和填充字符的流对象。
+     * @param v 要格式化的指针值。
+     * @return 写入结束后的输出迭代器。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Formats a pointer value in hexadecimal and writes it to the output iterator.
+     *
+     * Temporarily sets the stream flags to `hex | showbase` (restored by `fmtflags_guard`),
+     * then casts the pointer to a platform-sized unsigned integer type and delegates
+     * to `insert_int`.
+     *
+     * @tparam TIter The output iterator type.
+     * @param s Output iterator to receive the formatted result.
+     * @param io Stream object providing format flags, width, and fill character.
+     * @param v The pointer value to format.
+     * @return The output iterator after writing.
+     * @endif
+     */
     template <typename TIter>
     TIter put(TIter s, ios_base<char_type>& io, const void* v) const
     {
@@ -146,6 +409,46 @@ public:
         return insert_int(s, io, reinterpret_cast<uintptr_carrier_t>(v)); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
     }
 
+    /**
+     * @lang{ZH}
+     * @brief 从字符流中解析布尔值。
+     *
+     * 若 `boolalpha` 标志未设置，则将输入解析为 `long`（有效值为 0 或 1），
+     * 超出范围则按 LWG 23 将结果设为 `true` 并失败。
+     * 若设置了 `boolalpha`，则将输入字符与 `truename()`/`falsename()` 逐字符前缀匹配，
+     * 以最长匹配确定结果；若无法确定，则按 LWG 23 将结果设为 `false` 并失败。
+     * 解析失败时抛出异常。
+     *
+     * @tparam TIter 输入迭代器类型。
+     * @tparam TSent 哨兵类型，满足 `std::sentinel_for<TIter>`。
+     * @param beg 输入范围的起始迭代器。
+     * @param end 输入范围的结束哨兵。
+     * @param io 提供格式标志的流对象。
+     * @param v 解析成功后写入结果的布尔值引用。
+     * @return 消费输入后的迭代器。
+     * @throw stream_error 若解析失败。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Parses a boolean value from the character stream.
+     *
+     * Without `boolalpha`, the input is parsed as a `long` (valid values are 0 or 1);
+     * out-of-range values set the result to `true` and fail per LWG 23.
+     * With `boolalpha`, the input is matched character by character against
+     * `truename()`/`falsename()` using the longest-match rule; if no match is
+     * determined, the result is set to `false` and fails per LWG 23.
+     * Throws on parse failure.
+     *
+     * @tparam TIter The input iterator type.
+     * @tparam TSent The sentinel type satisfying `std::sentinel_for<TIter>`.
+     * @param beg Start iterator of the input range.
+     * @param end End sentinel of the input range.
+     * @param io Stream object providing format flags.
+     * @param v Reference to the boolean variable to receive the parsed result.
+     * @return The iterator after consuming the parsed input.
+     * @throw stream_error If parsing fails.
+     * @endif
+     */
     template <typename TIter, std::sentinel_for<TIter> TSent>
     TIter get(TIter beg, TSent end, ios_base<char_type>& io, bool& v) const
     {
@@ -222,6 +525,39 @@ public:
         return beg;
     }
 
+    /**
+     * @lang{ZH}
+     * @brief 从字符流中解析整数值，委托给 `extract_int`。
+     *
+     * 解析失败时抛出异常。
+     *
+     * @tparam TIter 输入迭代器类型。
+     * @tparam TSent 哨兵类型，满足 `std::sentinel_for<TIter>`。
+     * @tparam TValue 目标整数类型（非 `bool`）。
+     * @param beg 输入范围的起始迭代器。
+     * @param end 输入范围的结束哨兵。
+     * @param io 提供格式标志的流对象。
+     * @param v 解析成功后写入结果的整数引用。
+     * @return 消费输入后的迭代器。
+     * @throw stream_error 若解析失败。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Parses an integer value from the character stream; delegates to `extract_int`.
+     *
+     * Throws on parse failure.
+     *
+     * @tparam TIter The input iterator type.
+     * @tparam TSent The sentinel type satisfying `std::sentinel_for<TIter>`.
+     * @tparam TValue The target integer type (not `bool`).
+     * @param beg Start iterator of the input range.
+     * @param end End sentinel of the input range.
+     * @param io Stream object providing format flags.
+     * @param v Reference to the integer variable to receive the parsed result.
+     * @return The iterator after consuming the parsed input.
+     * @throw stream_error If parsing fails.
+     * @endif
+     */
     template <typename TIter, std::sentinel_for<TIter> TSent, typename TValue>
         requires (std::is_integral_v<TValue> && (!std::is_same_v<TValue, bool>))
     TIter get(TIter beg, TSent end, ios_base<char_type>& io, TValue& v) const
@@ -231,6 +567,40 @@ public:
         return res;
     }
 
+    /**
+     * @lang{ZH}
+     * @brief 从字符流中解析指针地址（十六进制整数）。
+     *
+     * 临时将流标志设为 `hex`，使用与平台指针大小匹配的无符号整数类型调用 `extract_int`，
+     * 再将结果转型为 `void*`。解析失败时抛出异常。
+     *
+     * @tparam TIter 输入迭代器类型。
+     * @tparam TSent 哨兵类型，满足 `std::sentinel_for<TIter>`。
+     * @param beg 输入范围的起始迭代器。
+     * @param end 输入范围的结束哨兵。
+     * @param io 提供格式标志的流对象。
+     * @param v 解析成功后写入结果的指针引用。
+     * @return 消费输入后的迭代器。
+     * @throw stream_error 若解析失败。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Parses a pointer address (hexadecimal integer) from the character stream.
+     *
+     * Temporarily sets the stream flags to `hex`, calls `extract_int` with a
+     * platform-sized unsigned integer type, then casts the result to `void*`.
+     * Throws on parse failure.
+     *
+     * @tparam TIter The input iterator type.
+     * @tparam TSent The sentinel type satisfying `std::sentinel_for<TIter>`.
+     * @param beg Start iterator of the input range.
+     * @param end End sentinel of the input range.
+     * @param io Stream object providing format flags.
+     * @param v Reference to the pointer variable to receive the parsed result.
+     * @return The iterator after consuming the parsed input.
+     * @throw stream_error If parsing fails.
+     * @endif
+     */
     template <typename TIter, std::sentinel_for<TIter> TSent>
     TIter get(TIter beg, TSent end, ios_base<char_type>& io, void*& v) const
     {
@@ -249,6 +619,42 @@ public:
         return res;
     }
 
+    /**
+     * @lang{ZH}
+     * @brief 从字符流中解析浮点值。
+     *
+     * 先由 `extract_float` 将有效字符提取并规范化为 "C" locale 的 ASCII 字符串，
+     * 再由 `convert_to_v` 将其转换为目标浮点类型。解析失败时抛出异常。
+     *
+     * @tparam TIter 输入迭代器类型。
+     * @tparam TSent 哨兵类型，满足 `std::sentinel_for<TIter>`。
+     * @tparam TValue 目标浮点类型。
+     * @param beg 输入范围的起始迭代器。
+     * @param end 输入范围的结束哨兵。
+     * @param io 提供格式标志的流对象。
+     * @param v 解析成功后写入结果的浮点数引用。
+     * @return 消费输入后的迭代器。
+     * @throw stream_error 若解析失败。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Parses a floating-point value from the character stream.
+     *
+     * First, `extract_float` extracts and normalizes the numeric characters into a
+     * "C"-locale ASCII string; then `convert_to_v` converts it to the target
+     * floating-point type. Throws on parse failure.
+     *
+     * @tparam TIter The input iterator type.
+     * @tparam TSent The sentinel type satisfying `std::sentinel_for<TIter>`.
+     * @tparam TValue The target floating-point type.
+     * @param beg Start iterator of the input range.
+     * @param end End sentinel of the input range.
+     * @param io Stream object providing format flags.
+     * @param v Reference to the floating-point variable to receive the parsed result.
+     * @return The iterator after consuming the parsed input.
+     * @throw stream_error If parsing fails.
+     * @endif
+     */
     template <typename TIter, std::sentinel_for<TIter> TSent, typename TValue>
         requires (std::is_floating_point_v<TValue>)
     TIter get(TIter beg, TSent end, ios_base<char_type>& io, TValue& v) const
@@ -263,6 +669,20 @@ public:
     }
 
 private:
+    /**
+     * @lang{ZH}
+     * @brief RAII 守卫，在析构时自动恢复 `ios_base` 的格式标志。
+     *
+     * 用于在临时修改格式标志的代码块中，确保即使发生异常也能还原原始标志。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief RAII guard that automatically restores the format flags of an `ios_base` object on destruction.
+     *
+     * Used in code blocks that temporarily modify format flags, ensuring the original
+     * flags are restored even if an exception is thrown.
+     * @endif
+     */
     struct fmtflags_guard
     {
         fmtflags_guard(ios_base<char_type>& i) : m_io(i), m_saved(i.flags()) {}
@@ -276,6 +696,42 @@ private:
         ios_defs::fmtflags m_saved;
     };
 
+    /**
+     * @lang{ZH}
+     * @brief 将浮点值格式化为字符类型序列并写入输出迭代器。
+     *
+     * 在 "C" locale 下通过 `snprintf` 生成 ASCII 表示（阶段 1），
+     * 再用 `ctype::widen_seq` 扩宽为目标字符类型，并将 ASCII 小数点替换为
+     * locale 专有字符（阶段 2），按需插入千位分隔符，最后应用对齐填充（阶段 3/4）。
+     *
+     * @tparam TIter 输出迭代器类型。
+     * @tparam TValue 浮点类型。
+     * @param s 输出迭代器，写入格式化结果。
+     * @param io 提供格式标志、宽度和精度的流对象。
+     * @param v 要格式化的浮点值。
+     * @param mod `snprintf` 长度修饰符（`'L'` 表示 `long double`，`'\0'` 表示其他类型）。
+     * @return 写入结束后的输出迭代器。
+     * @throw stream_error 若 `snprintf` 转换失败或输出为空。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Formats a floating-point value as a character-type sequence and writes it to the output iterator.
+     *
+     * Generates an ASCII representation via `snprintf` under the "C" locale (stage 1),
+     * widens it to the target character type via `ctype::widen_seq`, replaces the ASCII
+     * decimal point with the locale-specific character (stage 2), inserts grouping
+     * separators if needed, then applies alignment padding (stages 3/4).
+     *
+     * @tparam TIter The output iterator type.
+     * @tparam TValue The floating-point type.
+     * @param s Output iterator to receive the formatted result.
+     * @param io Stream object providing format flags, width, and precision.
+     * @param v The floating-point value to format.
+     * @param mod The `snprintf` length modifier (`'L'` for `long double`, `'\0'` otherwise).
+     * @return The output iterator after writing.
+     * @throw stream_error If `snprintf` conversion fails or produces an empty result.
+     * @endif
+     */
     template <typename TIter, typename TValue>
     TIter insert_float(TIter s, ios_base<char_type>& io, TValue v, char mod) const
     {
@@ -404,6 +860,37 @@ private:
         return std::copy(ws, ws + len, s);
     }
 
+    /**
+     * @lang{ZH}
+     * @brief 将整数值格式化为字符类型序列并写入输出迭代器。
+     *
+     * 按基数（十进制/八进制/十六进制）将数字写入缓冲区（阶段 1），
+     * 按需插入千位分组分隔符，然后前置基数前缀（`0`/`0x`/`0X`）或符号（`+`/`-`），
+     * 最后应用对齐填充（阶段 3/4）。
+     *
+     * @tparam TIter 输出迭代器类型。
+     * @tparam TValue 整数类型。
+     * @param s 输出迭代器，写入格式化结果。
+     * @param io 提供格式标志、宽度和填充字符的流对象。
+     * @param v 要格式化的整数值。
+     * @return 写入结束后的输出迭代器。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Formats an integer value as a character-type sequence and writes it to the output iterator.
+     *
+     * Converts digits by radix (decimal/octal/hexadecimal) into a buffer (stage 1),
+     * inserts grouping separators as needed, prepends the base prefix (`0`/`0x`/`0X`)
+     * or sign (`+`/`-`), then applies alignment padding (stages 3/4).
+     *
+     * @tparam TIter The output iterator type.
+     * @tparam TValue The integer type.
+     * @param s Output iterator to receive the formatted result.
+     * @param io Stream object providing format flags, width, and fill character.
+     * @param v The integer value to format.
+     * @return The output iterator after writing.
+     * @endif
+     */
     template <typename TIter, typename TValue>
     TIter insert_int(TIter s, ios_base<char_type>& io, TValue v) const
     {
@@ -485,6 +972,33 @@ private:
         return std::copy(cs, cs + len, s);
     }
 
+    /**
+     * @lang{ZH}
+     * @brief 将无符号整数按指定进制逐位写入缓冲区末端，返回写入的字符数。
+     *
+     * 结果在缓冲区中右对齐（从 `bufend` 向低地址方向填充）。
+     *
+     * @tparam TValue 无符号整数类型。
+     * @param bufend 写入缓冲区的尾后指针（结果从此向低地址填充）。
+     * @param v 要转换的无符号整数值。
+     * @param flags 格式标志，用于选择基数和大小写。
+     * @param dec 若为 `true`，则使用十进制；否则根据 `flags` 选择八进制或十六进制。
+     * @return 写入的字符数。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Converts an unsigned integer to characters in the specified base, writing right-to-left from the buffer end.
+     *
+     * The result is right-justified in the buffer (filled from `bufend` toward lower addresses).
+     *
+     * @tparam TValue The unsigned integer type.
+     * @param bufend One-past-the-end pointer of the write buffer (filling goes toward lower addresses).
+     * @param v The unsigned integer value to convert.
+     * @param flags Format flags used to select the radix and case.
+     * @param dec If `true`, use decimal; otherwise select octal or hexadecimal from `flags`.
+     * @return The number of characters written.
+     * @endif
+     */
     template <typename TValue>
     int int_to_char(CharT* bufend, TValue v, ios_defs::fmtflags flags, bool dec) const
     {
@@ -518,6 +1032,33 @@ private:
         return bufend - buf;
     }
 
+    /**
+     * @lang{ZH}
+     * @brief 对格式化缓冲区应用宽度填充，委托给 `pad_impl_`。同时将 `len` 更新为填充后的总宽度。
+     *
+     * @param fill 填充字符。
+     * @param w 目标字段宽度。
+     * @param adjust 对齐标志（left/right/internal）。
+     * @param new_buf 输出缓冲区，容量不小于 `w`。
+     * @param cs 原始格式化内容的起始指针。
+     * @param len 原始内容的字符数；函数返回后更新为 `w`。
+     * @param startSign 原始内容是否以符号字符（`+`/`-`）开头。
+     * @param start0x 原始内容是否以 `0x`/`0X` 开头。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Applies width padding to the formatted buffer; delegates to `pad_impl_`. Updates `len` to the padded total width.
+     *
+     * @param fill The fill character.
+     * @param w The target field width.
+     * @param adjust The alignment flag (left/right/internal).
+     * @param new_buf Output buffer with capacity of at least `w`.
+     * @param cs Pointer to the start of the original formatted content.
+     * @param len Number of characters in the original content; updated to `w` on return.
+     * @param startSign Whether the original content begins with a sign character (`+`/`-`).
+     * @param start0x Whether the original content begins with `0x`/`0X`.
+     * @endif
+     */
     void pad(char_type fill, std::streamsize w, ios_defs::fmtflags adjust,
              char_type* new_buf, const char_type* cs, size_t& len,
              bool startSign, bool start0x) const
@@ -528,6 +1069,44 @@ private:
       len = static_cast<size_t>(w);
     }
 
+    /**
+     * @lang{ZH}
+     * @brief 按对齐方式将原始内容与填充字符合并到新缓冲区中。
+     *
+     * - 左对齐：内容在前，填充在后。
+     * - 右对齐：填充在前，内容在后。
+     * - 内部对齐：若内容以符号字符开头则将其保留在最前，若以 `0x`/`0X` 开头则保留两字符，
+     *   之后插入填充，最后是剩余内容。
+     *
+     * @param adjust 对齐标志。
+     * @param fill 填充字符。
+     * @param news 输出缓冲区起始指针。
+     * @param olds 原始内容起始指针。
+     * @param newlen 填充后的总字符数（即字段宽度）。
+     * @param oldlen 原始内容的字符数。
+     * @param startSign 原始内容是否以符号字符开头。
+     * @param start0x 原始内容是否以 `0x`/`0X` 开头。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Merges the original content and fill characters into a new buffer according to the alignment.
+     *
+     * - Left-align: content first, fill last.
+     * - Right-align: fill first, content last.
+     * - Internal: if the content begins with a sign character it is placed first; if it
+     *   begins with `0x`/`0X` those two characters are placed first; then fill is inserted,
+     *   followed by the remaining content.
+     *
+     * @param adjust The alignment flag.
+     * @param fill The fill character.
+     * @param news Pointer to the start of the output buffer.
+     * @param olds Pointer to the start of the original content.
+     * @param newlen Total character count after padding (i.e., the field width).
+     * @param oldlen Character count of the original content.
+     * @param startSign Whether the original content begins with a sign character.
+     * @param start0x Whether the original content begins with `0x`/`0X`.
+     * @endif
+     */
     void pad_impl_(ios_defs::fmtflags adjust, char_type fill,
                    char_type* news, const char_type* olds,
                    std::streamsize newlen, std::streamsize oldlen,
@@ -569,6 +1148,29 @@ private:
         std::copy(olds + mod, olds + oldlen, news + plen);
     }
 
+    /**
+     * @lang{ZH}
+     * @brief 根据 `ios_base` 格式标志构造 `snprintf` 用的格式字符串，写入 `fptr`。
+     *
+     * 按照 C++ 标准 [22.2.2.2.2] 表 58/60 的规则，将 `showpos`、`showpoint`、
+     * `floatfield` 和 `uppercase` 等标志翻译为对应的 `printf` 格式说明符。
+     *
+     * @param flags 当前流的格式标志。
+     * @param fptr 写入格式字符串的字符缓冲区，调用者保证容量足够（至少 16 字节）。
+     * @param mod 长度修饰符（`'L'` 或 `'\0'`）。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Builds the `snprintf` format string from the `ios_base` format flags, writing to `fptr`.
+     *
+     * Translates `showpos`, `showpoint`, `floatfield`, and `uppercase` flags into the
+     * corresponding `printf` format specifiers following C++ standard [22.2.2.2.2] tables 58/60.
+     *
+     * @param flags The current stream format flags.
+     * @param fptr Character buffer to receive the format string; the caller guarantees sufficient capacity (at least 16 bytes).
+     * @param mod The length modifier (`'L'` or `'\0'`).
+     * @endif
+     */
     void format_float_(ios_defs::fmtflags flags, char* fptr, char mod) const noexcept
     {
         *fptr++ = '%';
@@ -600,6 +1202,35 @@ private:
         *fptr = '\0';
     }
 
+    /**
+     * @lang{ZH}
+     * @brief 向浮点数的整数部分插入千位分隔符，保留小数部分不变，并更新 `len`。
+     *
+     * 通过 `FacetHelper::add_grouping` 在整数部分插入 `sep`，然后将
+     * 原始内容中小数点及其后的部分原样追加到结果末尾。
+     *
+     * @param grouping 数字分组规则（内部规范化格式）。
+     * @param sep 千位分隔符字符。
+     * @param p 指向宽字符缓冲区中小数点位置的指针；若无小数点则为 `nullptr`。
+     * @param new_buf 输出缓冲区。
+     * @param cs 输入宽字符缓冲区的起始指针。
+     * @param len 输入字符数；函数返回后更新为输出字符数。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Inserts grouping separators into the integer part of a floating-point number, leaving the fractional part unchanged, and updates `len`.
+     *
+     * Uses `FacetHelper::add_grouping` to insert `sep` into the integer part, then
+     * appends the decimal point and everything after it from the original content.
+     *
+     * @param grouping Digit grouping rules (internal normalized form).
+     * @param sep The thousands separator character.
+     * @param p Pointer to the decimal point position in the wide-character buffer; `nullptr` if no decimal point.
+     * @param new_buf Output buffer.
+     * @param cs Pointer to the start of the input wide-character buffer.
+     * @param len Input character count; updated to the output character count on return.
+     * @endif
+     */
     void group_float(const std::vector<uint8_t>& grouping, char_type sep, const char_type* p, char_type* new_buf, char_type* cs, size_t& len) const
     {
         // _GLIBCXX_RESOLVE_LIB_DEFECTS
@@ -618,6 +1249,48 @@ private:
         len = newlen;
     }
 
+    /**
+     * @lang{ZH}
+     * @brief 从字符流中提取整数字段并解析为 `TValue`。
+     *
+     * 自动检测基数前缀（`0x`/`0X` 表示十六进制，`0` 表示八进制），
+     * 在 `basefield == 0` 时依据输入内容动态确定基数。
+     * 在提取过程中同步累计分组信息，提取完成后调用 `FacetHelper::verify_grouping`
+     * 校验是否符合 locale 的分组规则。
+     * 溢出时按 LWG 23 将结果设为 `numeric_limits` 的极值并返回失败；
+     * 溢出信号优先于分组校验失败，以避免将结构合法但数值越界的输入误归类为格式错误。
+     *
+     * @tparam TIter 输入迭代器类型。
+     * @tparam TSent 哨兵类型。
+     * @tparam TValue 目标整数类型。
+     * @param beg 输入范围的起始迭代器。
+     * @param end 输入范围的结束哨兵。
+     * @param io 提供格式标志的流对象。
+     * @param v 解析成功后写入结果的整数引用。
+     * @return `{成功标志, 消费后迭代器}` 的 `pair`。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Extracts an integer field from the character stream and parses it into `TValue`.
+     *
+     * Automatically detects base prefixes (`0x`/`0X` for hexadecimal, `0` for octal),
+     * and determines the base dynamically from the input when `basefield == 0`.
+     * Grouping information is accumulated during extraction and validated by
+     * `FacetHelper::verify_grouping` after extraction. On overflow, the result is clamped
+     * to the `numeric_limits` extreme value and failure is returned per LWG 23; the overflow
+     * signal takes priority over grouping-check failure to avoid misclassifying
+     * structurally valid but out-of-range input as a format error.
+     *
+     * @tparam TIter The input iterator type.
+     * @tparam TSent The sentinel type.
+     * @tparam TValue The target integer type.
+     * @param beg Start iterator of the input range.
+     * @param end End sentinel of the input range.
+     * @param io Stream object providing format flags.
+     * @param v Reference to the integer variable to receive the parsed result.
+     * @return A `pair` of `{success flag, iterator after consumed input}`.
+     * @endif
+     */
     template <typename TIter, std::sentinel_for<TIter> TSent, typename TValue>
     std::pair<bool, TIter> extract_int(TIter beg, TSent end, ios_base<char_type>& io, TValue& v) const
     {
@@ -807,6 +1480,42 @@ private:
         return std::pair(success, beg);
     }
 
+    /**
+     * @lang{ZH}
+     * @brief 从字符流中提取浮点数字段，将其规范化为 "C" locale 的 ASCII 字符串。
+     *
+     * 依次识别符号、前导零、整数部分（含千位分隔符和分组校验）、小数点、
+     * 小数部分以及科学计数法指数（含指数符号）。
+     * 所有识别到的字符都被转换为对应的 ASCII 字符并追加到 `xtrc`，
+     * 以便随后由 `convert_to_v` 在 "C" locale 下调用 `strtof`/`strtod`/`strtold` 解析。
+     *
+     * @tparam TIter 输入迭代器类型。
+     * @tparam TSent 哨兵类型。
+     * @param beg 输入范围的起始迭代器。
+     * @param end 输入范围的结束哨兵。
+     * @param io 提供格式标志的流对象。
+     * @param xtrc 接收规范化 ASCII 字符串的输出字符串；调用前应已预留容量。
+     * @return `{成功标志, 消费后迭代器}` 的 `pair`。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Extracts a floating-point field from the character stream and normalizes it into a "C"-locale ASCII string.
+     *
+     * Recognizes, in order: sign, leading zeros, integer part (including grouping
+     * separators and grouping validation), decimal point, fractional digits, and
+     * scientific-notation exponent (including exponent sign). All recognized characters
+     * are translated to their ASCII equivalents and appended to `xtrc`, ready for
+     * `strtof`/`strtod`/`strtold` under the "C" locale inside `convert_to_v`.
+     *
+     * @tparam TIter The input iterator type.
+     * @tparam TSent The sentinel type.
+     * @param beg Start iterator of the input range.
+     * @param end End sentinel of the input range.
+     * @param io Stream object providing format flags.
+     * @param xtrc Output string that receives the normalized ASCII representation; should have reserved capacity before the call.
+     * @return A `pair` of `{success flag, iterator after consumed input}`.
+     * @endif
+     */
     template <typename TIter, std::sentinel_for<TIter> TSent>
     std::pair<bool, TIter> extract_float(TIter beg, TSent end, ios_base<char_type>& io, std::string& xtrc) const
     {
@@ -1001,6 +1710,34 @@ private:
         return std::pair(success, beg);
     }
 
+    /**
+     * @lang{ZH}
+     * @brief 将 "C" locale 格式的 ASCII 浮点字符串转换为浮点值。
+     *
+     * 在 "C" locale 守卫下调用 `strtof`/`strtod`/`strtold`。
+     * 按 LWG 23 处理特殊情况：无穷大映射为 `numeric_limits::max()` 的有限极值并返回失败；
+     * 转换失败（`sanity == s` 或字符串未完全消耗）时将 `v` 设为 0 并返回失败。
+     *
+     * @tparam TValue 浮点类型（`float`、`double` 或 `long double`）。
+     * @param s 以 `'\0'` 结尾的 "C" locale ASCII 浮点字符串。
+     * @param v 转换成功后写入结果的浮点数引用。
+     * @return 若转换成功且结果为有限值则返回 `true`，否则返回 `false`。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Converts a "C"-locale ASCII floating-point string to a floating-point value.
+     *
+     * Calls `strtof`/`strtod`/`strtold` under a "C" locale guard.
+     * Handles special cases per LWG 23: infinity is mapped to the finite extreme value
+     * `numeric_limits::max()` and failure is returned; conversion failure (when
+     * `sanity == s` or the string is not fully consumed) sets `v` to 0 and returns failure.
+     *
+     * @tparam TValue The floating-point type (`float`, `double`, or `long double`).
+     * @param s Null-terminated "C"-locale ASCII floating-point string.
+     * @param v Reference to the floating-point variable to receive the converted result.
+     * @return `true` if conversion succeeded and the result is finite; `false` otherwise.
+     * @endif
+     */
     template <typename TValue>
     bool convert_to_v(const char* s, TValue& v) const
     {
@@ -1037,19 +1774,41 @@ private:
         return res;
     }
 
-    // Verify ctype::widen is injective on the digit / sign / base / scientific
-    // atom set. extract_int / extract_float compare incoming wide characters
-    // against entries in m_in_atoms (directly or via std::find) and assume
-    // distinct narrow source characters widen to distinct wide values; a
-    // collision (e.g. widen('a') == widen('A') in an exotic locale) would
-    // make certain digits unreachable on the input side, and insert_int /
-    // insert_float would emit indistinguishable glyphs for semantically
-    // different positions on the output side. The standard library silently
-    // assumes injectivity on this 26-character set; IOv2 catches violations
-    // at construction time in debug / coverage / sanitizer builds via the
-    // asserts in the constructor. A future unit test can exercise the
-    // failure branch by deriving from ctype<CharT> and overriding widen_seq
-    // to be intentionally non-injective.
+    /**
+     * @lang{ZH}
+     * @brief 断言辅助函数：验证宽字符原子数组中所有元素两两不同。
+     *
+     * `extract_int`/`extract_float` 将输入宽字符与 `m_in_atoms` 中的条目直接比较，
+     * `insert_int`/`insert_float` 依据位置索引从 `m_out_atoms` 发出字形；
+     * 两者均假设 `ctype::widen` 在这 26 个字符集合上是单射的。
+     * 若某个非 ASCII locale 的 `widen` 使 `widen('a') == widen('A')` 之类的碰撞发生，
+     * 则某些数字在输入侧将不可达，在输出侧会产生语义上不同位置的相同字形。
+     * C++ 标准库对此集合的单射性隐式依赖，但不作显式保证；
+     * IOv2 在构造时通过此函数在 debug/覆盖率/sanitizer 构建中捕获违规。
+     *
+     * @param p 原子字符数组的起始指针。
+     * @param n 数组元素个数。
+     * @return 若所有元素两两不同则返回 `true`，否则返回 `false`。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Assertion helper that verifies all elements in a wide-character atom array are pairwise distinct.
+     *
+     * `extract_int`/`extract_float` compare incoming wide characters directly against
+     * entries in `m_in_atoms`, and `insert_int`/`insert_float` emit glyphs from
+     * `m_out_atoms` by position index; both assume `ctype::widen` is injective on
+     * this 26-character set. If an exotic locale's `widen` produces a collision such
+     * as `widen('a') == widen('A')`, certain digits become unreachable on the input
+     * side and semantically distinct output positions emit identical glyphs. The C++
+     * standard library implicitly relies on injectivity over this set without an
+     * explicit guarantee; IOv2 catches violations at construction time in
+     * debug/coverage/sanitizer builds via this function.
+     *
+     * @param p Pointer to the start of the atom character array.
+     * @param n Number of elements in the array.
+     * @return `true` if all elements are pairwise distinct; `false` otherwise.
+     * @endif
+     */
     static bool atoms_pairwise_distinct(const CharT* p, size_t n)
     {
         for (size_t i = 0; i < n; ++i)
@@ -1059,35 +1818,63 @@ private:
     }
 
 private:
-    std::shared_ptr<const ctype<CharT>> m_ctype;
-    CharT m_decimal_point;
-    CharT m_thousands_sep;
-    std::basic_string<CharT>  m_true_name;
-    std::basic_string<CharT>  m_false_name;
-    std::vector<uint8_t>      m_grouping;
+    std::shared_ptr<const ctype<CharT>> m_ctype;        ///< @lang{ZH} 用于字符扩宽的 `ctype` facet 共享指针。 @endif @lang{EN} Shared pointer to the `ctype` facet used for character widening. @endif
+    CharT m_decimal_point;                              ///< @lang{ZH} 小数点字符，从 `numeric_conf` 缓存。 @endif @lang{EN} Decimal point character, cached from `numeric_conf`. @endif
+    CharT m_thousands_sep;                              ///< @lang{ZH} 千位分隔符，从 `numeric_conf` 缓存；`CharT('\0')` 表示不分组。 @endif @lang{EN} Thousands separator, cached from `numeric_conf`; `CharT('\0')` means no grouping. @endif
+    std::basic_string<CharT>  m_true_name;              ///< @lang{ZH} `true` 的文本表示，从 `numeric_conf` 缓存。 @endif @lang{EN} Textual representation of `true`, cached from `numeric_conf`. @endif
+    std::basic_string<CharT>  m_false_name;             ///< @lang{ZH} `false` 的文本表示，从 `numeric_conf` 缓存。 @endif @lang{EN} Textual representation of `false`, cached from `numeric_conf`. @endif
+    std::vector<uint8_t>      m_grouping;               ///< @lang{ZH} 数字分组规则（内部规范化格式），从 `numeric_conf` 缓存；为空时不分组。 @endif @lang{EN} Digit grouping rules (internal normalized form), cached from `numeric_conf`; empty means no grouping. @endif
 
 private:
+    ///< @lang{ZH}
+    ///< 26 个输入原子字符的宽字符形式，对应 ASCII 串 `"-+xX0123456789abcdefABCDEF"`。
+    ///< 用于解析时将输入字符与符号、基数前缀和十六进制数字进行比较。
+    ///< 通过 `s_iminus`、`s_iplus`、`s_ix`、`s_iX`、`s_izero` 等索引访问各位置。
+    ///< @endif
+    ///< @lang{EN}
+    ///< Widened form of the 26 input atom characters corresponding to `"-+xX0123456789abcdefABCDEF"`.
+    ///< Used during parsing to match incoming characters against signs, base prefixes, and hex digits.
+    ///< Positions are accessed via `s_iminus`, `s_iplus`, `s_ix`, `s_iX`, `s_izero`, and related indices.
+    ///< @endif
     std::array<char_type, 26> m_in_atoms{};
-    std::array<char_type, 36> m_out_atoms{};
-    static constexpr int s_ominus       = 0;
-    static constexpr int s_oplus        = 1;
-    static constexpr int s_ox           = 2;
-    static constexpr int s_oX           = 3;
-    static constexpr int s_odigits      = 4;
-    static constexpr int s_oudigits     = s_odigits + 16;
-    static constexpr int s_oa           = s_odigits + 10;
-    static constexpr int s_oe           = s_odigits + 14;
-    static constexpr int s_oA           = s_oudigits + 10;
-    static constexpr int s_oE           = s_oudigits + 14;
 
-    static constexpr int s_iminus       = 0;
-    static constexpr int s_iplus        = 1;
-    static constexpr int s_ix           = 2;
-    static constexpr int s_iX           = 3;
-    static constexpr int s_izero        = 4;
-    static constexpr int s_ie           = s_izero + 14;
-    static constexpr int s_iE           = s_izero + 20;
-    static constexpr int s_iend         = 26;
+    ///< @lang{ZH}
+    ///< 36 个输出原子字符的宽字符形式，对应 ASCII 串 `"-+xX0123456789abcdef0123456789ABCDEF"`。
+    ///< 其中 `'0'..'9'` 在 `[4..13]`（小写十六进制字母表 `s_odigits`）和
+    ///< `[20..29]`（大写十六进制字母表 `s_oudigits`）各出现一次，
+    ///< 使两段均构成完整的 16 元素字母表。
+    ///< 通过 `s_ominus`、`s_oplus`、`s_ox`、`s_oX`、`s_odigits`、`s_oudigits` 等索引访问各位置。
+    ///< @endif
+    ///< @lang{EN}
+    ///< Widened form of the 36 output atom characters corresponding to `"-+xX0123456789abcdef0123456789ABCDEF"`.
+    ///< The `'0'..'9'` range appears at both `[4..13]` (lowercase hex alphabet, `s_odigits`) and
+    ///< `[20..29]` (uppercase hex alphabet, `s_oudigits`), so each 16-entry section is a
+    ///< self-contained digit alphabet for its case.
+    ///< Positions are accessed via `s_ominus`, `s_oplus`, `s_ox`, `s_oX`, `s_odigits`, `s_oudigits`, and related indices.
+    ///< @endif
+    std::array<char_type, 36> m_out_atoms{};
+
+    // Output atom indices into m_out_atoms ("-+xX0123456789abcdef0123456789ABCDEF").
+    static constexpr int s_ominus       = 0;            ///< @lang{ZH} `'-'` 在 `m_out_atoms` 中的索引。 @endif @lang{EN} Index of `'-'` in `m_out_atoms`. @endif
+    static constexpr int s_oplus        = 1;            ///< @lang{ZH} `'+'` 在 `m_out_atoms` 中的索引。 @endif @lang{EN} Index of `'+'` in `m_out_atoms`. @endif
+    static constexpr int s_ox           = 2;            ///< @lang{ZH} `'x'` 在 `m_out_atoms` 中的索引。 @endif @lang{EN} Index of `'x'` in `m_out_atoms`. @endif
+    static constexpr int s_oX           = 3;            ///< @lang{ZH} `'X'` 在 `m_out_atoms` 中的索引。 @endif @lang{EN} Index of `'X'` in `m_out_atoms`. @endif
+    static constexpr int s_odigits      = 4;            ///< @lang{ZH} 小写十六进制字母表（`'0'..'9','a'..'f'`）在 `m_out_atoms` 中的起始索引。 @endif @lang{EN} Start index of the lowercase hex alphabet (`'0'..'9','a'..'f'`) in `m_out_atoms`. @endif
+    static constexpr int s_oudigits     = s_odigits + 16;  ///< @lang{ZH} 大写十六进制字母表（`'0'..'9','A'..'F'`）在 `m_out_atoms` 中的起始索引。 @endif @lang{EN} Start index of the uppercase hex alphabet (`'0'..'9','A'..'F'`) in `m_out_atoms`. @endif
+    static constexpr int s_oa           = s_odigits + 10;  ///< @lang{ZH} `'a'` 在 `m_out_atoms` 中的索引。 @endif @lang{EN} Index of `'a'` in `m_out_atoms`. @endif
+    static constexpr int s_oe           = s_odigits + 14;  ///< @lang{ZH} `'e'` 在 `m_out_atoms` 中的索引。 @endif @lang{EN} Index of `'e'` in `m_out_atoms`. @endif
+    static constexpr int s_oA           = s_oudigits + 10; ///< @lang{ZH} `'A'` 在 `m_out_atoms` 中的索引。 @endif @lang{EN} Index of `'A'` in `m_out_atoms`. @endif
+    static constexpr int s_oE           = s_oudigits + 14; ///< @lang{ZH} `'E'` 在 `m_out_atoms` 中的索引。 @endif @lang{EN} Index of `'E'` in `m_out_atoms`. @endif
+
+    // Input atom indices into m_in_atoms ("-+xX0123456789abcdefABCDEF").
+    static constexpr int s_iminus       = 0;            ///< @lang{ZH} `'-'` 在 `m_in_atoms` 中的索引。 @endif @lang{EN} Index of `'-'` in `m_in_atoms`. @endif
+    static constexpr int s_iplus        = 1;            ///< @lang{ZH} `'+'` 在 `m_in_atoms` 中的索引。 @endif @lang{EN} Index of `'+'` in `m_in_atoms`. @endif
+    static constexpr int s_ix           = 2;            ///< @lang{ZH} `'x'` 在 `m_in_atoms` 中的索引。 @endif @lang{EN} Index of `'x'` in `m_in_atoms`. @endif
+    static constexpr int s_iX           = 3;            ///< @lang{ZH} `'X'` 在 `m_in_atoms` 中的索引。 @endif @lang{EN} Index of `'X'` in `m_in_atoms`. @endif
+    static constexpr int s_izero        = 4;            ///< @lang{ZH} `'0'`（数字段起始）在 `m_in_atoms` 中的索引。 @endif @lang{EN} Index of `'0'` (start of digit section) in `m_in_atoms`. @endif
+    static constexpr int s_ie           = s_izero + 14; ///< @lang{ZH} `'e'` 在 `m_in_atoms` 中的索引。 @endif @lang{EN} Index of `'e'` in `m_in_atoms`. @endif
+    static constexpr int s_iE           = s_izero + 20; ///< @lang{ZH} `'E'` 在 `m_in_atoms` 中的索引。 @endif @lang{EN} Index of `'E'` in `m_in_atoms`. @endif
+    static constexpr int s_iend         = 26;           ///< @lang{ZH} `m_in_atoms` 有效索引的尾后值（同时是数组大小）。 @endif @lang{EN} One-past-the-last valid index into `m_in_atoms` (also the array size). @endif
 };
 
 template<typename TConfPtr, typename TCtypePtr>

--- a/include/facet/numeric_details.h
+++ b/include/facet/numeric_details.h
@@ -1,3 +1,19 @@
+/**
+ * @file numeric_details.h
+ * @lang{ZH}
+ * 定义了 `numeric_conf` 类模板的各特化版本，这些类是 `numeric<CharT>` facet 的底层实现。
+ * 每个特化版本从指定的 locale 中提取数值格式化所需的参数，包括小数点字符、千位分隔符、
+ * 数字分组规则以及布尔值的文本表示。
+ * @endif
+ *
+ * @lang{EN}
+ * Defines the specializations of the `numeric_conf` class template, which are the
+ * underlying implementations for the `numeric<CharT>` facet. Each specialization
+ * extracts locale-dependent numeric formatting parameters, including the decimal point
+ * character, thousands separator, digit grouping rules, and textual representations
+ * of boolean values.
+ * @endif
+ */
 #pragma once
 #include <common/clocale_wrapper.h>
 #include <common/metafunctions.h>
@@ -18,10 +34,50 @@ namespace IOv2
 template <typename CharT> class numeric_conf;
 template <typename CharT> class numeric;
 
+/**
+ * @lang{ZH}
+ * @brief `numeric<char>` facet 的配置类。
+ *
+ * 从指定的 locale 中提取窄字符（`char`）类型的数值格式化参数，包括小数点字符、
+ * 千位分隔符、数字分组规则以及布尔值的文本名称。
+ * @endif
+ *
+ * @lang{EN}
+ * @brief Configuration class for the `numeric<char>` facet.
+ *
+ * Extracts narrow-character (`char`) numeric formatting parameters from the
+ * specified locale, including the decimal point character, thousands separator,
+ * digit grouping rules, and boolean text names.
+ * @endif
+ */
 template <>
 class numeric_conf<char> : public ft_basic<numeric<char>>
 {
 public:
+    /**
+     * @lang{ZH}
+     * @brief 构造函数，从指定的 locale 中读取并初始化所有数值格式化参数。
+     *
+     * 对于 "C" 和 "POSIX" locale，直接使用标准 ASCII 值。对于其他 locale，
+     * 在 locale 守卫有效期间将所有依赖 locale 的指针（`lconv*`、`nl_langinfo()`）
+     * 快照为原始字符串，以防后续的 `setlocale()`/`uselocale()` 调用使指针失效，
+     * 再于守卫结束后执行字符转换。
+     *
+     * @param name locale 名称字符串（例如 `"zh_CN.UTF-8"`）。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Constructor that reads and initializes all numeric formatting parameters from the specified locale.
+     *
+     * For "C" and "POSIX" locales, standard ASCII values are assigned directly.
+     * For other locales, all locale-dependent pointers (`lconv*`, `nl_langinfo()`)
+     * are snapshotted into raw strings while the locale guard is active, preventing
+     * invalidation by subsequent `setlocale()`/`uselocale()` calls; character
+     * conversion is then performed after the guard ends.
+     *
+     * @param name The locale name string (e.g., `"zh_CN.UTF-8"`).
+     * @endif
+     */
     numeric_conf(const std::string& name)
         : ft_basic<numeric<char>>()
     {
@@ -99,20 +155,111 @@ public:
     }
 
 public:
+    /**
+     * @lang{ZH}
+     * @brief 返回此 locale 的小数点字符。
+     * @return 小数点字符。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the decimal point character for this locale.
+     * @return The decimal point character.
+     * @endif
+     */
     [[nodiscard]] virtual char decimal_point() const { return m_decimal_point; }
+
+    /**
+     * @lang{ZH}
+     * @brief 返回此 locale 的千位分隔符字符。
+     *
+     * 若返回值为 `'\0'`，表示不使用分隔符，此时 `grouping()` 必为空。
+     * @return 千位分隔符字符，或 `'\0'`（不使用分隔符时）。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the thousands separator character for this locale.
+     *
+     * A return value of `'\0'` indicates that no separator is used,
+     * in which case `grouping()` is always empty.
+     * @return The thousands separator character, or `'\0'` if none is used.
+     * @endif
+     */
     [[nodiscard]] virtual char thousands_sep() const { return m_thousands_sep; }
+
+    /**
+     * @lang{ZH}
+     * @brief 返回此 locale 中 `true` 的文本表示。
+     * @return `true` 的文本字符串。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the textual representation of `true` for this locale.
+     * @return The text string for `true`.
+     * @endif
+     */
     [[nodiscard]] virtual const std::string& truename() const { return m_true_name; }
+
+    /**
+     * @lang{ZH}
+     * @brief 返回此 locale 中 `false` 的文本表示。
+     * @return `false` 的文本字符串。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the textual representation of `false` for this locale.
+     * @return The text string for `false`.
+     * @endif
+     */
     [[nodiscard]] virtual const std::string& falsename() const { return m_false_name; }
+
+    /**
+     * @lang{ZH}
+     * @brief 返回数字分组规则（内部规范化格式）。
+     *
+     * 向量中每个元素表示一个数字组的位数。若向量为空，则表示不进行分组。
+     * @return 数字分组规则向量；为空时表示不分组。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the digit grouping specification in the internal normalized form.
+     *
+     * Each element in the vector specifies the number of digits in one group.
+     * An empty vector indicates that no grouping is applied.
+     * @return The digit grouping vector; empty means no grouping.
+     * @endif
+     */
     [[nodiscard]] virtual const std::vector<uint8_t>& grouping() const { return m_grouping; }
 
 private:
-    char m_decimal_point;
-    char m_thousands_sep;
-    std::string m_true_name;
-    std::string m_false_name;
-    std::vector<uint8_t> m_grouping;
+    char m_decimal_point;   ///< @lang{ZH} 小数点字符。 @endif @lang{EN} The decimal point character. @endif
+    char m_thousands_sep;   ///< @lang{ZH} 千位分隔符；`'\0'` 表示不使用分隔符。 @endif @lang{EN} Thousands separator; `'\0'` means no separator. @endif
+    std::string m_true_name;              ///< @lang{ZH} `true` 的文本表示。 @endif @lang{EN} Textual representation of `true`. @endif
+    std::string m_false_name;             ///< @lang{ZH} `false` 的文本表示。 @endif @lang{EN} Textual representation of `false`. @endif
+    std::vector<uint8_t> m_grouping;      ///< @lang{ZH} 数字分组规则（内部规范化格式）；为空时表示不分组。 @endif @lang{EN} Digit grouping rules (internal normalized form); empty means no grouping. @endif
 };
 
+/**
+ * @lang{ZH}
+ * @brief `numeric<CharT>` facet 的配置类，适用于宽字符类型。
+ *
+ * 从指定的 locale 中提取宽字符（`wchar_t` 或 `char32_t`）类型的数值格式化参数，
+ * 包括小数点字符、千位分隔符、数字分组规则以及布尔值的文本名称。
+ * 此特化仅适用于 `wchar_t`，以及在 `wchar_t` 为 UTF-32 的平台上的 `char32_t`。
+ *
+ * @tparam CharT 宽字符类型，必须为 `wchar_t` 或（在 UTF-32 平台上的）`char32_t`。
+ * @endif
+ *
+ * @lang{EN}
+ * @brief Configuration class for the `numeric<CharT>` facet for wide character types.
+ *
+ * Extracts wide-character (`wchar_t` or `char32_t`) numeric formatting parameters
+ * from the specified locale, including the decimal point character, thousands separator,
+ * digit grouping rules, and boolean text names. This specialization applies to `wchar_t`
+ * and, on platforms where `wchar_t` is UTF-32, to `char32_t`.
+ *
+ * @tparam CharT The wide character type; must be `wchar_t` or (on UTF-32 platforms) `char32_t`.
+ * @endif
+ */
 template <typename CharT>
     requires std::is_same_v<CharT, wchar_t> ||
                 (std::is_same_v<CharT, char32_t> &&
@@ -120,9 +267,42 @@ template <typename CharT>
 class numeric_conf<CharT> : public ft_basic<numeric<CharT>>
 {
 public:
+    /**
+     * @lang{ZH}
+     * @brief 字符类型。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief The character type.
+     * @endif
+     */
     using char_type = CharT;
 
 public:
+    /**
+     * @lang{ZH}
+     * @brief 构造函数，从指定的 locale 中读取并初始化所有数值格式化参数。
+     *
+     * 对于 "C" 和 "POSIX" locale，直接使用标准 ASCII 宽字符值。对于其他 locale，
+     * 在 locale 守卫有效期间将所有依赖 locale 的指针（`lconv*`、`nl_langinfo()`）
+     * 快照为原始窄字符串，以防后续的 `setlocale()`/`uselocale()` 调用使指针失效，
+     * 再于守卫结束后执行宽字符转换。
+     *
+     * @param name locale 名称字符串（例如 `"zh_CN.UTF-8"`）。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Constructor that reads and initializes all numeric formatting parameters from the specified locale.
+     *
+     * For "C" and "POSIX" locales, standard ASCII wide-character values are assigned
+     * directly. For other locales, all locale-dependent pointers (`lconv*`, `nl_langinfo()`)
+     * are snapshotted into raw narrow strings while the locale guard is active, preventing
+     * invalidation by subsequent `setlocale()`/`uselocale()` calls; wide-character
+     * conversion is then performed after the guard ends.
+     *
+     * @param name The locale name string (e.g., `"zh_CN.UTF-8"`).
+     * @endif
+     */
     numeric_conf(const std::string& name)
         : ft_basic<numeric<CharT>>()
     {
@@ -233,20 +413,117 @@ public:
     }
 
 public:
+    /**
+     * @lang{ZH}
+     * @brief 返回此 locale 的小数点字符。
+     * @return 小数点字符。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the decimal point character for this locale.
+     * @return The decimal point character.
+     * @endif
+     */
     [[nodiscard]] virtual CharT decimal_point() const { return m_decimal_point; }
+
+    /**
+     * @lang{ZH}
+     * @brief 返回此 locale 的千位分隔符字符。
+     *
+     * 若返回值为 `CharT('\0')`，表示不使用分隔符，此时 `grouping()` 必为空。
+     * @return 千位分隔符字符，或 `CharT('\0')`（不使用分隔符时）。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the thousands separator character for this locale.
+     *
+     * A return value of `CharT('\0')` indicates that no separator is used,
+     * in which case `grouping()` is always empty.
+     * @return The thousands separator character, or `CharT('\0')` if none is used.
+     * @endif
+     */
     [[nodiscard]] virtual CharT thousands_sep() const { return m_thousands_sep; }
+
+    /**
+     * @lang{ZH}
+     * @brief 返回此 locale 中 `true` 的文本表示。
+     * @return `true` 的文本字符串。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the textual representation of `true` for this locale.
+     * @return The text string for `true`.
+     * @endif
+     */
     [[nodiscard]] virtual const std::basic_string<CharT>& truename() const { return m_true_name; }
+
+    /**
+     * @lang{ZH}
+     * @brief 返回此 locale 中 `false` 的文本表示。
+     * @return `false` 的文本字符串。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the textual representation of `false` for this locale.
+     * @return The text string for `false`.
+     * @endif
+     */
     [[nodiscard]] virtual const std::basic_string<CharT>& falsename() const { return m_false_name; }
+
+    /**
+     * @lang{ZH}
+     * @brief 返回数字分组规则（内部规范化格式）。
+     *
+     * 向量中每个元素表示一个数字组的位数。若向量为空，则表示不进行分组。
+     * @return 数字分组规则向量；为空时表示不分组。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the digit grouping specification in the internal normalized form.
+     *
+     * Each element in the vector specifies the number of digits in one group.
+     * An empty vector indicates that no grouping is applied.
+     * @return The digit grouping vector; empty means no grouping.
+     * @endif
+     */
     [[nodiscard]] virtual const std::vector<uint8_t>& grouping() const { return m_grouping; }
 
 private:
-    CharT m_decimal_point;
-    CharT m_thousands_sep;
-    std::basic_string<CharT>    m_true_name;
-    std::basic_string<CharT>    m_false_name;
-    std::vector<uint8_t>        m_grouping;
+    CharT m_decimal_point;                  ///< @lang{ZH} 小数点字符。 @endif @lang{EN} The decimal point character. @endif
+    CharT m_thousands_sep;                  ///< @lang{ZH} 千位分隔符；`CharT('\0')` 表示不使用分隔符。 @endif @lang{EN} Thousands separator; `CharT('\0')` means no separator. @endif
+    std::basic_string<CharT> m_true_name;   ///< @lang{ZH} `true` 的文本表示。 @endif @lang{EN} Textual representation of `true`. @endif
+    std::basic_string<CharT> m_false_name;  ///< @lang{ZH} `false` 的文本表示。 @endif @lang{EN} Textual representation of `false`. @endif
+    std::vector<uint8_t>     m_grouping;    ///< @lang{ZH} 数字分组规则（内部规范化格式）；为空时表示不分组。 @endif @lang{EN} Digit grouping rules (internal normalized form); empty means no grouping. @endif
 };
 
+/**
+ * @lang{ZH}
+ * @brief `numeric<char8_t>` facet 的配置类。
+ *
+ * 通过委托给 `numeric_conf<char32_t>` 来获取 locale 参数，再将各参数收窄为单字节
+ * UTF-8 字符。若某参数的 UTF-8 编码超过一个字节，或编码结果为 `u8'\0'`，则回退到
+ * ASCII 默认值（小数点回退为 `u8'.'`，千位分隔符回退并清空分组规则）。
+ * 当两个分隔符回退后重合时，分组规则也会被清空，以避免解析歧义。
+ *
+ * @note 此特化要求 `wchar_t` 为 32 位 UTF-32 编码单元（即 `wchar_t_is_utf32` 为真），
+ *       因为其实现依赖 `numeric_conf<char32_t>`。
+ * @endif
+ *
+ * @lang{EN}
+ * @brief Configuration class for the `numeric<char8_t>` facet.
+ *
+ * Obtains locale parameters by delegating to `numeric_conf<char32_t>`, then narrows
+ * each parameter to a single-byte UTF-8 character. If a parameter's UTF-8 encoding
+ * spans more than one byte, or the encoded result is `u8'\0'`, it falls back to an
+ * ASCII default (decimal point falls back to `u8'.'`; thousands separator falls back
+ * and the grouping is cleared). When the two separators coincide after fallback,
+ * the grouping is also cleared to avoid parsing ambiguity.
+ *
+ * @note This specialization requires `wchar_t` to be a 32-bit UTF-32 code unit
+ *       (i.e., `wchar_t_is_utf32` is true), as the implementation delegates to
+ *       `numeric_conf<char32_t>`.
+ * @endif
+ */
 template <>
 class numeric_conf<char8_t> : public ft_basic<numeric<char8_t>>
 {
@@ -256,9 +533,40 @@ class numeric_conf<char8_t> : public ft_basic<numeric<char8_t>>
         "(e.g. wchar_t is 16-bit UTF-16) does not satisfy that assumption.");
 
 public:
+    /**
+     * @lang{ZH}
+     * @brief 字符类型。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief The character type.
+     * @endif
+     */
     using char_type = char8_t;
 
 public:
+    /**
+     * @lang{ZH}
+     * @brief 构造函数，从指定的 locale 中读取并初始化所有数值格式化参数。
+     *
+     * 对于 "C" 和 "POSIX" locale，直接使用标准 ASCII UTF-8 值。对于其他 locale，
+     * 先构造 `numeric_conf<char32_t>` 获取 Unicode 参数，再逐一将其收窄为单字节
+     * UTF-8 字符；若无法收窄则使用默认值。
+     *
+     * @param name locale 名称字符串（例如 `"zh_CN.UTF-8"`）。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Constructor that reads and initializes all numeric formatting parameters from the specified locale.
+     *
+     * For "C" and "POSIX" locales, standard ASCII UTF-8 values are assigned directly.
+     * For other locales, a `numeric_conf<char32_t>` is constructed first to obtain
+     * Unicode parameters, which are then narrowed one by one to single-byte UTF-8
+     * characters; a default value is used whenever narrowing is not possible.
+     *
+     * @param name The locale name string (e.g., `"zh_CN.UTF-8"`).
+     * @endif
+     */
     numeric_conf(const std::string& name)
         : ft_basic<numeric<char8_t>>()
     {
@@ -312,17 +620,86 @@ public:
     }
 
 public:
+    /**
+     * @lang{ZH}
+     * @brief 返回此 locale 的小数点字符（单字节 UTF-8）。
+     * @return 小数点字符。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the decimal point character for this locale (single-byte UTF-8).
+     * @return The decimal point character.
+     * @endif
+     */
     [[nodiscard]] virtual char8_t decimal_point() const { return m_decimal_point; }
+
+    /**
+     * @lang{ZH}
+     * @brief 返回此 locale 的千位分隔符字符（单字节 UTF-8）。
+     *
+     * 若返回值为 `u8'\0'`，表示不使用分隔符，此时 `grouping()` 必为空。
+     * @return 千位分隔符字符，或 `u8'\0'`（不使用分隔符时）。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the thousands separator character for this locale (single-byte UTF-8).
+     *
+     * A return value of `u8'\0'` indicates that no separator is used,
+     * in which case `grouping()` is always empty.
+     * @return The thousands separator character, or `u8'\0'` if none is used.
+     * @endif
+     */
     [[nodiscard]] virtual char8_t thousands_sep() const { return m_thousands_sep; }
+
+    /**
+     * @lang{ZH}
+     * @brief 返回此 locale 中 `true` 的文本表示（UTF-8 编码）。
+     * @return `true` 的 UTF-8 文本字符串。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the textual representation of `true` for this locale (UTF-8 encoded).
+     * @return The UTF-8 text string for `true`.
+     * @endif
+     */
     [[nodiscard]] virtual const std::basic_string<char8_t>& truename() const { return m_true_name; }
+
+    /**
+     * @lang{ZH}
+     * @brief 返回此 locale 中 `false` 的文本表示（UTF-8 编码）。
+     * @return `false` 的 UTF-8 文本字符串。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the textual representation of `false` for this locale (UTF-8 encoded).
+     * @return The UTF-8 text string for `false`.
+     * @endif
+     */
     [[nodiscard]] virtual const std::basic_string<char8_t>& falsename() const { return m_false_name; }
+
+    /**
+     * @lang{ZH}
+     * @brief 返回数字分组规则（内部规范化格式）。
+     *
+     * 向量中每个元素表示一个数字组的位数。若向量为空，则表示不进行分组。
+     * @return 数字分组规则向量；为空时表示不分组。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the digit grouping specification in the internal normalized form.
+     *
+     * Each element in the vector specifies the number of digits in one group.
+     * An empty vector indicates that no grouping is applied.
+     * @return The digit grouping vector; empty means no grouping.
+     * @endif
+     */
     [[nodiscard]] virtual const std::vector<uint8_t>& grouping() const { return m_grouping; }
 
 private:
-    char8_t m_decimal_point;
-    char8_t m_thousands_sep;
-    std::basic_string<char8_t>  m_true_name;
-    std::basic_string<char8_t>  m_false_name;
-    std::vector<uint8_t>        m_grouping;
+    char8_t m_decimal_point;                    ///< @lang{ZH} 小数点字符（单字节 UTF-8）。 @endif @lang{EN} The decimal point character (single-byte UTF-8). @endif
+    char8_t m_thousands_sep;                    ///< @lang{ZH} 千位分隔符（单字节 UTF-8）；`u8'\0'` 表示不使用分隔符。 @endif @lang{EN} Thousands separator (single-byte UTF-8); `u8'\0'` means no separator. @endif
+    std::basic_string<char8_t> m_true_name;     ///< @lang{ZH} `true` 的 UTF-8 文本表示。 @endif @lang{EN} UTF-8 textual representation of `true`. @endif
+    std::basic_string<char8_t> m_false_name;    ///< @lang{ZH} `false` 的 UTF-8 文本表示。 @endif @lang{EN} UTF-8 textual representation of `false`. @endif
+    std::vector<uint8_t>       m_grouping;      ///< @lang{ZH} 数字分组规则（内部规范化格式）；为空时表示不分组。 @endif @lang{EN} Digit grouping rules (internal normalized form); empty means no grouping. @endif
 };
 }


### PR DESCRIPTION
Add Chinese/English Doxygen documentation (using @lang{ZH}/@lang{EN} blocks) to four facet headers, following the existing style in include/device/. All pre-existing inline implementation comments are preserved in place.

- collate_details.h: document collate_conf class, constructor (UTF-8 probe rationale), compare/transform_length/transform methods, and the m_inter_locale thread-safety note.
- collate.h: document the collate class, all four compare overloads, both transform_length overloads, all four transform overloads, and the private data_to_vec helper.
- numeric_details.h: document all three numeric_conf specialisations (char, wchar_t/char32_t, char8_t), their constructors, virtual getters, and private data members.
- numeric.h: document the numeric class, constructor, five accessors, four put/get overloads each, and all private helpers (insert_int, insert_float, extract_int, extract_float, convert_to_v, atoms_pairwise_distinct, etc.) and atom index constants.