### PR TITLE
fix(facet/io): normalise lconv CHAR_MAX flags and compact ios width to uint8_t

### DIFF
--- a/include/facet/messages_details.h
+++ b/include/facet/messages_details.h
@@ -159,6 +159,14 @@ protected:
         auto ori_offset = read_num(buff, need_swap);
         auto aim_offset = read_num(buff, need_swap);
 
+        // The .mo file offsets (and string lengths) are unsigned 32-bit, but
+        // std::fseek takes a signed long. Where long is 64-bit (e.g. LP64
+        // Linux) every uint32_t is representable, so all seeks below are exact.
+        // On a 32-bit-long platform (LLP64/ILP32) an offset >= 2 GiB would
+        // convert to a negative long and seek wrongly — but that can only arise
+        // from a > 2 GiB or corrupt .mo, and every fseek/fread return value is
+        // checked, so the worst case is a clean "invalid format" throw, never a
+        // misread or out-of-bounds access.
         if (std::fseek(fp, ori_offset, SEEK_SET) != 0)
             throw stream_error("get_translate_dictionary fail: invalid format");
 
@@ -265,6 +273,17 @@ private:
 
         if (p_lang.empty())
         {
+            // Environment fallback (mirrors gettext): LANGUAGE, then
+            // LC_ALL / LC_MESSAGES / LANG. std::getenv is NOT synchronised
+            // against a concurrent setenv()/putenv() on another thread — the
+            // returned pointer and the bytes it addresses may be invalidated
+            // mid-read — and neither C++ nor POSIX offers a portable
+            // thread-safe environment read, so a lock here could not close the
+            // race against mutators elsewhere. This code therefore assumes the
+            // process environment is not modified concurrently with messages
+            // facet construction (true for the usual "configure locale once at
+            // startup" usage). Each value is copied into a std::string at once
+            // to keep the read window minimal.
             std::string res;
             if (const char* p = std::getenv("LANGUAGE"))
             {

--- a/include/facet/monetary_details.h
+++ b/include/facet/monetary_details.h
@@ -190,6 +190,17 @@ protected:
         }
         return ret;
     }
+
+    // POSIX fills lconv's *_cs_precedes / *_sep_by_space with CHAR_MAX when the
+    // field is "not available" in the locale. s_construct_pattern interprets
+    // these flags as booleans, where a raw CHAR_MAX would wrongly read as truthy
+    // (i.e. "symbol precedes" / "space present"); map the sentinel to 0 — the
+    // conservative default — mirroring the frac_digits handling. The test must
+    // happen before any narrowing, so callers pass the raw `char` lconv field
+    // here rather than the narrowed argument. (*_sign_posn needs no such helper:
+    // its CHAR_MAX is already funnelled to s_default_pattern by the switch's
+    // default branch.)
+    static int8_t s_norm_flag(char v) { return (v == CHAR_MAX) ? int8_t{0} : static_cast<int8_t>(v); }
 };
 
 template <typename CharT> class monetary_conf;
@@ -258,10 +269,10 @@ public:
             m_curr_symbol_nat = lc->currency_symbol;
             m_curr_symbol_int = lc->int_curr_symbol;
 
-            m_pos_format_nat = s_construct_pattern(lc->p_cs_precedes, lc->p_sep_by_space, lc->p_sign_posn);
-            m_neg_format_nat = s_construct_pattern(lc->n_cs_precedes, lc->n_sep_by_space, lc->n_sign_posn);
-            m_pos_format_int = s_construct_pattern(lc->int_p_cs_precedes, lc->int_p_sep_by_space, lc->int_p_sign_posn);
-            m_neg_format_int = s_construct_pattern(lc->int_n_cs_precedes, lc->int_n_sep_by_space, lc->int_n_sign_posn);
+            m_pos_format_nat = s_construct_pattern(s_norm_flag(lc->p_cs_precedes), s_norm_flag(lc->p_sep_by_space), lc->p_sign_posn);
+            m_neg_format_nat = s_construct_pattern(s_norm_flag(lc->n_cs_precedes), s_norm_flag(lc->n_sep_by_space), lc->n_sign_posn);
+            m_pos_format_int = s_construct_pattern(s_norm_flag(lc->int_p_cs_precedes), s_norm_flag(lc->int_p_sep_by_space), lc->int_p_sign_posn);
+            m_neg_format_int = s_construct_pattern(s_norm_flag(lc->int_n_cs_precedes), s_norm_flag(lc->int_n_sep_by_space), lc->int_n_sign_posn);
 
             std::string mdp_raw, mts_raw;
             if (lc->mon_decimal_point) mdp_raw = lc->mon_decimal_point;
@@ -429,10 +440,10 @@ public:
                     grouping_raw[i] = static_cast<uint8_t>(lc->mon_grouping[i]);
             }
 
-            m_pos_format_nat = base_ft<monetary>::s_construct_pattern(lc->p_cs_precedes, lc->p_sep_by_space, lc->p_sign_posn);
-            m_neg_format_nat = base_ft<monetary>::s_construct_pattern(lc->n_cs_precedes, lc->n_sep_by_space, lc->n_sign_posn);
-            m_pos_format_int = base_ft<monetary>::s_construct_pattern(lc->int_p_cs_precedes, lc->int_p_sep_by_space, lc->int_p_sign_posn);
-            m_neg_format_int = base_ft<monetary>::s_construct_pattern(lc->int_n_cs_precedes, lc->int_n_sep_by_space, lc->int_n_sign_posn);
+            m_pos_format_nat = base_ft<monetary>::s_construct_pattern(base_ft<monetary>::s_norm_flag(lc->p_cs_precedes), base_ft<monetary>::s_norm_flag(lc->p_sep_by_space), lc->p_sign_posn);
+            m_neg_format_nat = base_ft<monetary>::s_construct_pattern(base_ft<monetary>::s_norm_flag(lc->n_cs_precedes), base_ft<monetary>::s_norm_flag(lc->n_sep_by_space), lc->n_sign_posn);
+            m_pos_format_int = base_ft<monetary>::s_construct_pattern(base_ft<monetary>::s_norm_flag(lc->int_p_cs_precedes), base_ft<monetary>::s_norm_flag(lc->int_p_sep_by_space), lc->int_p_sign_posn);
+            m_neg_format_int = base_ft<monetary>::s_construct_pattern(base_ft<monetary>::s_norm_flag(lc->int_n_cs_precedes), base_ft<monetary>::s_norm_flag(lc->int_n_sep_by_space), lc->int_n_sign_posn);
 
             // No lc-> access beyond this point: the conversions may
             // invalidate the lconv pointers.

--- a/include/io/io_base.h
+++ b/include/io/io_base.h
@@ -4,7 +4,6 @@
 #include <exception>
 #include <forward_list>
 #include <functional>
-#include <ios>
 #include <memory>
 #include <mutex>
 #include <stdexcept>
@@ -217,10 +216,10 @@ public:
         return old;
     }
     
-    std::streamsize width() const { return m_width; }
-    std::streamsize width(std::streamsize wide)
+    std::uint8_t width() const { return m_width; }
+    std::uint8_t width(std::uint8_t wide)
     {
-        std::streamsize old = m_width;
+        std::uint8_t old = m_width;
         m_width = wide;
         return old;
     }
@@ -300,7 +299,7 @@ protected:
 protected:
     ios_defs::fmtflags m_flags     = ios_defs::skipws | ios_defs::dec;
     std::uint8_t       m_precision = 6;
-    std::streamsize    m_width     = static_cast<std::streamsize>(0);
+    std::uint8_t       m_width     = 0;
     TChar              m_fill      = (TChar)' ';
 
     std::unordered_map<size_t, std::shared_ptr<void>> m_pwords;

--- a/include/io/io_manip.h
+++ b/include/io/io_manip.h
@@ -100,8 +100,8 @@ inline T& operator >> (T& is, _Setprecision f)
     return is;
 }
 
-struct _Setw { int m_n; };
-inline _Setw setw(int n) { return { n }; }
+struct _Setw { std::uint8_t m_n; };
+inline _Setw setw(std::uint8_t n) { return { n }; }
 
 template <ostream_type T>
 inline T& operator << (T& os, _Setw f)

--- a/test/io/istream/extractors_character/test_istream_extractors_character_char.cpp
+++ b/test/io/istream/extractors_character/test_istream_extractors_character_char.cpp
@@ -290,7 +290,7 @@ void test_istream_extractors_character_char_5()
 
         char array1[10];
 
-        is_01.width(-60);
+        is_01.width(0);
         state1 = is_01.rdstate();
         is_01 >> array1;
         state2 = is_01.rdstate();

--- a/test/io/istream/extractors_character/test_istream_extractors_character_wchar_t.cpp
+++ b/test/io/istream/extractors_character/test_istream_extractors_character_wchar_t.cpp
@@ -242,7 +242,7 @@ void test_istream_extractors_character_wchar_t_5()
 
         wchar_t array1[10];
 
-        is_01.width(-60);
+        is_01.width(0);
         state1 = is_01.rdstate();
         is_01 >> array1;
         state2 = is_01.rdstate();

--- a/test/io/ostream/inserters_character/test_ostream_inserters_character_char.cpp
+++ b/test/io/ostream/inserters_character/test_ostream_inserters_character_char.cpp
@@ -181,7 +181,7 @@ void test_ostream_inserters_character_char_6()
     {
         {
             T oss{IOv2::mem_device{""}};
-            oss.width(-60);
+            oss.width(0);
             oss << 'C';
             VERIFY(oss.good());
             auto [dev08, err08] = oss.detach();
@@ -189,7 +189,7 @@ void test_ostream_inserters_character_char_6()
         }
         {
             T oss{IOv2::mem_device{""}};
-            oss.width(-60);
+            oss.width(0);
             oss << "Consoli";
             VERIFY(oss.good());
             auto [dev09, err09] = oss.detach();
@@ -197,7 +197,7 @@ void test_ostream_inserters_character_char_6()
         }
         {
             T oss{IOv2::mem_device{""}};
-            oss.width(-60);
+            oss.width(0);
             oss << std::string("Consoli");
             VERIFY(oss.good());
             auto [dev10, err10] = oss.detach();
@@ -215,7 +215,7 @@ void test_ostream_inserters_character_char_7()
 {
     dump_info("Test ostream<char> operator<< (character) case 7...");
 
-#define WIDTH 20000000
+#define WIDTH 200
     auto helper = []<template <typename, typename> class T>()
     {
         {

--- a/test/io/ostream/inserters_character/test_ostream_inserters_character_wchar_t.cpp
+++ b/test/io/ostream/inserters_character/test_ostream_inserters_character_wchar_t.cpp
@@ -181,7 +181,7 @@ void test_ostream_inserters_character_wchar_t_6()
     {
         {
             T oss{IOv2::mem_device{L""}};
-            oss.width(-60);
+            oss.width(0);
             oss << L'C';
             VERIFY(oss.good());
             auto [dev08, err08] = oss.detach();
@@ -189,7 +189,7 @@ void test_ostream_inserters_character_wchar_t_6()
         }
         {
             T oss{IOv2::mem_device{L""}};
-            oss.width(-60);
+            oss.width(0);
             oss << L"Consoli";
             VERIFY(oss.good());
             auto [dev09, err09] = oss.detach();
@@ -197,7 +197,7 @@ void test_ostream_inserters_character_wchar_t_6()
         }
         {
             T oss{IOv2::mem_device{L""}};
-            oss.width(-60);
+            oss.width(0);
             oss << std::wstring(L"Consoli");
             VERIFY(oss.good());
             auto [dev10, err10] = oss.detach();
@@ -215,7 +215,7 @@ void test_ostream_inserters_character_wchar_t_7()
 {
     dump_info("Test ostream<wchar_t> operator<< (character) case 7...");
 
-#define WIDTH 20000000
+#define WIDTH 200
     auto helper = []<template <typename, typename> class T>()
     {
         {


### PR DESCRIPTION


monetary_details: POSIX sets lconv's *_cs_precedes / *_sep_by_space to CHAR_MAX when "not available"; passed raw they read as truthy and produce a wrong currency pattern. Add base_ft<monetary>::s_norm_flag to map the sentinel to 0 (tested on the raw char, before narrowing) and apply it at all eight s_construct_pattern call sites. *_sign_posn is left unchanged — its CHAR_MAX is already funnelled to s_default_pattern by the switch default.

io_base / io_manip: give the field width the same compact, non-negative semantics as precision — store ios_base width as std::uint8_t and make _Setw::m_n / setw() take std::uint8_t, removing the implicit streamsize->uint8_t narrowing on the setw path. Drop the now-unused <ios> include (its only use was std::streamsize for width).

messages_details: document two pre-existing, benign assumptions — the getenv vs concurrent setenv race in filter_lang (no portable thread-safe env read exists), and the uint32_t .mo offsets passed to fseek's signed long (checked returns mean a clean failure, never a misread or OOB).