### PR TITLE
fix(facet): drop unused include, gettext-faithful lang filter, strong-guarantee monetary get

### DIFF
--- a/include/facet/messages_details.h
+++ b/include/facet/messages_details.h
@@ -6,7 +6,6 @@
 #include <cvt/root_cvt.h>
 #include <device/mem_device.h>
 #include <facet/facet_common.h>
-#include <facet/facet_helper.h>
 
 #include <bit>
 #include <cstdint>
@@ -95,7 +94,12 @@ public:
                 if (const char* p = std::getenv(var); p && p[0] != '\0')
                 {
                     res = p;
-                    if (base_ft<messages>::available(domain, res)) return res;
+                    // Unlike LANGUAGE, these are a single locale name, not a
+                    // ':'-separated list (gettext never splits them). A value
+                    // containing ':' is therefore not a valid locale name:
+                    // skip it and try the next variable.
+                    if (res.find(':') == std::string::npos && base_ft<messages>::available(domain, res))
+                        return res;
                 }
             }
 

--- a/include/facet/monetary.h
+++ b/include/facet/monetary.h
@@ -129,9 +129,11 @@ public:
         std::tie(succ, beg) = intl ? extract<true>(beg, end, io, str)
                                    : extract<false>(beg, end, io, str);
 
-        succ &= str_to_v(str, utils);
+        TVal tmp{};
+        succ &= str_to_v(str, tmp);
         if (!succ)
             throw stream_error("monetary parse fail");
+        utils = tmp;
         return beg;
     }
 
@@ -144,20 +146,22 @@ public:
         std::tie(succ, beg) = intl ? extract<true>(beg, end, io, str)
                                    : extract<false>(beg, end, io, str);
         const auto len = str.size();
+        std::basic_string<char_type> tmp;
         if (len)
         {
-            digits.clear();
-            digits.reserve(len);
+            tmp.reserve(len);
             for (auto ch : str)
             {
                 if (ch == '-')
-                    digits.push_back(s_atoms[0]);
+                    tmp.push_back(s_atoms[0]);
                 else if ((ch >= '0') && (ch <= '9'))
-                    digits.push_back(s_atoms[ch - '0' + 1]);
+                    tmp.push_back(s_atoms[ch - '0' + 1]);
             }
         }
         if (!succ)
             throw stream_error("monetary parse fail");
+        if (len)
+            digits.swap(tmp);
         return beg;
     }
 

--- a/test/facet/monetary/test_monetary_char.cpp
+++ b/test/facet/monetary/test_monetary_char.cpp
@@ -1244,8 +1244,10 @@ void test_monetary_char_get_21()
     IOv2::monetary<char> obj(tmp_io);
     std::string buffer1("00#0#1");
     std::string buffer2("000##1");
-    std::string val1, val2;
-    
+    // Strong exception guarantee: a failed parse must leave the caller's
+    // output argument untouched, so pre-seed a sentinel and verify it survives.
+    std::string val1("sentinel"), val2("sentinel");
+
     {
         try
         {
@@ -1254,7 +1256,7 @@ void test_monetary_char_get_21()
             std::abort();
         }
         catch (IOv2::stream_error&) {}
-        if (val1 != "1") throw std::runtime_error("IOv2::monetary<char>::get fails");
+        if (val1 != "sentinel") throw std::runtime_error("IOv2::monetary<char>::get fails");
     }
     {
         try
@@ -1264,7 +1266,7 @@ void test_monetary_char_get_21()
             std::abort();
         }
         catch (IOv2::stream_error&) {}
-        if (val2 != "") throw std::runtime_error("IOv2::monetary<char>::get fails");
+        if (val2 != "sentinel") throw std::runtime_error("IOv2::monetary<char>::get fails");
     }
 
     dump_info("Done\n");
@@ -2308,7 +2310,9 @@ void test_monetary_char_get_44()
                                 IOv2::base_ft<IOv2::monetary>::value});
                                   
     IOv2::monetary<char> obj(tmp_io);
-    std::string val1, val2;
+    // Strong exception guarantee: a failed parse must leave the caller's
+    // output argument untouched, so pre-seed a sentinel and verify it survives.
+    std::string val1("sentinel"), val2("sentinel");
 
     using namespace IOv2;
     {
@@ -2322,7 +2326,7 @@ void test_monetary_char_get_44()
             std::abort();
         }
         catch (IOv2::stream_error&) {}
-        if (val1 != "1") throw std::runtime_error("IOv2::monetary<char>::get fails");
+        if (val1 != "sentinel") throw std::runtime_error("IOv2::monetary<char>::get fails");
         if (it != end) throw std::runtime_error("IOv2::monetary<char>::get fails");
     }
     {
@@ -2336,7 +2340,7 @@ void test_monetary_char_get_44()
             std::abort();
         }
         catch (IOv2::stream_error&) {}
-        if (val2 != "") throw std::runtime_error("IOv2::monetary<char>::get fails");
+        if (val2 != "sentinel") throw std::runtime_error("IOv2::monetary<char>::get fails");
         if (*it != '#') throw std::runtime_error("IOv2::monetary<char>::get fails");
     }
 

--- a/test/facet/monetary/test_monetary_char32_t.cpp
+++ b/test/facet/monetary/test_monetary_char32_t.cpp
@@ -1243,8 +1243,10 @@ void test_monetary_char32_t_get_21()
     IOv2::monetary<char32_t> obj(tmp_io);
     std::u32string  buffer1(U"00#0#1");
     std::u32string  buffer2(U"000##1");
-    std::u32string  val1, val2;
-    
+    // Strong exception guarantee: a failed parse must leave the caller's
+    // output argument untouched, so pre-seed a sentinel and verify it survives.
+    std::u32string  val1(U"sentinel"), val2(U"sentinel");
+
     {
         try
         {
@@ -1253,7 +1255,7 @@ void test_monetary_char32_t_get_21()
             std::abort();
         }
         catch (IOv2::stream_error&) {}
-        if (val1 != U"1") throw std::runtime_error("IOv2::monetary<char32_t>::get fails");
+        if (val1 != U"sentinel") throw std::runtime_error("IOv2::monetary<char32_t>::get fails");
     }
     {
         try
@@ -1263,7 +1265,7 @@ void test_monetary_char32_t_get_21()
             std::abort();
         }
         catch (IOv2::stream_error&) {}
-        if (val2 != U"") throw std::runtime_error("IOv2::monetary<char32_t>::get fails");
+        if (val2 != U"sentinel") throw std::runtime_error("IOv2::monetary<char32_t>::get fails");
     }
 
     dump_info("Done\n");

--- a/test/facet/monetary/test_monetary_char8_t.cpp
+++ b/test/facet/monetary/test_monetary_char8_t.cpp
@@ -1243,8 +1243,10 @@ void test_monetary_char8_t_get_21()
     IOv2::monetary<char8_t> obj(tmp_io);
     std::u8string  buffer1(u8"00#0#1");
     std::u8string  buffer2(u8"000##1");
-    std::u8string  val1, val2;
-    
+    // Strong exception guarantee: a failed parse must leave the caller's
+    // output argument untouched, so pre-seed a sentinel and verify it survives.
+    std::u8string  val1(u8"sentinel"), val2(u8"sentinel");
+
     {
         try
         {
@@ -1253,7 +1255,7 @@ void test_monetary_char8_t_get_21()
             std::abort();
         }
         catch (IOv2::stream_error&) {}
-        if (val1 != u8"1") throw std::runtime_error("IOv2::monetary<char8_t>::get fails");
+        if (val1 != u8"sentinel") throw std::runtime_error("IOv2::monetary<char8_t>::get fails");
     }
     {
         try
@@ -1263,7 +1265,7 @@ void test_monetary_char8_t_get_21()
             std::abort();
         }
         catch (IOv2::stream_error&) {}
-        if (val2 != u8"") throw std::runtime_error("IOv2::monetary<char8_t>::get fails");
+        if (val2 != u8"sentinel") throw std::runtime_error("IOv2::monetary<char8_t>::get fails");
     }
 
     dump_info("Done\n");

--- a/test/facet/monetary/test_monetary_wchar_t.cpp
+++ b/test/facet/monetary/test_monetary_wchar_t.cpp
@@ -1242,8 +1242,10 @@ void test_monetary_wchar_t_get_21()
     IOv2::monetary<wchar_t> obj(tmp_io);
     std::wstring buffer1(L"00#0#1");
     std::wstring buffer2(L"000##1");
-    std::wstring val1, val2;
-    
+    // Strong exception guarantee: a failed parse must leave the caller's
+    // output argument untouched, so pre-seed a sentinel and verify it survives.
+    std::wstring val1(L"sentinel"), val2(L"sentinel");
+
     {
         try
         {
@@ -1252,7 +1254,7 @@ void test_monetary_wchar_t_get_21()
             std::abort();
         }
         catch (IOv2::stream_error&) {}
-        if (val1 != L"1") throw std::runtime_error("IOv2::monetary<wchar_t>::get fails");
+        if (val1 != L"sentinel") throw std::runtime_error("IOv2::monetary<wchar_t>::get fails");
     }
     {
         try
@@ -1262,7 +1264,7 @@ void test_monetary_wchar_t_get_21()
             std::abort();
         }
         catch (IOv2::stream_error&) {}
-        if (val2 != L"") throw std::runtime_error("IOv2::monetary<wchar_t>::get fails");
+        if (val2 != L"sentinel") throw std::runtime_error("IOv2::monetary<wchar_t>::get fails");
     }
 
     dump_info("Done\n");


### PR DESCRIPTION
- messages_details.h: remove unused <facet/facet_helper.h> (FacetHelper is not referenced; abs_ft/ft_basic come from facet_common.h, stream_error from common/defs.h).
- messages_details.h: in filter_lang, skip LC_ALL/LC_MESSAGES/LANG values containing ':' instead of routing them through the colon-splitting available(); these env vars are single locale names (only LANGUAGE is a ':'-separated list), matching gettext semantics and removing the available()==true vs. construction-failure inconsistency.
- monetary.h: both get() overloads now parse into a local and commit to the output parameter only after success, so a thrown parse failure leaves the caller's output argument untouched.