### PR TITLE
test(facet): cover error/fallback paths in collate, numeric facets

### DIFF
--- a/test/facet/collate/test_collate.cpp
+++ b/test/facet/collate/test_collate.cpp
@@ -29,6 +29,7 @@ void test_collate_char8_t_transform_1();
 void test_collate_char8_t_transform_2();
 void test_collate_char8_t_transform_3();
 void test_collate_char8_t_transform_4();
+void test_collate_char8_t_ctor_locale_check();
 
 void test_collate()
 {
@@ -63,4 +64,5 @@ void test_collate()
     test_collate_char8_t_transform_2();
     test_collate_char8_t_transform_3();
     test_collate_char8_t_transform_4();
+    test_collate_char8_t_ctor_locale_check();
 }

--- a/test/facet/collate/test_collate_char8_t.cpp
+++ b/test/facet/collate/test_collate_char8_t.cpp
@@ -4,6 +4,7 @@
 #include <vector>
 #include <facet/collate.h>
 
+#include <common/defs.h>
 #include <common/dump_info.h>
 
 void test_collate_char8_t_compare_1()
@@ -591,6 +592,42 @@ void test_collate_char8_t_transform_4()
         obj.transform(ls_strlit.begin(), ls_strlit.end(), std::back_inserter(t4), t.size() - 3);
         if (t4.size() != t.size() - 3) throw std::runtime_error("collate::transform fail.");
         if (t4 != t.substr(0, t.size() - 3)) throw std::runtime_error("collate::transform fail.");
+    }
+
+    dump_info("Done\n");
+}
+
+void test_collate_char8_t_ctor_locale_check()
+{
+    dump_info("Test collate_conf<char8_t> ctor locale check...");
+
+    // The collate_conf<char8_t> constructor probes the inter locale's CTYPE
+    // codeset with mbrtoc32. A non-UTF-8 locale must be rejected with cvt_error,
+    // because collate<char8_t> routes through the narrow strcoll/strxfrm path
+    // which only parses UTF-8 byte input correctly when the codeset is UTF-8.
+    for (const char* name : {"C", "POSIX"})
+    {
+        bool threw = false;
+        try
+        {
+            IOv2::collate_conf<char8_t> conf(name);
+        }
+        catch (const IOv2::cvt_error&)
+        {
+            threw = true;
+        }
+        if (!threw)
+            throw std::runtime_error("collate_conf<char8_t> accepted a non-UTF-8 locale");
+    }
+
+    // A genuine UTF-8 locale must be accepted without throwing.
+    try
+    {
+        IOv2::collate_conf<char8_t> conf("C.UTF-8");
+    }
+    catch (const std::exception&)
+    {
+        throw std::runtime_error("collate_conf<char8_t> rejected a UTF-8 locale");
     }
 
     dump_info("Done\n");

--- a/test/facet/numeric/test_numeric.cpp
+++ b/test/facet/numeric/test_numeric.cpp
@@ -60,6 +60,11 @@ void test_numeric_char_get_40();
 void test_numeric_char_get_41();
 void test_numeric_char_get_42();
 void test_numeric_vulnerability_fix_char();
+void test_numeric_char_conf_bool_fallback();
+void test_numeric_char_get_bool_edge();
+void test_numeric_char_put_edge();
+void test_numeric_char_get_int_edge();
+void test_numeric_char_get_float_edge();
 
 void test_numeric_wchar_t_common_1();
 void test_numeric_wchar_t_put_1();
@@ -101,6 +106,7 @@ void test_numeric_wchar_t_get_18();
 void test_numeric_wchar_t_get_19();
 void test_numeric_wchar_t_get_20();
 void test_numeric_wchar_t_get_21();
+void test_numeric_wchar_t_conf_bool_fallback();
 
 void test_numeric_char32_t_common_1();
 void test_numeric_char32_t_put_1();
@@ -142,6 +148,7 @@ void test_numeric_char32_t_get_18();
 void test_numeric_char32_t_get_19();
 void test_numeric_char32_t_get_20();
 void test_numeric_char32_t_get_21();
+void test_numeric_char32_t_conf_bool_fallback();
 
 void test_numeric_char8_t_common_1();
 void test_numeric_char8_t_put_1();
@@ -183,6 +190,7 @@ void test_numeric_char8_t_get_18();
 void test_numeric_char8_t_get_19();
 void test_numeric_char8_t_get_20();
 void test_numeric_char8_t_get_21();
+void test_numeric_char8_t_conf_multibyte_sep();
 
 void test_numeric()
 {
@@ -248,6 +256,11 @@ void test_numeric()
     test_numeric_char_get_41();
     test_numeric_char_get_42();
     test_numeric_vulnerability_fix_char();
+    test_numeric_char_conf_bool_fallback();
+    test_numeric_char_get_bool_edge();
+    test_numeric_char_put_edge();
+    test_numeric_char_get_int_edge();
+    test_numeric_char_get_float_edge();
 
     test_numeric_wchar_t_common_1();
     test_numeric_wchar_t_put_1();
@@ -289,7 +302,8 @@ void test_numeric()
     test_numeric_wchar_t_get_19();
     test_numeric_wchar_t_get_20();
     test_numeric_wchar_t_get_21();
-    
+    test_numeric_wchar_t_conf_bool_fallback();
+
     test_numeric_char32_t_common_1();
     test_numeric_char32_t_put_1();
     test_numeric_char32_t_put_2();
@@ -330,7 +344,8 @@ void test_numeric()
     test_numeric_char32_t_get_19();
     test_numeric_char32_t_get_20();
     test_numeric_char32_t_get_21();
-    
+    test_numeric_char32_t_conf_bool_fallback();
+
     test_numeric_char8_t_common_1();
     test_numeric_char8_t_put_1();
     test_numeric_char8_t_put_2();
@@ -370,4 +385,5 @@ void test_numeric()
     test_numeric_char8_t_get_19();
     test_numeric_char8_t_get_20();
     test_numeric_char8_t_get_21();
+    test_numeric_char8_t_conf_multibyte_sep();
 }

--- a/test/facet/numeric/test_numeric_char.cpp
+++ b/test/facet/numeric/test_numeric_char.cpp
@@ -3951,3 +3951,241 @@ void test_numeric_vulnerability_fix_char()
 
     dump_info("Done\n");
 }
+
+void test_numeric_char_conf_bool_fallback()
+{
+    dump_info("Test numeric_conf<char> bool-name fallback...");
+
+    // "C.UTF-8" is NOT the literal "C"/"POSIX" fast path, so the constructor
+    // runs the full locale-snapshot branch. glibc's C.UTF-8 exposes empty
+    // YESSTR/NOSTR, which the constructor treats as missing keys and replaces
+    // with the ASCII defaults "true"/"false".
+    IOv2::numeric_conf<char> conf("C.UTF-8");
+
+    VERIFY(conf.truename() == "true");
+    VERIFY(conf.falsename() == "false");
+    // C.UTF-8 has no thousands separator, so grouping stays empty and
+    // decimal_point is the plain ASCII dot.
+    VERIFY(conf.decimal_point() == '.');
+    VERIFY(conf.thousands_sep() == '\0');
+    VERIFY(conf.grouping().empty());
+
+    dump_info("Done\n");
+}
+
+void test_numeric_char_get_bool_edge()
+{
+    dump_info("Test numeric<char>::get bool edge cases...");
+
+    IOv2::numeric<char> obj(std::make_shared<IOv2::numeric_conf<char>>("C"), s_ctype_c);
+
+    // Without boolalpha, the field is parsed as a long; any value other than
+    // 0/1 is out of range. Per LWG 23 the result is set to true and the parse
+    // fails (throws).
+    {
+        IOv2::ios_base<char> ios;
+        bool v = false;
+        std::string in = "2";
+        bool threw = false;
+        try { obj.get(in.begin(), in.end(), ios, v); }
+        catch (const IOv2::stream_error&) { threw = true; }
+        VERIFY(threw);
+        VERIFY(v == true);
+    }
+
+    // With boolalpha, identical truename()/falsename() make a matching input
+    // ambiguous: it satisfies both names at the same length, so the parse
+    // fails and the result is set to false (LWG 23).
+    {
+        auto punct = std::make_shared<Punct>("C");
+        punct->set_truename("same");
+        punct->set_falsename("same");
+        IOv2::numeric<char> ambiguous(punct, s_ctype_c);
+
+        IOv2::ios_base<char> ios;
+        ios.setf(IOv2::ios_defs::boolalpha);
+        bool v = true;
+        std::string in = "same";
+        bool threw = false;
+        try { ambiguous.get(in.begin(), in.end(), ios, v); }
+        catch (const IOv2::stream_error&) { threw = true; }
+        VERIFY(threw);
+        VERIFY(v == false);
+    }
+
+    dump_info("Done\n");
+}
+
+void test_numeric_char_put_edge()
+{
+    dump_info("Test numeric<char>::put edge cases...");
+
+    IOv2::numeric<char> obj(std::make_shared<IOv2::numeric_conf<char>>("C"), s_ctype_c);
+
+    // Octal base with showbase prepends a single '0' for non-zero values.
+    {
+        IOv2::ios_base<char> ios;
+        ios.setf(IOv2::ios_defs::oct, IOv2::ios_defs::basefield);
+        ios.setf(IOv2::ios_defs::showbase);
+        std::string out;
+        obj.put(std::back_inserter(out), ios, 64L);
+        VERIFY(out == "0100");
+    }
+
+    // showpoint sets the '#' printf flag, forcing a decimal point.
+    {
+        IOv2::ios_base<char> ios;
+        ios.setf(IOv2::ios_defs::showpoint);
+        std::string out;
+        obj.put(std::back_inserter(out), ios, 1.0);
+        VERIFY(out.find('.') != std::string::npos);
+        VERIFY(out.size() > 1);
+    }
+
+    // A float formatted as "0.5", right-padded into a wider field, drives the
+    // pad path where the leading '0' triggers the 0x-prefix probe.
+    {
+        IOv2::ios_base<char> ios;
+        ios.width(10);
+        std::string out;
+        obj.put(std::back_inserter(out), ios, 0.5);
+        VERIFY(out.size() == 10);
+        VERIFY(out.back() == '5');
+    }
+
+    // Internal adjustment on a negative value keeps the sign anchored to the
+    // left and inserts fill between the sign and the digits.
+    {
+        IOv2::ios_base<char> ios;
+        ios.width(8);
+        ios.setf(IOv2::ios_defs::internal, IOv2::ios_defs::adjustfield);
+        std::string out;
+        obj.put(std::back_inserter(out), ios, -42L);
+        VERIFY(out.size() == 8);
+        VERIFY(out.front() == '-');
+        VERIFY(out.substr(out.size() - 2) == "42");
+    }
+
+    dump_info("Done\n");
+}
+
+void test_numeric_char_get_int_edge()
+{
+    dump_info("Test numeric<char>::get integer edge cases...");
+
+    IOv2::numeric<char> obj(std::make_shared<IOv2::numeric_conf<char>>("C"), s_ctype_c);
+
+    // A lone sign with no following digit is a parse failure.
+    {
+        IOv2::ios_base<char> ios;
+        long v = 123;
+        std::string in = "-";
+        bool threw = false;
+        try { obj.get(in.begin(), in.end(), ios, v); }
+        catch (const IOv2::stream_error&) { threw = true; }
+        VERIFY(threw);
+    }
+
+    // Under an explicit octal base, "0x5" stops at 'x' (the "0x" prefix is only
+    // honored for hex/auto base) and yields just the leading zero.
+    {
+        IOv2::ios_base<char> ios;
+        ios.setf(IOv2::ios_defs::oct, IOv2::ios_defs::basefield);
+        long v = -1;
+        std::string in = "0x5";
+        auto it = obj.get(in.begin(), in.end(), ios, v);
+        VERIFY(v == 0);
+        VERIFY(it == in.begin() + 1);
+    }
+
+    // A single digit group exceeding 255 digits cannot be stored in the
+    // uint8_t group counter and is rejected. Leading zeros under an explicit
+    // decimal base accumulate the group length without overflowing the value.
+    auto punct = std::make_shared<Punct>("C");
+    punct->set_grouping({3});
+    punct->set_thousands_sep(',');
+    IOv2::numeric<char> grp(punct, s_ctype_c);
+
+    {
+        IOv2::ios_base<char> ios;
+        ios.setf(IOv2::ios_defs::dec, IOv2::ios_defs::basefield);
+        long v = 1;
+        std::string in = std::string(256, '0') + ",5";  // oversized leading group, then a separator
+        bool threw = false;
+        try { grp.get(in.begin(), in.end(), ios, v); }
+        catch (const IOv2::stream_error&) { threw = true; }
+        VERIFY(threw);
+    }
+    {
+        IOv2::ios_base<char> ios;
+        ios.setf(IOv2::ios_defs::dec, IOv2::ios_defs::basefield);
+        long v = 1;
+        // A leading '0' keeps the running value at zero so it never overflows;
+        // the digit count then reaches the >255 grouping limit at end of input.
+        std::string in = "0," + std::string(256, '0');  // oversized final group at end of input
+        bool threw = false;
+        try { grp.get(in.begin(), in.end(), ios, v); }
+        catch (const IOv2::stream_error&) { threw = true; }
+        VERIFY(threw);
+    }
+
+    dump_info("Done\n");
+}
+
+void test_numeric_char_get_float_edge()
+{
+    dump_info("Test numeric<char>::get floating-point edge cases...");
+
+    IOv2::numeric<char> obj(std::make_shared<IOv2::numeric_conf<char>>("C"), s_ctype_c);
+
+    auto throws = [&](const std::string& in)
+    {
+        IOv2::ios_base<char> ios;
+        double v = -1.0;
+        try { obj.get(in.begin(), in.end(), ios, v); return false; }
+        catch (const IOv2::stream_error&) { return true; }
+    };
+
+    // A lone sign fails.
+    VERIFY(throws("+"));
+    // An exponent marker with no exponent digits fails.
+    VERIFY(throws("1e"));
+    // Magnitudes that strtod rounds to +/-infinity map to +/-max() and fail
+    // per LWG 23.
+    VERIFY(throws("1e400"));
+    VERIFY(throws("-1e400"));
+
+    // A bare "0" parses successfully to 0.0 (exercises the leading-zero / EOF path).
+    {
+        IOv2::ios_base<char> ios;
+        double v = -1.0;
+        std::string in = "0";
+        obj.get(in.begin(), in.end(), ios, v);
+        VERIFY(v == 0.0);
+    }
+
+    // Oversized digit groups (>255 digits) are rejected at each structural
+    // boundary: before a thousands separator, before the decimal point, before
+    // the exponent marker, and at end of input.
+    auto punct = std::make_shared<Punct>("C");
+    punct->set_grouping({3});
+    punct->set_thousands_sep(',');
+    punct->set_decimal_point('.');
+    IOv2::numeric<char> grp(punct, s_ctype_c);
+
+    auto grp_throws = [&](const std::string& in)
+    {
+        IOv2::ios_base<char> ios;
+        double v = -1.0;
+        try { grp.get(in.begin(), in.end(), ios, v); return false; }
+        catch (const IOv2::stream_error&) { return true; }
+    };
+
+    const std::string big(256, '1');
+    VERIFY(grp_throws(big + ",5"));        // oversized group before a separator
+    VERIFY(grp_throws("1," + big + ".5")); // oversized group before the decimal point
+    VERIFY(grp_throws("1," + big + "e5")); // oversized group before the exponent
+    VERIFY(grp_throws("1," + big));        // oversized final group at end of input
+
+    dump_info("Done\n");
+}

--- a/test/facet/numeric/test_numeric_char32_t.cpp
+++ b/test/facet/numeric/test_numeric_char32_t.cpp
@@ -2261,3 +2261,27 @@ void test_numeric_char32_t_get_21()
 
     dump_info("Done\n");
 }
+
+void test_numeric_char32_t_conf_bool_fallback()
+{
+    dump_info("Test numeric_conf<char32_t> bool-name fallback...");
+
+    // "C.UTF-8" is NOT the literal "C"/"POSIX" fast path, so the constructor
+    // runs the full locale-snapshot branch. glibc's C.UTF-8 exposes empty
+    // YESSTR/NOSTR, which the constructor treats as missing keys and replaces
+    // with the UTF-32 ASCII defaults U"true"/U"false".
+    IOv2::numeric_conf<char32_t> conf("C.UTF-8");
+
+    if (conf.truename() != U"true")
+        throw std::runtime_error("numeric_conf<char32_t>::truename fallback incorrect");
+    if (conf.falsename() != U"false")
+        throw std::runtime_error("numeric_conf<char32_t>::falsename fallback incorrect");
+    if (conf.decimal_point() != U'.')
+        throw std::runtime_error("numeric_conf<char32_t>::decimal_point incorrect");
+    if (conf.thousands_sep() != U'\0')
+        throw std::runtime_error("numeric_conf<char32_t>::thousands_sep incorrect");
+    if (!conf.grouping().empty())
+        throw std::runtime_error("numeric_conf<char32_t>::grouping incorrect");
+
+    dump_info("Done\n");
+}

--- a/test/facet/numeric/test_numeric_char8_t.cpp
+++ b/test/facet/numeric/test_numeric_char8_t.cpp
@@ -2261,3 +2261,29 @@ void test_numeric_char8_t_get_21()
 
     dump_info("Done\n");
 }
+
+void test_numeric_char8_t_conf_multibyte_sep()
+{
+    dump_info("Test numeric_conf<char8_t> multi-byte separator fallback...");
+
+    // fr_FR.UTF-8 uses ',' as the decimal point and U+202F (NARROW NO-BREAK
+    // SPACE, a multi-byte UTF-8 sequence) as the thousands separator. The
+    // char8_t specialization narrows each parameter to a single UTF-8 byte:
+    //   - the multi-byte thousands separator is not single-byte representable,
+    //     so it is dropped and the grouping is cleared, then
+    //   - the fallback separator u8',' coincides with the decimal point u8',',
+    //     so the grouping is cleared again on the equal-separator guard.
+    IOv2::numeric_conf<char8_t> conf("fr_FR.UTF-8");
+
+    if (conf.decimal_point() != u8',')
+        throw std::runtime_error("numeric_conf<char8_t>::decimal_point incorrect");
+    // Multi-byte separator collapses onto the single-byte fallback u8','.
+    if (conf.thousands_sep() != u8',')
+        throw std::runtime_error("numeric_conf<char8_t>::thousands_sep incorrect");
+    // Both clearing paths must leave grouping empty so downstream parsing
+    // takes the no-grouping branch instead of misclassifying digits.
+    if (!conf.grouping().empty())
+        throw std::runtime_error("numeric_conf<char8_t>::grouping should be cleared");
+
+    dump_info("Done\n");
+}

--- a/test/facet/numeric/test_numeric_wchar_t.cpp
+++ b/test/facet/numeric/test_numeric_wchar_t.cpp
@@ -2233,9 +2233,33 @@ void test_numeric_wchar_t_get_21()
             if (ul0 != ul1) throw std::runtime_error("IOv2::numeric<wchar_t>::get fails");
         }
     };
-    
+
     IOv2::numeric<wchar_t> obj(std::make_shared<IOv2::numeric_conf<wchar_t>>("C"), s_ctype_c);
     helper(obj);
+
+    dump_info("Done\n");
+}
+
+void test_numeric_wchar_t_conf_bool_fallback()
+{
+    dump_info("Test numeric_conf<wchar_t> bool-name fallback...");
+
+    // "C.UTF-8" is NOT the literal "C"/"POSIX" fast path, so the constructor
+    // runs the full locale-snapshot branch. glibc's C.UTF-8 exposes empty
+    // YESSTR/NOSTR, which the constructor treats as missing keys and replaces
+    // with the wide ASCII defaults L"true"/L"false".
+    IOv2::numeric_conf<wchar_t> conf("C.UTF-8");
+
+    if (conf.truename() != L"true")
+        throw std::runtime_error("numeric_conf<wchar_t>::truename fallback incorrect");
+    if (conf.falsename() != L"false")
+        throw std::runtime_error("numeric_conf<wchar_t>::falsename fallback incorrect");
+    if (conf.decimal_point() != L'.')
+        throw std::runtime_error("numeric_conf<wchar_t>::decimal_point incorrect");
+    if (conf.thousands_sep() != L'\0')
+        throw std::runtime_error("numeric_conf<wchar_t>::thousands_sep incorrect");
+    if (!conf.grouping().empty())
+        throw std::runtime_error("numeric_conf<wchar_t>::grouping incorrect");
 
     dump_info("Done\n");
 }


### PR DESCRIPTION
Add unit tests to existing facet test files (no new files) to raise line coverage on the facet detail/implementation headers:

- collate_details.h: 111/115 -> 112/115. Cover the collate_conf<char8_t>
  constructor rejecting a non-UTF-8 inter-locale (probes "C"/"POSIX").
- numeric_details.h: 111/122 -> 119/122. Cover the YESSTR/NOSTR-missing bool-name fallbacks (via "C.UTF-8", which is not the literal "C"/"POSIX" fast path and exposes empty YESSTR/NOSTR) for char/wchar_t/char32_t, and the multi-byte thousands-separator narrowing + equal-separator grouping clear for char8_t (via fr_FR.UTF-8, whose separator is U+202F).
- numeric.h: 466/498 -> 495/498. Cover bool/int/float get edge cases (out-of-range bool, lone sign, octal "0x", oversized digit groups, "1e", infinity via 1e400) and put edge cases (octal showbase, showpoint, leading-zero float padding, internal-adjust sign).

The remaining uncovered lines are unreachable defensive guards on glibc: strxfrm/wcsxfrm failure (collate), the equal-separator / decimal '\0' fallbacks for which no installed locale qualifies (numeric_details), and the snprintf-failure branches in insert_float (numeric).