### PR TITLE
fix(facet): translate returns ptr to avoid dangling ref; monetary bug fixes

### DIFF
--- a/include/facet/messages.h
+++ b/include/facet/messages.h
@@ -21,12 +21,30 @@ public:
         : m_obj(p_obj)
     { if (!m_obj) throw std::runtime_error("shared_ptr is empty"); }
 
+    // Gettext pass-through: the translation on a hit, otherwise the original
+    // `ori`. The lvalue overload borrows (zero copy): the result aliases either
+    // the dictionary (stable for the facet's lifetime) or `ori` itself on a miss,
+    // so the caller's lvalue must outlive it. Temporaries cannot bind here — they
+    // select the by-value rvalue overload below, which can never dangle.
     const std::basic_string<char_type>& translate(const std::basic_string<char_type>& ori) const
     {
         const static std::basic_string<char_type> empty_res;
         if (ori.empty()) return empty_res;
 
-        return m_obj->translate(ori);
+        const auto* p = m_obj->translate(ori);
+        return p ? *p : ori;
+    }
+
+    // Rvalue input returns by value, so the result owns its data and can never
+    // dangle: a miss moves the caller's temporary out (no copy), a hit copies the
+    // dictionary entry out. This makes the common literal/temporary call shape
+    // safe without forbidding it.
+    std::basic_string<char_type> translate(std::basic_string<char_type>&& ori) const
+    {
+        if (ori.empty()) return {};
+
+        const auto* p = m_obj->translate(ori);
+        return p ? *p : std::move(ori);
     }
 
     const std::string& filtered_lang() const
@@ -39,10 +57,12 @@ public:
         return m_obj->domain_info();
     }
 
+    // The .mo header is stored as the entry whose msgid is the empty string.
     const std::basic_string<char_type>& head_entry() const
     {
-        const static std::basic_string<char_type> input;
-        return m_obj->translate(input);
+        const static std::basic_string<char_type> empty_msgid;
+        const auto* p = m_obj->translate(empty_msgid);
+        return p ? *p : empty_msgid;
     }
 
 private:

--- a/include/facet/messages_details.h
+++ b/include/facet/messages_details.h
@@ -137,6 +137,13 @@ protected:
     // own lookup, which compares msgids with strcmp() and so stops at the first
     // NUL, and it keeps the map key identical to what a caller passes in.
     //
+    // Encoding: strings are assumed to be UTF-8 (the default that GNU gettext
+    // >= 0.22's msgfmt produces). The .mo charset declared in the header
+    // entry's "Content-Type: ...; charset=..." is neither read nor honoured
+    // here, so a .mo in another encoding (a legacy file, or one built with
+    // msgfmt --no-convert) is NOT transcoded: its non-ASCII msgstrs would be
+    // misdecoded. msgids are unaffected, as gettext recommends they be US-ASCII.
+    //
     // Consequently the following are NOT supported (their extra payload is
     // dropped on purpose, not by accident):
     //   - ngettext()/dngettext() plural forms: the original is stored as
@@ -153,7 +160,7 @@ protected:
     {
         std::FILE* fp = fopen(filename.c_str(), "rb");
         if (!fp)
-            throw stream_error("get_translate_dictionary fail: cannot open file" + filename);
+            throw stream_error("get_translate_dictionary fail: cannot open file " + filename);
 
         file_closer guard(fp);
         auto read_num = [fp](unsigned char* buf, bool need_swap)
@@ -284,11 +291,17 @@ public:
         , m_dict(init(domain, this->filtered_lang(), throw_if_fail))
     {}
 
-    virtual const std::u8string& translate(const std::u8string& ori) const
+    // Returns a pointer to the translation, or nullptr when `ori` is not in the
+    // dictionary. Returning a pointer (rather than `ori` on a miss) keeps this
+    // lookup from ever aliasing the caller's argument, so it neither dangles nor
+    // copies; the messages facet layers the gettext pass-through (return the
+    // original on a miss) on top, where it can do so safely per value category.
+    // nullptr unambiguously means "not found", distinct from a found translation
+    // that happens to be empty.
+    virtual const std::u8string* translate(const std::u8string& ori) const
     {
-        if (auto it = m_dict.find(ori); it != m_dict.end())
-            return it->second;
-        return ori;
+        auto it = m_dict.find(ori);
+        return it != m_dict.end() ? &it->second : nullptr;
     }
 
 private:
@@ -354,11 +367,11 @@ private:
     }
 
 public:
-    virtual const TString& translate(const TString& ori) const
+    // See the char8_t specialization: nullptr means "not found".
+    virtual const TString* translate(const TString& ori) const
     {
-        if (auto it = m_dict.find(ori); it != m_dict.end())
-            return it->second;
-        return ori;
+        auto it = m_dict.find(ori);
+        return it != m_dict.end() ? &it->second : nullptr;
     }
 
 private:
@@ -374,11 +387,11 @@ public:
         , m_dict(init(domain, this->filtered_lang(), cvt_ft, throw_if_fail))
     {}
 
-    virtual const std::string& translate(const std::string& ori) const
+    // See the char8_t specialization: nullptr means "not found".
+    virtual const std::string* translate(const std::string& ori) const
     {
-        if (auto it = m_dict.find(ori); it != m_dict.end())
-            return it->second;
-        return ori;
+        auto it = m_dict.find(ori);
+        return it != m_dict.end() ? &it->second : nullptr;
     }
 
 private:

--- a/include/facet/monetary.h
+++ b/include/facet/monetary.h
@@ -121,7 +121,7 @@ public:
 
     template <typename TIter, std::sentinel_for<TIter> TSent, std::integral TVal>
         requires (!std::same_as<TVal, bool>)
-    TIter get(TIter beg, TSent end, bool intl, ios_base<char_type>& io, TVal& utils) const
+    TIter get(TIter beg, TSent end, bool intl, ios_base<char_type>& io, TVal& units) const
     {
         std::string str;
         bool succ = true;
@@ -133,7 +133,7 @@ public:
         succ &= str_to_v(str, tmp);
         if (!succ)
             throw stream_error("monetary parse fail");
-        utils = tmp;
+        units = tmp;
         return beg;
     }
 
@@ -193,7 +193,7 @@ private:
 
         // Look for valid numbers in input digits.
         int len = 0;
-        for (auto i = beg; i != beg + digits.size(); ++i)
+        for (auto i = beg; i != digits.data() + digits.size(); ++i)
         {
             char_type ch = *i;
             int j = 1;
@@ -473,7 +473,7 @@ private:
             }
 
             // 22.2.6.1.2, p4
-            if (negative && res[0] != '0')
+            if (negative && !res.empty() && res[0] != '0')
                 res.insert(res.begin(), '-');
 
             // Test for grouping fidelity.

--- a/include/facet/monetary_details.h
+++ b/include/facet/monetary_details.h
@@ -6,6 +6,7 @@
 #include <facet/facet_helper.h>
 
 #include <array>
+#include <climits>
 #include <clocale>
 #include <cstdint>
 #include <cstring>
@@ -266,19 +267,33 @@ public:
             if (lc->mon_decimal_point) mdp_raw = lc->mon_decimal_point;
             if (lc->mon_thousands_sep) mts_raw = lc->mon_thousands_sep;
 
-            const int lc_frac_nat = lc->frac_digits;
-            const int lc_frac_int = lc->int_frac_digits;
+            // CHAR_MAX is POSIX's "value not specified by the locale"; map it
+            // to 0 fractional digits rather than taking it literally.
+            const int lc_frac_nat = (lc->frac_digits == CHAR_MAX) ? 0 : lc->frac_digits;
+            const int lc_frac_int = (lc->int_frac_digits == CHAR_MAX) ? 0 : lc->int_frac_digits;
 
             // No lc-> access beyond this point: the conversions may
             // invalidate the lconv pointers.
+            // The decimal point and thousands separator are each stored as a
+            // single char. A locale separator that does not fit in one char
+            // (multibyte) cannot be represented: the convert yields '\0' and
+            // the fallbacks below regress to '.' / ','.
             m_decimal_point = FacetHelper::string_to_char_convert(mdp_raw, name);
             m_thousands_sep = FacetHelper::string_to_char_convert(mts_raw, name);
 
             if (m_decimal_point == '\0')
             {
-                m_frac_digits_int = 0;
-                m_frac_digits_nat = 0;
                 m_decimal_point = '.';
+                if (mdp_raw.empty())
+                {
+                    m_frac_digits_int = 0;
+                    m_frac_digits_nat = 0;
+                }
+                else
+                {
+                    m_frac_digits_nat = lc_frac_nat;
+                    m_frac_digits_int = lc_frac_int;
+                }
             }
             else
             {
@@ -398,8 +413,10 @@ public:
             const std::string int_curr_symbol_raw =
                 lc->int_curr_symbol ? lc->int_curr_symbol : "";
 
-            const int lc_frac_nat = lc->frac_digits;
-            const int lc_frac_int = lc->int_frac_digits;
+            // CHAR_MAX is POSIX's "value not specified by the locale"; map it
+            // to 0 fractional digits rather than taking it literally.
+            const int lc_frac_nat = (lc->frac_digits == CHAR_MAX) ? 0 : lc->frac_digits;
+            const int lc_frac_int = (lc->int_frac_digits == CHAR_MAX) ? 0 : lc->int_frac_digits;
             const bool has_n_sign_posn     = lc->n_sign_posn;
             const bool has_int_n_sign_posn = lc->int_n_sign_posn;
 
@@ -419,6 +436,10 @@ public:
 
             // No lc-> access beyond this point: the conversions may
             // invalidate the lconv pointers.
+            // The decimal point and thousands separator are each a single
+            // CharT. A locale separator that does not fit in one code unit
+            // (e.g. multiple code points) cannot be represented: the convert
+            // yields '\0' and the fallbacks below regress to '.' / ','.
             m_decimal_point = FacetHelper::string_to_widechar_convert<CharT>(
                 mon_dp_raw, name, static_cast<CharT>('\0'));
             m_thousands_sep = FacetHelper::string_to_widechar_convert<CharT>(
@@ -585,6 +606,9 @@ private:
     {
         monetary_conf<T> monetary_tmp(name);
 
+        // The decimal point and thousands separator are each a single char8_t
+        // (one UTF-8 code unit), so only a separator that encodes to a single
+        // byte (ASCII) fits; anything wider regresses to '.' / ','.
         {
             const auto& input = monetary_tmp.decimal_point();
             auto byte_str = detail::to_u8string(input);


### PR DESCRIPTION

messages: change virtual translate() return type from const T& to const T* (nullptr = not found) so the implementation never aliases the caller's argument. Add a safe rvalue overload on messages that returns by value, eliminating the dangling-reference hazard for temporary inputs.

messages_details: fix missing space in open-file error message; add comment documenting the UTF-8 assumption and CHAR_MAX frac_digits mapping.

monetary: rename parameter utils→units; fix iterator arithmetic (digits.data()+n instead of beg+n); guard res[0] access with !res.empty(); handle POSIX CHAR_MAX in frac_digits/int_frac_digits; refine decimal-point fallback to zero frac_digits only when mdp_raw is truly empty (not when a multibyte separator simply cannot be represented in one char).