### PR TITLE
fix(facet): cap .mo string count and add missing facet includes

### DIFF
--- a/include/facet/messages.h
+++ b/include/facet/messages.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <common/metafunctions.h>
+#include <facet/facet_common.h>
 #include <facet/messages_details.h>
 
 #include <memory>

--- a/include/facet/messages_details.h
+++ b/include/facet/messages_details.h
@@ -127,6 +127,15 @@ protected:
             throw stream_error("get_translate_dictionary fail: cannot open file " + filename);
 
         file_closer guard(fp);
+
+        if (std::fseek(fp, 0, SEEK_END) != 0)
+            throw stream_error("get_translate_dictionary fail: invalid format");
+        const long file_size = std::ftell(fp);
+        if (file_size < 0)
+            throw stream_error("get_translate_dictionary fail: file inconsistent");
+        if (std::fseek(fp, 0, SEEK_SET) != 0)
+            throw stream_error("get_translate_dictionary fail: invalid format");
+
         auto read_num = [fp](unsigned char* buf, bool need_swap)
         {
             if (std::fread(buf, 1, 4, fp) != 4)
@@ -158,6 +167,13 @@ protected:
         auto str_num = read_num(buff, need_swap);
         auto ori_offset = read_num(buff, need_swap);
         auto aim_offset = read_num(buff, need_swap);
+
+        // Each entry needs an 8-byte (length, offset) descriptor in both the
+        // original and translation tables, so a valid str_num cannot exceed
+        // file_size / 16. Rejecting larger counts caps the O(str_num) growth of
+        // oris and the result map, which the per-string length cap does not.
+        if (str_num > static_cast<std::uint64_t>(file_size) / 16u)
+            throw stream_error("get_translate_dictionary fail: implausible string count");
 
         if (std::fseek(fp, ori_offset, SEEK_SET) != 0)
             throw stream_error("get_translate_dictionary fail: invalid format");

--- a/include/facet/monetary.h
+++ b/include/facet/monetary.h
@@ -1,5 +1,7 @@
 #pragma once
+#include <common/defs.h>
 #include <common/metafunctions.h>
+#include <facet/facet_common.h>
 #include <facet/facet_helper.h>
 #include <facet/monetary_details.h>
 #include <io/io_base.h>


### PR DESCRIPTION
get_translate_dictionary capped only the per-string length (64 MiB), leaving str_num unbounded. A crafted .mo with a huge str_num and many length-0 descriptors drove O(str_num) growth of the oris vector and the result map, amplifying memory ~10x per input byte (CWE-770 DoS).

Determine the file size up front and reject str_num > file_size / 16 (each entry needs an 8-byte (length, offset) descriptor in both the original and translation tables), bounding allocation by file size.

Also add missing direct includes: facet_common.h to monetary.h and messages.h (facet_create_rule / base_ft) and common/defs.h to monetary.h (stream_error), which were only reachable transitively.