### PR TITLE
style(facet): make monetary/messages headers clang-tidy clean and add to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,8 @@ jobs:
           include/facet/ctype_details.h include/facet/ctype.h \
           include/facet/collate_details.h include/facet/collate.h \
           include/facet/numeric_details.h include/facet/numeric.h \
+          include/facet/monetary_details.h include/facet/monetary.h \
+          include/facet/messages_details.h include/facet/messages.h \
           --checks='bugprone-*,performance-*,modernize-*,cppcoreguidelines-*,-modernize-use-trailing-return-type,-cppcoreguidelines-avoid-magic-numbers,-cppcoreguidelines-pro-bounds-pointer-arithmetic,-cppcoreguidelines-pro-bounds-constant-array-index,-cppcoreguidelines-avoid-non-const-global-variables,-cppcoreguidelines-pro-bounds-avoid-unchecked-container-access,-clang-diagnostic-pragma-once-outside-header' \
           --warnings-as-errors='bugprone-*' \
           -- -std=c++23 -x c++ -I include -I /usr/include -I /usr/include/botan-2

--- a/include/facet/messages.h
+++ b/include/facet/messages.h
@@ -6,6 +6,7 @@
 #include <memory>
 #include <stdexcept>
 #include <string>
+#include <utility>
 
 namespace IOv2
 {
@@ -63,12 +64,12 @@ public:
         return p ? *p : ori;
     }
 
-    const std::string& filtered_lang() const
+    [[nodiscard]] const std::string& filtered_lang() const
     {
         return m_obj->filtered_lang();
     }
 
-    const std::string& domain_info() const
+    [[nodiscard]] const std::string& domain_info() const
     {
         return m_obj->domain_info();
     }

--- a/include/facet/messages_details.h
+++ b/include/facet/messages_details.h
@@ -7,6 +7,7 @@
 #include <device/mem_device.h>
 #include <facet/facet_common.h>
 
+#include <array>
 #include <bit>
 #include <cstdint>
 #include <cstdio>
@@ -32,7 +33,9 @@ class base_ft<messages> : public abs_ft
             : m_fp(fp) {}
         file_closer(const file_closer&) = delete;
         file_closer& operator=(const file_closer&) = delete;
-        ~file_closer() { fclose(m_fp); }
+        file_closer(file_closer&&) = delete;
+        file_closer& operator=(file_closer&&) = delete;
+        ~file_closer() { fclose(m_fp); } // NOLINT(cppcoreguidelines-owning-memory)
     private:
         std::FILE* m_fp;
     };
@@ -40,7 +43,7 @@ class base_ft<messages> : public abs_ft
 public:
     static void bind_text_domain(const std::string& domain, const std::string& dirname)
     {
-        std::lock_guard<std::mutex> guard(s_domain_mutex);
+        std::scoped_lock guard(s_domain_mutex);
         auto it = s_domain_dirs.find(domain);
         if (it != s_domain_dirs.end())
             it->second = dirname;
@@ -53,12 +56,12 @@ public:
     // another thread rebinds the domain via bind_text_domain() concurrently.
     static bool available(const std::string& domain, const std::string& lang)
     {
-        return available(get_dirname(domain), domain, lang);
+        return available({.dirname = get_dirname(domain), .domain = domain}, lang);
     }
 
     static std::string filter_lang(const std::string& domain, const std::string& p_lang)
     {
-        return filter_lang(get_dirname(domain), domain, p_lang);
+        return filter_lang({.dirname = get_dirname(domain), .domain = domain}, p_lang);
     }
 
     base_ft(size_t id, const std::string& p_domain, const std::string& p_lang)
@@ -70,24 +73,36 @@ public:
         // one dirname, so the recorded domain_info can never disagree with the
         // dictionary actually loaded.
         , m_dirname(get_dirname(p_domain))
-        , m_filtered_lang(filter_lang(m_dirname, p_domain, p_lang))
+        , m_filtered_lang(filter_lang({.dirname = m_dirname, .domain = p_domain}, p_lang))
         , m_domain_info('[' + p_domain + "] [" + p_lang + '(' + m_filtered_lang + ')' + "] [" +
                         m_dirname + "]")
     {}
 
-    const std::string& domain_info() const { return m_domain_info; }
-    const std::string& filtered_lang() const { return m_filtered_lang; }
+    [[nodiscard]] const std::string& domain_info() const { return m_domain_info; }
+    [[nodiscard]] const std::string& filtered_lang() const { return m_filtered_lang; }
 
 protected:
     // The directory bound to this domain (gettext's `dirname`), snapshotted at
     // construction. Derived configs read this so their dictionary load uses the
     // same directory that domain_info() reports.
-    const std::string& dirname() const { return m_dirname; }
+    [[nodiscard]] const std::string& dirname() const { return m_dirname; }
 
-    static std::string get_domain_file(const std::string& dirname, const std::string& domain, const std::string& lang)
+    // The bound text domain and its directory. These two same-typed strings are
+    // always passed together to the lookup helpers below; bundling them here (vs
+    // two positional std::string parameters) makes them impossible to swap by
+    // mistake (bugprone-easily-swappable-parameters). The language stays a
+    // separate argument because it varies independently — filter_lang() probes
+    // several candidate languages against one fixed (dirname, domain) pair.
+    struct text_domain
     {
-        std::filesystem::path dom{dirname};
-        dom = dom / lang / "LC_MESSAGES" / (domain + ".mo");
+        std::string dirname;  // gettext dirname: the directory holding the locale tree
+        std::string domain;   // text domain: the .mo file's basename
+    };
+
+    static std::string get_domain_file(const text_domain& td, const std::string& lang)
+    {
+        std::filesystem::path dom{td.dirname};
+        dom = dom / lang / "LC_MESSAGES" / (td.domain + ".mo");
         return dom.string();
     }
 
@@ -122,7 +137,7 @@ protected:
     // ever required.
     static std::unordered_map<std::u8string, std::u8string> get_translate_dictionary(const std::string& filename)
     {
-        std::FILE* fp = fopen(filename.c_str(), "rb");
+        std::FILE* fp = fopen(filename.c_str(), "rb"); // NOLINT(cppcoreguidelines-owning-memory)
         if (!fp)
             throw stream_error("get_translate_dictionary fail: cannot open file " + filename);
 
@@ -150,8 +165,8 @@ protected:
             return res;
         };
 
-        unsigned char buff[8];
-        if (std::fread(buff, 1, 8, fp) != 8)
+        std::array<unsigned char, 8> buff{};
+        if (std::fread(buff.data(), 1, 8, fp) != 8)
             throw stream_error("get_translate_dictionary fail: invalid format");
 
         bool need_swap = false;
@@ -164,9 +179,9 @@ protected:
         if ((buff[4] != 0) || (buff[5] != 0) || (buff[6] != 0) || (buff[7] != 0))
             throw stream_error("get_translate_dictionary fail: invalid format");
 
-        auto str_num = read_num(buff, need_swap);
-        auto ori_offset = read_num(buff, need_swap);
-        auto aim_offset = read_num(buff, need_swap);
+        auto str_num = read_num(buff.data(), need_swap);
+        auto ori_offset = read_num(buff.data(), need_swap);
+        auto aim_offset = read_num(buff.data(), need_swap);
 
         // Each entry needs an 8-byte (length, offset) descriptor in both the
         // original and translation tables, so a valid str_num cannot exceed
@@ -195,8 +210,8 @@ protected:
         std::vector<std::u8string> oris;
         for (size_t i = 0; i < str_num; ++i)
         {
-            auto length = read_num(buff, need_swap);
-            auto offset = read_num(buff, need_swap);
+            auto length = read_num(buff.data(), need_swap);
+            auto offset = read_num(buff.data(), need_swap);
             auto cur_pos = std::ftell(fp);
             if (cur_pos == -1L) throw stream_error("get_translate_dictionary fail: file inconsistent");
 
@@ -212,7 +227,7 @@ protected:
                 throw stream_error("get_translate_dictionary fail: invalid format");
 
             str_buf[length] = u8'\0';
-            oris.push_back(str_buf.data());
+            oris.emplace_back(str_buf.data());
 
             if (std::fseek(fp, cur_pos, SEEK_SET) != 0)
                 throw stream_error("get_translate_dictionary fail: invalid format");
@@ -224,8 +239,8 @@ protected:
 
         for (size_t i = 0; i < str_num; ++i)
         {
-            auto length = read_num(buff, need_swap);
-            auto offset = read_num(buff, need_swap);
+            auto length = read_num(buff.data(), need_swap);
+            auto offset = read_num(buff.data(), need_swap);
             auto cur_pos = std::ftell(fp);
             if (cur_pos == -1L) throw stream_error("get_translate_dictionary fail: file inconsistent");
 
@@ -254,34 +269,34 @@ private:
     // Snapshot-taking implementations: the dirname is resolved once by the
     // caller and threaded through here, so neither recursion into available()
     // nor the language scan re-reads s_domain_dirs.
-    static bool available(const std::string& dirname, const std::string& domain, const std::string& lang)
+    static bool available(const text_domain& td, const std::string& lang)
     {
         if (lang.empty() || lang.find(':') != std::string::npos)
         {
-            std::string resolved = filter_lang(dirname, domain, lang);
+            std::string resolved = filter_lang(td, lang);
             if (resolved.empty())
                 return false;
-            return std::filesystem::exists(get_domain_file(dirname, domain, resolved));
+            return std::filesystem::exists(get_domain_file(td, resolved));
         }
-        return std::filesystem::exists(get_domain_file(dirname, domain, lang));
+        return std::filesystem::exists(get_domain_file(td, lang));
     }
 
-    static std::string filter_lang(const std::string& dirname, const std::string& domain, const std::string& p_lang)
+    static std::string filter_lang(const text_domain& td, const std::string& p_lang)
     {
-        auto match_lang = [&dirname, &domain](const std::string& str_lang)
+        auto match_lang = [&td](const std::string& str_lang)
         {
             std::size_t start = 0;
-            std::size_t end;
+            std::size_t end = 0;
             while ((end = str_lang.find(':', start)) != std::string::npos)
             {
                 auto cur_lang = str_lang.substr(start, end - start);
-                if ((!cur_lang.empty()) && (base_ft<messages>::available(dirname, domain, cur_lang)))
+                if ((!cur_lang.empty()) && (base_ft<messages>::available(td, cur_lang)))
                     return cur_lang;
                 start = end + 1;
             }
 
             auto last_str = str_lang.substr(start);
-            if ((!last_str.empty()) && (base_ft<messages>::available(dirname, domain, last_str)))
+            if ((!last_str.empty()) && (base_ft<messages>::available(td, last_str)))
                 return last_str;
 
             return std::string{};
@@ -316,7 +331,7 @@ private:
                     // ':'-separated list (gettext never splits them). A value
                     // containing ':' is therefore not a valid locale name:
                     // skip it and try the next variable.
-                    if (res.find(':') == std::string::npos && base_ft<messages>::available(dirname, domain, res))
+                    if (res.find(':') == std::string::npos && base_ft<messages>::available(td, res))
                         return res;
                 }
             }
@@ -334,7 +349,7 @@ private:
     {
         const static std::string def_dir = "/usr/share/locale";
 
-        std::lock_guard<std::mutex> guard(s_domain_mutex);
+        std::scoped_lock guard(s_domain_mutex);
         auto it = s_domain_dirs.find(domain);
         return (it == s_domain_dirs.end()) ? def_dir : it->second;
     }
@@ -379,7 +394,7 @@ private:
             if (lang.empty())
                 throw stream_error("messages_conf init fail: no language available");
             else
-                return get_translate_dictionary(get_domain_file(dirname, domain, lang));
+                return get_translate_dictionary(get_domain_file({.dirname = dirname, .domain = domain}, lang));
         }
         catch(...)
         {
@@ -415,7 +430,7 @@ private:
                 throw stream_error("messages_conf init fail: no language available");
 
             std::unordered_map<TString, TString> res;
-            auto tmp_dict = base_ft<messages>::get_translate_dictionary(base_ft<messages>::get_domain_file(dirname, domain, lang));
+            auto tmp_dict = base_ft<messages>::get_translate_dictionary(base_ft<messages>::get_domain_file({.dirname = dirname, .domain = domain}, lang));
             for (const auto& [k, v] : tmp_dict)
             {
                 const std::u32string uk = detail::to_u32string(k.c_str());
@@ -442,13 +457,19 @@ public:
     }
 
 private:
-    const std::unordered_map<TString, TString> m_dict;
+    const std::unordered_map<TString, TString> m_dict; // NOLINT(cppcoreguidelines-avoid-const-or-ref-data-members)
 };
 
 template <>
 class messages_conf<char> : public ft_basic<messages<char>>
 {
 public:
+    // domain, lang and cvt_ft are three distinct strings the caller must supply
+    // (cvt_ft names the char<->wchar_t converter facet, absent from the other
+    // specializations). This is the public, stable construction API, so the
+    // arguments cannot be bundled into a struct without breaking callers or
+    // diverging from the sibling specializations' (domain, lang) shape.
+    // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
     messages_conf(const std::string& domain, const std::string& lang, const std::string& cvt_ft, bool throw_if_fail = true)
         : ft_basic<messages<char>>(domain, lang)
         , m_dict(init(this->dirname(), domain, this->filtered_lang(), cvt_ft, throw_if_fail))
@@ -462,6 +483,10 @@ public:
     }
 
 private:
+    // Mirrors the public ctor's argument shape (see above): dirname/domain are
+    // bundled into a text_domain only where get_domain_file is called below;
+    // lang and cvt_ft remain distinct strings inherent to this char-only API.
+    // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
     static std::unordered_map<std::string, std::string> init(const std::string& dirname, const std::string& domain, const std::string& lang, const std::string& cvt_ft, bool throw_if_fail)
     {
         try
@@ -472,7 +497,7 @@ private:
                     throw stream_error("messages_conf init fail: no language available");
 
                 std::unordered_map<std::string, std::string> res;
-                auto tmp_dict = get_translate_dictionary(get_domain_file(dirname, domain, lang));
+                auto tmp_dict = get_translate_dictionary(get_domain_file({.dirname = dirname, .domain = domain}, lang));
 
                 auto cvt = IOv2::code_cvt_creator<char, wchar_t>(cvt_ft).create(rb_root_cvt{mem_device{""}});
 

--- a/include/facet/monetary.h
+++ b/include/facet/monetary.h
@@ -7,6 +7,7 @@
 #include <io/io_base.h>
 
 #include <algorithm>
+#include <array>
 #include <concepts>
 #include <cstddef>
 #include <cstdint>
@@ -70,30 +71,30 @@ public:
         // POSIX boundary in monetary_conf, not here.
     }
 
-    const std::vector<uint8_t>& grouping() const { return m_grouping; }
-    const std::basic_string<CharT>& curr_symbol_int() const { return m_int.m_curr_symbol; }
-    const std::basic_string<CharT>& curr_symbol_nat() const { return m_nat.m_curr_symbol; }
-    const std::basic_string<CharT>& positive_sign_int() const { return m_int.m_positive_sign; }
-    const std::basic_string<CharT>& positive_sign_nat() const { return m_nat.m_positive_sign; }
-    const std::basic_string<CharT>& negative_sign_int() const { return m_int.m_negative_sign; }
-    const std::basic_string<CharT>& negative_sign_nat() const { return m_nat.m_negative_sign; }
-    const base_ft<monetary>::pattern& pos_format_int() const { return m_int.m_pos_format; }
-    const base_ft<monetary>::pattern& pos_format_nat() const { return m_nat.m_pos_format; }
-    const base_ft<monetary>::pattern& neg_format_int() const { return m_int.m_neg_format; }
-    const base_ft<monetary>::pattern& neg_format_nat() const { return m_nat.m_neg_format; }
-    int frac_digits_int() const { return m_int.m_frac_digits; }
-    int frac_digits_nat() const { return m_nat.m_frac_digits; }
-    CharT decimal_point() const { return m_decimal_point; }
-    CharT thousands_sep() const { return m_thousands_sep; }
+    [[nodiscard]] const std::vector<uint8_t>& grouping() const { return m_grouping; }
+    [[nodiscard]] const std::basic_string<CharT>& curr_symbol_int() const { return m_int.m_curr_symbol; }
+    [[nodiscard]] const std::basic_string<CharT>& curr_symbol_nat() const { return m_nat.m_curr_symbol; }
+    [[nodiscard]] const std::basic_string<CharT>& positive_sign_int() const { return m_int.m_positive_sign; }
+    [[nodiscard]] const std::basic_string<CharT>& positive_sign_nat() const { return m_nat.m_positive_sign; }
+    [[nodiscard]] const std::basic_string<CharT>& negative_sign_int() const { return m_int.m_negative_sign; }
+    [[nodiscard]] const std::basic_string<CharT>& negative_sign_nat() const { return m_nat.m_negative_sign; }
+    [[nodiscard]] const base_ft<monetary>::pattern& pos_format_int() const { return m_int.m_pos_format; }
+    [[nodiscard]] const base_ft<monetary>::pattern& pos_format_nat() const { return m_nat.m_pos_format; }
+    [[nodiscard]] const base_ft<monetary>::pattern& neg_format_int() const { return m_int.m_neg_format; }
+    [[nodiscard]] const base_ft<monetary>::pattern& neg_format_nat() const { return m_nat.m_neg_format; }
+    [[nodiscard]] int frac_digits_int() const { return m_int.m_frac_digits; }
+    [[nodiscard]] int frac_digits_nat() const { return m_nat.m_frac_digits; }
+    [[nodiscard]] CharT decimal_point() const { return m_decimal_point; }
+    [[nodiscard]] CharT thousands_sep() const { return m_thousands_sep; }
 
     template <typename TIter, std::integral TVal>
         requires (!std::same_as<TVal, bool>)
     TIter put(TIter s, bool intl, ios_base<char_type>& io, TVal v) const
     {
         constexpr size_t buf_size = std::numeric_limits<TVal>::digits10 + 3;
-        char_type vec[buf_size];
+        std::array<char_type, buf_size> vec;
 
-        char_type* p = vec + buf_size;
+        char_type* p = vec.data() + buf_size;
         *--p = '\0';
 
         using TU = std::make_unsigned_t<TVal>;
@@ -109,7 +110,7 @@ public:
                           : static_cast<TU>(v);
         }
 
-        do {
+        do { // NOLINT(cppcoreguidelines-avoid-do-while)
             *--p = static_cast<char_type>('0' + (uv % 10));
             uv /= 10;
         } while (uv != 0);
@@ -195,7 +196,7 @@ private:
         const char_type* beg = digits.data();
 
         base_ft<monetary>::pattern p;
-        const std::basic_string<char_type>* sign_ptr;
+        const std::basic_string<char_type>* sign_ptr = nullptr;
         if (!(*beg == s_atoms[s_minus]))
         {
             p = info.m_pos_format;
@@ -276,21 +277,21 @@ private:
                 const part which = static_cast<part>(p[i]);
                 switch (which)
                 {
-                case base_ft<monetary>::symbol:
+                case part::symbol:
                     if (io.flags() & ios_defs::showbase)
                         res += info.m_curr_symbol;
                     break;
-                case base_ft<monetary>::sign:
+                case part::sign:
                     // Sign might not exist, or be more than one
                     // character long. In that case, add in the rest
                     // below.
                     if (!sign_ptr->empty())
                         res += (*sign_ptr)[0];
                     break;
-                case base_ft<monetary>::value:
+                case part::value:
                     res += value;
                     break;
-                case base_ft<monetary>::space:
+                case part::space:
                     // At least one space is required, but if internal
                     // formatting is required, an arbitrary number of
                     // fill spaces will be necessary.
@@ -299,7 +300,7 @@ private:
                     else
                         res += io.fill();
                     break;
-                case base_ft<monetary>::none:
+                case part::none:
                     if (testipad)
                         res.append(width - len, io.fill());
                     break;
@@ -355,7 +356,7 @@ private:
         // The tentative returned string is stored here.
         std::string res; res.reserve(32);
 
-        const char_type* lit_zero = s_atoms + s_zero;
+        const char_type* lit_zero = s_atoms.data() + s_zero;
         const base_ft<monetary>::pattern p = info.m_neg_format;
 
         for (int i = 0; i < 4 && testvalid; ++i)
@@ -363,7 +364,7 @@ private:
             const part which = static_cast<part>(p[i]);
             switch (which)
             {
-            case base_ft<monetary>::symbol:
+            case part::symbol:
                 // According to 22.2.6.1.2, p2, symbol is required
                 // if (io.flags() & ios_base::showbase), otherwise
                 // is optional and consumed only if other characters
@@ -372,14 +373,14 @@ private:
                     || i == 0
                     || (i == 1 && (mandatory_sign
                         || (static_cast<part>(p[0])
-                        == base_ft<monetary>::sign)
+                        == part::sign)
                         || (static_cast<part>(p[2])
-                        == base_ft<monetary>::space)))
+                        == part::space)))
                     || (i == 2 && ((static_cast<part>(p[3])
-                        == base_ft<monetary>::value)
+                        == part::value)
                         || (mandatory_sign
                         && (static_cast<part>(p[3])
-                            == base_ft<monetary>::sign)))))
+                            == part::sign)))))
                 {
                     const int len = info.m_curr_symbol.size();
                     int j = 0;
@@ -388,7 +389,7 @@ private:
                         testvalid = false;
                 }
                 break;
-            case base_ft<monetary>::sign:
+            case part::sign:
                 // Sign might not exist, or be more than one character long.
                 if (!info.m_positive_sign.empty() && beg != end && *beg == info.m_positive_sign[0])
                 {
@@ -408,7 +409,7 @@ private:
                 else if (mandatory_sign)
                     testvalid = false;
                 break;
-            case base_ft<monetary>::value:
+            case part::value:
                 // Extract digits, remove and stash away the
                 // grouping of found thousands separators.
                 for (; beg != end; ++beg)
@@ -435,7 +436,7 @@ private:
                         // longer than the largest representable group size,
                         // can never satisfy any grouping spec: reject outright
                         // rather than truncating the count.
-                        if (n == 0 || n > std::numeric_limits<uint8_t>::max())
+                        if (n == 0 || std::cmp_greater(n, std::numeric_limits<uint8_t>::max()))
                         {
                             testvalid = false;
                             break;
@@ -450,14 +451,14 @@ private:
                 if (res.empty())
                     testvalid = false;
                 break;
-            case base_ft<monetary>::space:
+            case part::space:
                 // At least one space is required.
                 if (beg != end && (*beg == io.fill()))
                     ++beg;
                 else
                     testvalid = false;
                 [[fallthrough]];
-            case base_ft<monetary>::none:
+            case part::none:
                 // Only if not at the end of the pattern.
                 if (i != 3)
                 for (; beg != end && (*beg == io.fill()); ++beg);
@@ -499,7 +500,7 @@ private:
                 // largest representable group size cannot satisfy any spec:
                 // fail rather than truncating.
                 const int last_group = testdecfound ? last_pos : n;
-                if (last_group > std::numeric_limits<uint8_t>::max())
+                if (std::cmp_greater(last_group, std::numeric_limits<uint8_t>::max()))
                     succ = false;
                 else
                 {
@@ -596,7 +597,7 @@ private:
     CharT                     m_decimal_point;
     CharT                     m_thousands_sep;
 
-    const inline static char_type s_atoms[11] = {
+    static constexpr std::array<char_type, 11> s_atoms = {
             (char_type)'-', (char_type)'0', (char_type)'1', (char_type)'2',
             (char_type)'3', (char_type)'4', (char_type)'5', (char_type)'6',
             (char_type)'7', (char_type)'8', (char_type)'9'

--- a/include/facet/monetary_details.h
+++ b/include/facet/monetary_details.h
@@ -25,13 +25,26 @@ class base_ft<monetary> : public abs_ft
 public:
     using abs_ft::abs_ft;
 
-    enum part { none, space, symbol, sign, value };
+    enum class part : std::uint8_t { none, space, symbol, sign, value };
     using pattern = std::array<part, 4>;
 
-protected:
-    inline const static pattern s_default_pattern = {symbol, sign, none, value};
-    static pattern s_construct_pattern(int8_t precedes, int8_t sp, int8_t posn)
+    // Groups the three POSIX lconv flags that drive s_construct_pattern into one
+    // named argument. They are all small integers and trivially swapped if passed
+    // positionally (bugprone-easily-swappable-parameters); naming the fields here
+    // makes each call site self-documenting and the swap impossible.
+    struct pattern_spec
     {
+        int8_t precedes;      // *_cs_precedes:  symbol precedes (1) or follows (0) the value
+        int8_t sep_by_space;  // *_sep_by_space: a space separates symbol and value
+        int    sign_posn;     // *_sign_posn:    sign placement (0..4)
+    };
+
+protected:
+    inline const static pattern s_default_pattern = {part::symbol, part::sign, part::none, part::value};
+    static pattern s_construct_pattern(pattern_spec spec)
+    {
+        using enum part;
+        const auto [precedes, sp, posn] = spec;
         pattern ret;
 
         // This insanely complicated routine attempts to construct a valid
@@ -269,10 +282,10 @@ public:
             m_curr_symbol_nat = lc->currency_symbol;
             m_curr_symbol_int = lc->int_curr_symbol;
 
-            m_pos_format_nat = s_construct_pattern(s_norm_flag(lc->p_cs_precedes), s_norm_flag(lc->p_sep_by_space), lc->p_sign_posn);
-            m_neg_format_nat = s_construct_pattern(s_norm_flag(lc->n_cs_precedes), s_norm_flag(lc->n_sep_by_space), lc->n_sign_posn);
-            m_pos_format_int = s_construct_pattern(s_norm_flag(lc->int_p_cs_precedes), s_norm_flag(lc->int_p_sep_by_space), lc->int_p_sign_posn);
-            m_neg_format_int = s_construct_pattern(s_norm_flag(lc->int_n_cs_precedes), s_norm_flag(lc->int_n_sep_by_space), lc->int_n_sign_posn);
+            m_pos_format_nat = s_construct_pattern({.precedes = s_norm_flag(lc->p_cs_precedes), .sep_by_space = s_norm_flag(lc->p_sep_by_space), .sign_posn = lc->p_sign_posn});
+            m_neg_format_nat = s_construct_pattern({.precedes = s_norm_flag(lc->n_cs_precedes), .sep_by_space = s_norm_flag(lc->n_sep_by_space), .sign_posn = lc->n_sign_posn});
+            m_pos_format_int = s_construct_pattern({.precedes = s_norm_flag(lc->int_p_cs_precedes), .sep_by_space = s_norm_flag(lc->int_p_sep_by_space), .sign_posn = lc->int_p_sign_posn});
+            m_neg_format_int = s_construct_pattern({.precedes = s_norm_flag(lc->int_n_cs_precedes), .sep_by_space = s_norm_flag(lc->int_n_sep_by_space), .sign_posn = lc->int_n_sign_posn});
 
             std::string mdp_raw, mts_raw;
             if (lc->mon_decimal_point) mdp_raw = lc->mon_decimal_point;
@@ -327,21 +340,21 @@ public:
     }
 
 public:
-    virtual const std::vector<uint8_t>& grouping() const { return m_grouping; }
-    virtual const std::string& curr_symbol_int() const { return m_curr_symbol_int; }
-    virtual const std::string& curr_symbol_nat() const { return m_curr_symbol_nat; }
-    virtual const std::string& positive_sign_int() const { return m_positive_sign_int; }
-    virtual const std::string& positive_sign_nat() const { return m_positive_sign_nat; }
-    virtual const std::string& negative_sign_int() const { return m_negative_sign_int; }
-    virtual const std::string& negative_sign_nat() const { return m_negative_sign_nat; }
-    virtual const pattern& pos_format_int() const { return m_pos_format_int; }
-    virtual const pattern& pos_format_nat() const { return m_pos_format_nat; }
-    virtual const pattern& neg_format_int() const { return m_neg_format_int; }
-    virtual const pattern& neg_format_nat() const { return m_neg_format_nat; }
-    virtual int frac_digits_int() const { return m_frac_digits_int; }
-    virtual int frac_digits_nat() const { return m_frac_digits_nat; }
-    virtual char decimal_point() const { return m_decimal_point; }
-    virtual char thousands_sep() const { return m_thousands_sep; }
+    [[nodiscard]] virtual const std::vector<uint8_t>& grouping() const { return m_grouping; }
+    [[nodiscard]] virtual const std::string& curr_symbol_int() const { return m_curr_symbol_int; }
+    [[nodiscard]] virtual const std::string& curr_symbol_nat() const { return m_curr_symbol_nat; }
+    [[nodiscard]] virtual const std::string& positive_sign_int() const { return m_positive_sign_int; }
+    [[nodiscard]] virtual const std::string& positive_sign_nat() const { return m_positive_sign_nat; }
+    [[nodiscard]] virtual const std::string& negative_sign_int() const { return m_negative_sign_int; }
+    [[nodiscard]] virtual const std::string& negative_sign_nat() const { return m_negative_sign_nat; }
+    [[nodiscard]] virtual const pattern& pos_format_int() const { return m_pos_format_int; }
+    [[nodiscard]] virtual const pattern& pos_format_nat() const { return m_pos_format_nat; }
+    [[nodiscard]] virtual const pattern& neg_format_int() const { return m_neg_format_int; }
+    [[nodiscard]] virtual const pattern& neg_format_nat() const { return m_neg_format_nat; }
+    [[nodiscard]] virtual int frac_digits_int() const { return m_frac_digits_int; }
+    [[nodiscard]] virtual int frac_digits_nat() const { return m_frac_digits_nat; }
+    [[nodiscard]] virtual char decimal_point() const { return m_decimal_point; }
+    [[nodiscard]] virtual char thousands_sep() const { return m_thousands_sep; }
 
 private:
     std::vector<uint8_t>    m_grouping;
@@ -351,10 +364,10 @@ private:
     std::string             m_positive_sign_nat;
     std::string             m_negative_sign_int;
     std::string             m_negative_sign_nat;
-    pattern                 m_pos_format_int;
-    pattern                 m_pos_format_nat;
-    pattern                 m_neg_format_int;
-    pattern                 m_neg_format_nat;
+    pattern                 m_pos_format_int{};
+    pattern                 m_pos_format_nat{};
+    pattern                 m_neg_format_int{};
+    pattern                 m_neg_format_nat{};
     int                     m_frac_digits_int;
     int                     m_frac_digits_nat;
     char                    m_decimal_point;
@@ -440,10 +453,10 @@ public:
                     grouping_raw[i] = static_cast<uint8_t>(lc->mon_grouping[i]);
             }
 
-            m_pos_format_nat = base_ft<monetary>::s_construct_pattern(base_ft<monetary>::s_norm_flag(lc->p_cs_precedes), base_ft<monetary>::s_norm_flag(lc->p_sep_by_space), lc->p_sign_posn);
-            m_neg_format_nat = base_ft<monetary>::s_construct_pattern(base_ft<monetary>::s_norm_flag(lc->n_cs_precedes), base_ft<monetary>::s_norm_flag(lc->n_sep_by_space), lc->n_sign_posn);
-            m_pos_format_int = base_ft<monetary>::s_construct_pattern(base_ft<monetary>::s_norm_flag(lc->int_p_cs_precedes), base_ft<monetary>::s_norm_flag(lc->int_p_sep_by_space), lc->int_p_sign_posn);
-            m_neg_format_int = base_ft<monetary>::s_construct_pattern(base_ft<monetary>::s_norm_flag(lc->int_n_cs_precedes), base_ft<monetary>::s_norm_flag(lc->int_n_sep_by_space), lc->int_n_sign_posn);
+            m_pos_format_nat = base_ft<monetary>::s_construct_pattern({.precedes = base_ft<monetary>::s_norm_flag(lc->p_cs_precedes), .sep_by_space = base_ft<monetary>::s_norm_flag(lc->p_sep_by_space), .sign_posn = lc->p_sign_posn});
+            m_neg_format_nat = base_ft<monetary>::s_construct_pattern({.precedes = base_ft<monetary>::s_norm_flag(lc->n_cs_precedes), .sep_by_space = base_ft<monetary>::s_norm_flag(lc->n_sep_by_space), .sign_posn = lc->n_sign_posn});
+            m_pos_format_int = base_ft<monetary>::s_construct_pattern({.precedes = base_ft<monetary>::s_norm_flag(lc->int_p_cs_precedes), .sep_by_space = base_ft<monetary>::s_norm_flag(lc->int_p_sep_by_space), .sign_posn = lc->int_p_sign_posn});
+            m_neg_format_int = base_ft<monetary>::s_construct_pattern({.precedes = base_ft<monetary>::s_norm_flag(lc->int_n_cs_precedes), .sep_by_space = base_ft<monetary>::s_norm_flag(lc->int_n_sep_by_space), .sign_posn = lc->int_n_sign_posn});
 
             // No lc-> access beyond this point: the conversions may
             // invalidate the lconv pointers.
@@ -538,21 +551,21 @@ public:
     }
 
 public:
-    virtual const std::vector<uint8_t>& grouping() const { return m_grouping; }
-    virtual const std::basic_string<CharT>& curr_symbol_int() const { return m_curr_symbol_int; }
-    virtual const std::basic_string<CharT>& curr_symbol_nat() const { return m_curr_symbol_nat; }
-    virtual const std::basic_string<CharT>& positive_sign_int() const { return m_positive_sign_int; }
-    virtual const std::basic_string<CharT>& positive_sign_nat() const { return m_positive_sign_nat; }
-    virtual const std::basic_string<CharT>& negative_sign_int() const { return m_negative_sign_int; }
-    virtual const std::basic_string<CharT>& negative_sign_nat() const { return m_negative_sign_nat; }
-    virtual const base_ft<monetary>::pattern& pos_format_int() const { return m_pos_format_int; }
-    virtual const base_ft<monetary>::pattern& pos_format_nat() const { return m_pos_format_nat; }
-    virtual const base_ft<monetary>::pattern& neg_format_int() const { return m_neg_format_int; }
-    virtual const base_ft<monetary>::pattern& neg_format_nat() const { return m_neg_format_nat; }
-    virtual int frac_digits_int() const { return m_frac_digits_int; }
-    virtual int frac_digits_nat() const { return m_frac_digits_nat; }
-    virtual CharT decimal_point() const { return m_decimal_point; }
-    virtual CharT thousands_sep() const { return m_thousands_sep; }
+    [[nodiscard]] virtual const std::vector<uint8_t>& grouping() const { return m_grouping; }
+    [[nodiscard]] virtual const std::basic_string<CharT>& curr_symbol_int() const { return m_curr_symbol_int; }
+    [[nodiscard]] virtual const std::basic_string<CharT>& curr_symbol_nat() const { return m_curr_symbol_nat; }
+    [[nodiscard]] virtual const std::basic_string<CharT>& positive_sign_int() const { return m_positive_sign_int; }
+    [[nodiscard]] virtual const std::basic_string<CharT>& positive_sign_nat() const { return m_positive_sign_nat; }
+    [[nodiscard]] virtual const std::basic_string<CharT>& negative_sign_int() const { return m_negative_sign_int; }
+    [[nodiscard]] virtual const std::basic_string<CharT>& negative_sign_nat() const { return m_negative_sign_nat; }
+    [[nodiscard]] virtual const base_ft<monetary>::pattern& pos_format_int() const { return m_pos_format_int; }
+    [[nodiscard]] virtual const base_ft<monetary>::pattern& pos_format_nat() const { return m_pos_format_nat; }
+    [[nodiscard]] virtual const base_ft<monetary>::pattern& neg_format_int() const { return m_neg_format_int; }
+    [[nodiscard]] virtual const base_ft<monetary>::pattern& neg_format_nat() const { return m_neg_format_nat; }
+    [[nodiscard]] virtual int frac_digits_int() const { return m_frac_digits_int; }
+    [[nodiscard]] virtual int frac_digits_nat() const { return m_frac_digits_nat; }
+    [[nodiscard]] virtual CharT decimal_point() const { return m_decimal_point; }
+    [[nodiscard]] virtual CharT thousands_sep() const { return m_thousands_sep; }
 
 private:
     std::vector<uint8_t>        m_grouping;
@@ -562,10 +575,10 @@ private:
     std::basic_string<CharT>    m_positive_sign_nat;
     std::basic_string<CharT>    m_negative_sign_int;
     std::basic_string<CharT>    m_negative_sign_nat;
-    base_ft<monetary>::pattern      m_pos_format_int;
-    base_ft<monetary>::pattern      m_pos_format_nat;
-    base_ft<monetary>::pattern      m_neg_format_int;
-    base_ft<monetary>::pattern      m_neg_format_nat;
+    base_ft<monetary>::pattern      m_pos_format_int{};
+    base_ft<monetary>::pattern      m_pos_format_nat{};
+    base_ft<monetary>::pattern      m_neg_format_int{};
+    base_ft<monetary>::pattern      m_neg_format_nat{};
     int                         m_frac_digits_int;
     int                         m_frac_digits_nat;
     CharT                       m_decimal_point;
@@ -688,21 +701,21 @@ private:
     }
 
 public:
-    virtual const std::vector<uint8_t>& grouping() const { return m_grouping; }
-    virtual const std::basic_string<char8_t>& curr_symbol_int() const { return m_curr_symbol_int; }
-    virtual const std::basic_string<char8_t>& curr_symbol_nat() const { return m_curr_symbol_nat; }
-    virtual const std::basic_string<char8_t>& positive_sign_int() const { return m_positive_sign_int; }
-    virtual const std::basic_string<char8_t>& positive_sign_nat() const { return m_positive_sign_nat; }
-    virtual const std::basic_string<char8_t>& negative_sign_int() const { return m_negative_sign_int; }
-    virtual const std::basic_string<char8_t>& negative_sign_nat() const { return m_negative_sign_nat; }
-    virtual const base_ft<monetary>::pattern& pos_format_int() const { return m_pos_format_int; }
-    virtual const base_ft<monetary>::pattern& pos_format_nat() const { return m_pos_format_nat; }
-    virtual const base_ft<monetary>::pattern& neg_format_int() const { return m_neg_format_int; }
-    virtual const base_ft<monetary>::pattern& neg_format_nat() const { return m_neg_format_nat; }
-    virtual int frac_digits_int() const { return m_frac_digits_int; }
-    virtual int frac_digits_nat() const { return m_frac_digits_nat; }
-    virtual char8_t decimal_point() const { return m_decimal_point; }
-    virtual char8_t thousands_sep() const { return m_thousands_sep; }
+    [[nodiscard]] virtual const std::vector<uint8_t>& grouping() const { return m_grouping; }
+    [[nodiscard]] virtual const std::basic_string<char8_t>& curr_symbol_int() const { return m_curr_symbol_int; }
+    [[nodiscard]] virtual const std::basic_string<char8_t>& curr_symbol_nat() const { return m_curr_symbol_nat; }
+    [[nodiscard]] virtual const std::basic_string<char8_t>& positive_sign_int() const { return m_positive_sign_int; }
+    [[nodiscard]] virtual const std::basic_string<char8_t>& positive_sign_nat() const { return m_positive_sign_nat; }
+    [[nodiscard]] virtual const std::basic_string<char8_t>& negative_sign_int() const { return m_negative_sign_int; }
+    [[nodiscard]] virtual const std::basic_string<char8_t>& negative_sign_nat() const { return m_negative_sign_nat; }
+    [[nodiscard]] virtual const base_ft<monetary>::pattern& pos_format_int() const { return m_pos_format_int; }
+    [[nodiscard]] virtual const base_ft<monetary>::pattern& pos_format_nat() const { return m_pos_format_nat; }
+    [[nodiscard]] virtual const base_ft<monetary>::pattern& neg_format_int() const { return m_neg_format_int; }
+    [[nodiscard]] virtual const base_ft<monetary>::pattern& neg_format_nat() const { return m_neg_format_nat; }
+    [[nodiscard]] virtual int frac_digits_int() const { return m_frac_digits_int; }
+    [[nodiscard]] virtual int frac_digits_nat() const { return m_frac_digits_nat; }
+    [[nodiscard]] virtual char8_t decimal_point() const { return m_decimal_point; }
+    [[nodiscard]] virtual char8_t thousands_sep() const { return m_thousands_sep; }
 
 private:
     std::vector<uint8_t>        m_grouping;
@@ -712,10 +725,10 @@ private:
     std::basic_string<char8_t>  m_positive_sign_nat;
     std::basic_string<char8_t>  m_negative_sign_int;
     std::basic_string<char8_t>  m_negative_sign_nat;
-    base_ft<monetary>::pattern      m_pos_format_int;
-    base_ft<monetary>::pattern      m_pos_format_nat;
-    base_ft<monetary>::pattern      m_neg_format_int;
-    base_ft<monetary>::pattern      m_neg_format_nat;
+    base_ft<monetary>::pattern      m_pos_format_int{};
+    base_ft<monetary>::pattern      m_pos_format_nat{};
+    base_ft<monetary>::pattern      m_neg_format_int{};
+    base_ft<monetary>::pattern      m_neg_format_nat{};
     int                         m_frac_digits_int;
     int                         m_frac_digits_nat;
     char8_t                     m_decimal_point;

--- a/test/facet/monetary/test_monetary_char.cpp
+++ b/test/facet/monetary/test_monetary_char.cpp
@@ -262,10 +262,10 @@ void test_monetary_char_put_4()
     tmp_io->set_grouping({3});
     tmp_io->set_negative_sign_nat("()");
     tmp_io->set_frac_digits_nat(2);
-    tmp_io->set_neg_format_nat({IOv2::base_ft<IOv2::monetary>::symbol,
-                                IOv2::base_ft<IOv2::monetary>::space,
-                                IOv2::base_ft<IOv2::monetary>::sign,
-                                IOv2::base_ft<IOv2::monetary>::value});
+    tmp_io->set_neg_format_nat({IOv2::base_ft<IOv2::monetary>::part::symbol,
+                                IOv2::base_ft<IOv2::monetary>::part::space,
+                                IOv2::base_ft<IOv2::monetary>::part::sign,
+                                IOv2::base_ft<IOv2::monetary>::part::value});
 
     IOv2::monetary<char> obj(tmp_io);
     IOv2::ios_base<char> ios;
@@ -632,10 +632,10 @@ void test_monetary_char_get_6()
     tmp_io->set_positive_sign_nat("");
     tmp_io->set_negative_sign_nat("-");
     tmp_io->set_frac_digits_nat(2);
-    tmp_io->set_neg_format_nat({IOv2::base_ft<IOv2::monetary>::symbol,
-                                IOv2::base_ft<IOv2::monetary>::none,
-                                IOv2::base_ft<IOv2::monetary>::sign,
-                                IOv2::base_ft<IOv2::monetary>::value});
+    tmp_io->set_neg_format_nat({IOv2::base_ft<IOv2::monetary>::part::symbol,
+                                IOv2::base_ft<IOv2::monetary>::part::none,
+                                IOv2::base_ft<IOv2::monetary>::part::sign,
+                                IOv2::base_ft<IOv2::monetary>::part::value});
 
     IOv2::monetary<char> obj(tmp_io);
     
@@ -721,10 +721,10 @@ void test_monetary_char_get_8()
     tmp_io_a->set_curr_symbol_nat("$");
     tmp_io_a->set_positive_sign_nat("()");
     tmp_io_a->set_frac_digits_nat(2);
-    tmp_io_a->set_neg_format_nat({IOv2::base_ft<IOv2::monetary>::sign,
-                                  IOv2::base_ft<IOv2::monetary>::value,
-                                  IOv2::base_ft<IOv2::monetary>::space,
-                                  IOv2::base_ft<IOv2::monetary>::symbol});
+    tmp_io_a->set_neg_format_nat({IOv2::base_ft<IOv2::monetary>::part::sign,
+                                  IOv2::base_ft<IOv2::monetary>::part::value,
+                                  IOv2::base_ft<IOv2::monetary>::part::space,
+                                  IOv2::base_ft<IOv2::monetary>::part::symbol});
 
     auto tmp_io_b = std::make_shared<MoneyIO>("C");
     tmp_io_b->set_decimal_point('.');
@@ -732,10 +732,10 @@ void test_monetary_char_get_8()
     tmp_io_b->set_curr_symbol_nat("$");
     tmp_io_b->set_positive_sign_nat("()");
     tmp_io_b->set_frac_digits_nat(2);
-    tmp_io_b->set_neg_format_nat({IOv2::base_ft<IOv2::monetary>::sign,
-                                  IOv2::base_ft<IOv2::monetary>::value,
-                                  IOv2::base_ft<IOv2::monetary>::symbol,
-                                  IOv2::base_ft<IOv2::monetary>::none});
+    tmp_io_b->set_neg_format_nat({IOv2::base_ft<IOv2::monetary>::part::sign,
+                                  IOv2::base_ft<IOv2::monetary>::part::value,
+                                  IOv2::base_ft<IOv2::monetary>::part::symbol,
+                                  IOv2::base_ft<IOv2::monetary>::part::none});
                                 
     IOv2::monetary<char> obj_a(tmp_io_a);
     IOv2::monetary<char> obj_b(tmp_io_b);
@@ -1154,28 +1154,28 @@ void test_monetary_char_get_19()
     tmp_io_a->set_curr_symbol_nat("$");
     tmp_io_a->set_positive_sign_nat("");
     tmp_io_a->set_negative_sign_nat("");
-    tmp_io_a->set_neg_format_nat({IOv2::base_ft<IOv2::monetary>::value,
-                                  IOv2::base_ft<IOv2::monetary>::symbol,
-                                  IOv2::base_ft<IOv2::monetary>::none,
-                                  IOv2::base_ft<IOv2::monetary>::sign});
+    tmp_io_a->set_neg_format_nat({IOv2::base_ft<IOv2::monetary>::part::value,
+                                  IOv2::base_ft<IOv2::monetary>::part::symbol,
+                                  IOv2::base_ft<IOv2::monetary>::part::none,
+                                  IOv2::base_ft<IOv2::monetary>::part::sign});
 
     auto tmp_io_b = std::make_shared<MoneyIO>("C");
     tmp_io_b->set_curr_symbol_nat("%");
     tmp_io_b->set_positive_sign_nat("");
     tmp_io_b->set_negative_sign_nat("-");
-    tmp_io_b->set_neg_format_nat({IOv2::base_ft<IOv2::monetary>::value,
-                                  IOv2::base_ft<IOv2::monetary>::symbol,
-                                  IOv2::base_ft<IOv2::monetary>::sign,
-                                  IOv2::base_ft<IOv2::monetary>::none});
+    tmp_io_b->set_neg_format_nat({IOv2::base_ft<IOv2::monetary>::part::value,
+                                  IOv2::base_ft<IOv2::monetary>::part::symbol,
+                                  IOv2::base_ft<IOv2::monetary>::part::sign,
+                                  IOv2::base_ft<IOv2::monetary>::part::none});
 
     auto tmp_io_c = std::make_shared<MoneyIO>("C");
     tmp_io_c->set_curr_symbol_nat("&");
     tmp_io_c->set_positive_sign_nat("");
     tmp_io_c->set_negative_sign_nat("");
-    tmp_io_c->set_neg_format_nat({IOv2::base_ft<IOv2::monetary>::value,
-                                  IOv2::base_ft<IOv2::monetary>::space,
-                                  IOv2::base_ft<IOv2::monetary>::symbol,
-                                  IOv2::base_ft<IOv2::monetary>::sign});
+    tmp_io_c->set_neg_format_nat({IOv2::base_ft<IOv2::monetary>::part::value,
+                                  IOv2::base_ft<IOv2::monetary>::part::space,
+                                  IOv2::base_ft<IOv2::monetary>::part::symbol,
+                                  IOv2::base_ft<IOv2::monetary>::part::sign});
                                 
     IOv2::monetary<char> obj_a(tmp_io_a);
     IOv2::monetary<char> obj_b(tmp_io_b);
@@ -1236,10 +1236,10 @@ void test_monetary_char_get_21()
     auto tmp_io = std::make_shared<MoneyIO>("C");
     tmp_io->set_grouping({1});
     tmp_io->set_thousands_sep('#');
-    tmp_io->set_neg_format_nat({IOv2::base_ft<IOv2::monetary>::symbol,
-                                IOv2::base_ft<IOv2::monetary>::none,
-                                IOv2::base_ft<IOv2::monetary>::sign,
-                                IOv2::base_ft<IOv2::monetary>::value});
+    tmp_io->set_neg_format_nat({IOv2::base_ft<IOv2::monetary>::part::symbol,
+                                IOv2::base_ft<IOv2::monetary>::part::none,
+                                IOv2::base_ft<IOv2::monetary>::part::sign,
+                                IOv2::base_ft<IOv2::monetary>::part::value});
                                   
     IOv2::monetary<char> obj(tmp_io);
     std::string buffer1("00#0#1");
@@ -1625,10 +1625,10 @@ void test_monetary_char_get_29()
     tmp_io->set_positive_sign_nat("");
     tmp_io->set_negative_sign_nat("-");
     tmp_io->set_frac_digits_nat(2);
-    tmp_io->set_neg_format_nat({IOv2::base_ft<IOv2::monetary>::symbol,
-                                IOv2::base_ft<IOv2::monetary>::none,
-                                IOv2::base_ft<IOv2::monetary>::sign,
-                                IOv2::base_ft<IOv2::monetary>::value});
+    tmp_io->set_neg_format_nat({IOv2::base_ft<IOv2::monetary>::part::symbol,
+                                IOv2::base_ft<IOv2::monetary>::part::none,
+                                IOv2::base_ft<IOv2::monetary>::part::sign,
+                                IOv2::base_ft<IOv2::monetary>::part::value});
 
     IOv2::monetary<char> obj(tmp_io);
     
@@ -1730,10 +1730,10 @@ void test_monetary_char_get_31()
     tmp_io_a->set_curr_symbol_nat("$");
     tmp_io_a->set_positive_sign_nat("()");
     tmp_io_a->set_frac_digits_nat(2);
-    tmp_io_a->set_neg_format_nat({IOv2::base_ft<IOv2::monetary>::sign,
-                                  IOv2::base_ft<IOv2::monetary>::value,
-                                  IOv2::base_ft<IOv2::monetary>::space,
-                                  IOv2::base_ft<IOv2::monetary>::symbol});
+    tmp_io_a->set_neg_format_nat({IOv2::base_ft<IOv2::monetary>::part::sign,
+                                  IOv2::base_ft<IOv2::monetary>::part::value,
+                                  IOv2::base_ft<IOv2::monetary>::part::space,
+                                  IOv2::base_ft<IOv2::monetary>::part::symbol});
 
     auto tmp_io_b = std::make_shared<MoneyIO>("C");
     tmp_io_b->set_decimal_point('.');
@@ -1741,10 +1741,10 @@ void test_monetary_char_get_31()
     tmp_io_b->set_curr_symbol_nat("$");
     tmp_io_b->set_positive_sign_nat("()");
     tmp_io_b->set_frac_digits_nat(2);
-    tmp_io_b->set_neg_format_nat({IOv2::base_ft<IOv2::monetary>::sign,
-                                  IOv2::base_ft<IOv2::monetary>::value,
-                                  IOv2::base_ft<IOv2::monetary>::symbol,
-                                  IOv2::base_ft<IOv2::monetary>::none});
+    tmp_io_b->set_neg_format_nat({IOv2::base_ft<IOv2::monetary>::part::sign,
+                                  IOv2::base_ft<IOv2::monetary>::part::value,
+                                  IOv2::base_ft<IOv2::monetary>::part::symbol,
+                                  IOv2::base_ft<IOv2::monetary>::part::none});
                                 
     IOv2::monetary<char> obj_a(tmp_io_a);
     IOv2::monetary<char> obj_b(tmp_io_b);
@@ -2216,28 +2216,28 @@ void test_monetary_char_get_42()
     tmp_io_a->set_curr_symbol_nat("$");
     tmp_io_a->set_positive_sign_nat("");
     tmp_io_a->set_negative_sign_nat("");
-    tmp_io_a->set_neg_format_nat({IOv2::base_ft<IOv2::monetary>::value,
-                                  IOv2::base_ft<IOv2::monetary>::symbol,
-                                  IOv2::base_ft<IOv2::monetary>::none,
-                                  IOv2::base_ft<IOv2::monetary>::sign});
+    tmp_io_a->set_neg_format_nat({IOv2::base_ft<IOv2::monetary>::part::value,
+                                  IOv2::base_ft<IOv2::monetary>::part::symbol,
+                                  IOv2::base_ft<IOv2::monetary>::part::none,
+                                  IOv2::base_ft<IOv2::monetary>::part::sign});
 
     auto tmp_io_b = std::make_shared<MoneyIO>("C");
     tmp_io_b->set_curr_symbol_nat("%");
     tmp_io_b->set_positive_sign_nat("");
     tmp_io_b->set_negative_sign_nat("-");
-    tmp_io_b->set_neg_format_nat({IOv2::base_ft<IOv2::monetary>::value,
-                                  IOv2::base_ft<IOv2::monetary>::symbol,
-                                  IOv2::base_ft<IOv2::monetary>::sign,
-                                  IOv2::base_ft<IOv2::monetary>::none});
+    tmp_io_b->set_neg_format_nat({IOv2::base_ft<IOv2::monetary>::part::value,
+                                  IOv2::base_ft<IOv2::monetary>::part::symbol,
+                                  IOv2::base_ft<IOv2::monetary>::part::sign,
+                                  IOv2::base_ft<IOv2::monetary>::part::none});
 
     auto tmp_io_c = std::make_shared<MoneyIO>("C");
     tmp_io_c->set_curr_symbol_nat("&");
     tmp_io_c->set_positive_sign_nat("");
     tmp_io_c->set_negative_sign_nat("");
-    tmp_io_c->set_neg_format_nat({IOv2::base_ft<IOv2::monetary>::value,
-                                  IOv2::base_ft<IOv2::monetary>::space,
-                                  IOv2::base_ft<IOv2::monetary>::symbol,
-                                  IOv2::base_ft<IOv2::monetary>::sign});
+    tmp_io_c->set_neg_format_nat({IOv2::base_ft<IOv2::monetary>::part::value,
+                                  IOv2::base_ft<IOv2::monetary>::part::space,
+                                  IOv2::base_ft<IOv2::monetary>::part::symbol,
+                                  IOv2::base_ft<IOv2::monetary>::part::sign});
                                 
     IOv2::monetary<char> obj_a(tmp_io_a);
     IOv2::monetary<char> obj_b(tmp_io_b);
@@ -2304,10 +2304,10 @@ void test_monetary_char_get_44()
     auto tmp_io = std::make_shared<MoneyIO>("C");
     tmp_io->set_grouping({1});
     tmp_io->set_thousands_sep('#');
-    tmp_io->set_neg_format_nat({IOv2::base_ft<IOv2::monetary>::symbol,
-                                IOv2::base_ft<IOv2::monetary>::none,
-                                IOv2::base_ft<IOv2::monetary>::sign,
-                                IOv2::base_ft<IOv2::monetary>::value});
+    tmp_io->set_neg_format_nat({IOv2::base_ft<IOv2::monetary>::part::symbol,
+                                IOv2::base_ft<IOv2::monetary>::part::none,
+                                IOv2::base_ft<IOv2::monetary>::part::sign,
+                                IOv2::base_ft<IOv2::monetary>::part::value});
                                   
     IOv2::monetary<char> obj(tmp_io);
     // Strong exception guarantee: a failed parse must leave the caller's

--- a/test/facet/monetary/test_monetary_char32_t.cpp
+++ b/test/facet/monetary/test_monetary_char32_t.cpp
@@ -261,10 +261,10 @@ void test_monetary_char32_t_put_4()
     tmp_io->set_grouping({3});
     tmp_io->set_negative_sign_nat(U"()");
     tmp_io->set_frac_digits_nat(2);
-    tmp_io->set_neg_format_nat({IOv2::base_ft<IOv2::monetary>::symbol,
-                                IOv2::base_ft<IOv2::monetary>::space,
-                                IOv2::base_ft<IOv2::monetary>::sign,
-                                IOv2::base_ft<IOv2::monetary>::value});
+    tmp_io->set_neg_format_nat({IOv2::base_ft<IOv2::monetary>::part::symbol,
+                                IOv2::base_ft<IOv2::monetary>::part::space,
+                                IOv2::base_ft<IOv2::monetary>::part::sign,
+                                IOv2::base_ft<IOv2::monetary>::part::value});
 
     IOv2::monetary<char32_t> obj(tmp_io);
     IOv2::ios_base<char32_t> ios;
@@ -631,10 +631,10 @@ void test_monetary_char32_t_get_6()
     tmp_io->set_positive_sign_nat(U"");
     tmp_io->set_negative_sign_nat(U"-");
     tmp_io->set_frac_digits_nat(2);
-    tmp_io->set_neg_format_nat({IOv2::base_ft<IOv2::monetary>::symbol,
-                                IOv2::base_ft<IOv2::monetary>::none,
-                                IOv2::base_ft<IOv2::monetary>::sign,
-                                IOv2::base_ft<IOv2::monetary>::value});
+    tmp_io->set_neg_format_nat({IOv2::base_ft<IOv2::monetary>::part::symbol,
+                                IOv2::base_ft<IOv2::monetary>::part::none,
+                                IOv2::base_ft<IOv2::monetary>::part::sign,
+                                IOv2::base_ft<IOv2::monetary>::part::value});
 
     IOv2::monetary<char32_t> obj(tmp_io);
     
@@ -720,10 +720,10 @@ void test_monetary_char32_t_get_8()
     tmp_io_a->set_curr_symbol_nat(U"$");
     tmp_io_a->set_positive_sign_nat(U"()");
     tmp_io_a->set_frac_digits_nat(2);
-    tmp_io_a->set_neg_format_nat({IOv2::base_ft<IOv2::monetary>::sign,
-                                  IOv2::base_ft<IOv2::monetary>::value,
-                                  IOv2::base_ft<IOv2::monetary>::space,
-                                  IOv2::base_ft<IOv2::monetary>::symbol});
+    tmp_io_a->set_neg_format_nat({IOv2::base_ft<IOv2::monetary>::part::sign,
+                                  IOv2::base_ft<IOv2::monetary>::part::value,
+                                  IOv2::base_ft<IOv2::monetary>::part::space,
+                                  IOv2::base_ft<IOv2::monetary>::part::symbol});
 
     auto tmp_io_b = std::make_shared<MoneyIO>("C");
     tmp_io_b->set_decimal_point(L'.');
@@ -731,10 +731,10 @@ void test_monetary_char32_t_get_8()
     tmp_io_b->set_curr_symbol_nat(U"$");
     tmp_io_b->set_positive_sign_nat(U"()");
     tmp_io_b->set_frac_digits_nat(2);
-    tmp_io_b->set_neg_format_nat({IOv2::base_ft<IOv2::monetary>::sign,
-                                  IOv2::base_ft<IOv2::monetary>::value,
-                                  IOv2::base_ft<IOv2::monetary>::symbol,
-                                  IOv2::base_ft<IOv2::monetary>::none});
+    tmp_io_b->set_neg_format_nat({IOv2::base_ft<IOv2::monetary>::part::sign,
+                                  IOv2::base_ft<IOv2::monetary>::part::value,
+                                  IOv2::base_ft<IOv2::monetary>::part::symbol,
+                                  IOv2::base_ft<IOv2::monetary>::part::none});
                                 
     IOv2::monetary<char32_t> obj_a(tmp_io_a);
     IOv2::monetary<char32_t> obj_b(tmp_io_b);
@@ -1153,28 +1153,28 @@ void test_monetary_char32_t_get_19()
     tmp_io_a->set_curr_symbol_nat(U"$");
     tmp_io_a->set_positive_sign_nat(U"");
     tmp_io_a->set_negative_sign_nat(U"");
-    tmp_io_a->set_neg_format_nat({IOv2::base_ft<IOv2::monetary>::value,
-                                  IOv2::base_ft<IOv2::monetary>::symbol,
-                                  IOv2::base_ft<IOv2::monetary>::none,
-                                  IOv2::base_ft<IOv2::monetary>::sign});
+    tmp_io_a->set_neg_format_nat({IOv2::base_ft<IOv2::monetary>::part::value,
+                                  IOv2::base_ft<IOv2::monetary>::part::symbol,
+                                  IOv2::base_ft<IOv2::monetary>::part::none,
+                                  IOv2::base_ft<IOv2::monetary>::part::sign});
 
     auto tmp_io_b = std::make_shared<MoneyIO>("C");
     tmp_io_b->set_curr_symbol_nat(U"%");
     tmp_io_b->set_positive_sign_nat(U"");
     tmp_io_b->set_negative_sign_nat(U"-");
-    tmp_io_b->set_neg_format_nat({IOv2::base_ft<IOv2::monetary>::value,
-                                  IOv2::base_ft<IOv2::monetary>::symbol,
-                                  IOv2::base_ft<IOv2::monetary>::sign,
-                                  IOv2::base_ft<IOv2::monetary>::none});
+    tmp_io_b->set_neg_format_nat({IOv2::base_ft<IOv2::monetary>::part::value,
+                                  IOv2::base_ft<IOv2::monetary>::part::symbol,
+                                  IOv2::base_ft<IOv2::monetary>::part::sign,
+                                  IOv2::base_ft<IOv2::monetary>::part::none});
 
     auto tmp_io_c = std::make_shared<MoneyIO>("C");
     tmp_io_c->set_curr_symbol_nat(U"&");
     tmp_io_c->set_positive_sign_nat(U"");
     tmp_io_c->set_negative_sign_nat(U"");
-    tmp_io_c->set_neg_format_nat({IOv2::base_ft<IOv2::monetary>::value,
-                                  IOv2::base_ft<IOv2::monetary>::space,
-                                  IOv2::base_ft<IOv2::monetary>::symbol,
-                                  IOv2::base_ft<IOv2::monetary>::sign});
+    tmp_io_c->set_neg_format_nat({IOv2::base_ft<IOv2::monetary>::part::value,
+                                  IOv2::base_ft<IOv2::monetary>::part::space,
+                                  IOv2::base_ft<IOv2::monetary>::part::symbol,
+                                  IOv2::base_ft<IOv2::monetary>::part::sign});
                                 
     IOv2::monetary<char32_t> obj_a(tmp_io_a);
     IOv2::monetary<char32_t> obj_b(tmp_io_b);
@@ -1235,10 +1235,10 @@ void test_monetary_char32_t_get_21()
     auto tmp_io = std::make_shared<MoneyIO>("C");
     tmp_io->set_grouping({1});
     tmp_io->set_thousands_sep(L'#');
-    tmp_io->set_neg_format_nat({IOv2::base_ft<IOv2::monetary>::symbol,
-                                IOv2::base_ft<IOv2::monetary>::none,
-                                IOv2::base_ft<IOv2::monetary>::sign,
-                                IOv2::base_ft<IOv2::monetary>::value});
+    tmp_io->set_neg_format_nat({IOv2::base_ft<IOv2::monetary>::part::symbol,
+                                IOv2::base_ft<IOv2::monetary>::part::none,
+                                IOv2::base_ft<IOv2::monetary>::part::sign,
+                                IOv2::base_ft<IOv2::monetary>::part::value});
                                   
     IOv2::monetary<char32_t> obj(tmp_io);
     std::u32string  buffer1(U"00#0#1");

--- a/test/facet/monetary/test_monetary_char8_t.cpp
+++ b/test/facet/monetary/test_monetary_char8_t.cpp
@@ -261,10 +261,10 @@ void test_monetary_char8_t_put_4()
     tmp_io->set_grouping({3});
     tmp_io->set_negative_sign_nat(u8"()");
     tmp_io->set_frac_digits_nat(2);
-    tmp_io->set_neg_format_nat({IOv2::base_ft<IOv2::monetary>::symbol,
-                                IOv2::base_ft<IOv2::monetary>::space,
-                                IOv2::base_ft<IOv2::monetary>::sign,
-                                IOv2::base_ft<IOv2::monetary>::value});
+    tmp_io->set_neg_format_nat({IOv2::base_ft<IOv2::monetary>::part::symbol,
+                                IOv2::base_ft<IOv2::monetary>::part::space,
+                                IOv2::base_ft<IOv2::monetary>::part::sign,
+                                IOv2::base_ft<IOv2::monetary>::part::value});
 
     IOv2::monetary<char8_t> obj(tmp_io);
     IOv2::ios_base<char8_t> ios;
@@ -631,10 +631,10 @@ void test_monetary_char8_t_get_6()
     tmp_io->set_positive_sign_nat(u8"");
     tmp_io->set_negative_sign_nat(u8"-");
     tmp_io->set_frac_digits_nat(2);
-    tmp_io->set_neg_format_nat({IOv2::base_ft<IOv2::monetary>::symbol,
-                                IOv2::base_ft<IOv2::monetary>::none,
-                                IOv2::base_ft<IOv2::monetary>::sign,
-                                IOv2::base_ft<IOv2::monetary>::value});
+    tmp_io->set_neg_format_nat({IOv2::base_ft<IOv2::monetary>::part::symbol,
+                                IOv2::base_ft<IOv2::monetary>::part::none,
+                                IOv2::base_ft<IOv2::monetary>::part::sign,
+                                IOv2::base_ft<IOv2::monetary>::part::value});
 
     IOv2::monetary<char8_t> obj(tmp_io);
     
@@ -720,10 +720,10 @@ void test_monetary_char8_t_get_8()
     tmp_io_a->set_curr_symbol_nat(u8"$");
     tmp_io_a->set_positive_sign_nat(u8"()");
     tmp_io_a->set_frac_digits_nat(2);
-    tmp_io_a->set_neg_format_nat({IOv2::base_ft<IOv2::monetary>::sign,
-                                  IOv2::base_ft<IOv2::monetary>::value,
-                                  IOv2::base_ft<IOv2::monetary>::space,
-                                  IOv2::base_ft<IOv2::monetary>::symbol});
+    tmp_io_a->set_neg_format_nat({IOv2::base_ft<IOv2::monetary>::part::sign,
+                                  IOv2::base_ft<IOv2::monetary>::part::value,
+                                  IOv2::base_ft<IOv2::monetary>::part::space,
+                                  IOv2::base_ft<IOv2::monetary>::part::symbol});
 
     auto tmp_io_b = std::make_shared<MoneyIO>("C");
     tmp_io_b->set_decimal_point(L'.');
@@ -731,10 +731,10 @@ void test_monetary_char8_t_get_8()
     tmp_io_b->set_curr_symbol_nat(u8"$");
     tmp_io_b->set_positive_sign_nat(u8"()");
     tmp_io_b->set_frac_digits_nat(2);
-    tmp_io_b->set_neg_format_nat({IOv2::base_ft<IOv2::monetary>::sign,
-                                  IOv2::base_ft<IOv2::monetary>::value,
-                                  IOv2::base_ft<IOv2::monetary>::symbol,
-                                  IOv2::base_ft<IOv2::monetary>::none});
+    tmp_io_b->set_neg_format_nat({IOv2::base_ft<IOv2::monetary>::part::sign,
+                                  IOv2::base_ft<IOv2::monetary>::part::value,
+                                  IOv2::base_ft<IOv2::monetary>::part::symbol,
+                                  IOv2::base_ft<IOv2::monetary>::part::none});
                                 
     IOv2::monetary<char8_t> obj_a(tmp_io_a);
     IOv2::monetary<char8_t> obj_b(tmp_io_b);
@@ -1153,28 +1153,28 @@ void test_monetary_char8_t_get_19()
     tmp_io_a->set_curr_symbol_nat(u8"$");
     tmp_io_a->set_positive_sign_nat(u8"");
     tmp_io_a->set_negative_sign_nat(u8"");
-    tmp_io_a->set_neg_format_nat({IOv2::base_ft<IOv2::monetary>::value,
-                                  IOv2::base_ft<IOv2::monetary>::symbol,
-                                  IOv2::base_ft<IOv2::monetary>::none,
-                                  IOv2::base_ft<IOv2::monetary>::sign});
+    tmp_io_a->set_neg_format_nat({IOv2::base_ft<IOv2::monetary>::part::value,
+                                  IOv2::base_ft<IOv2::monetary>::part::symbol,
+                                  IOv2::base_ft<IOv2::monetary>::part::none,
+                                  IOv2::base_ft<IOv2::monetary>::part::sign});
 
     auto tmp_io_b = std::make_shared<MoneyIO>("C");
     tmp_io_b->set_curr_symbol_nat(u8"%");
     tmp_io_b->set_positive_sign_nat(u8"");
     tmp_io_b->set_negative_sign_nat(u8"-");
-    tmp_io_b->set_neg_format_nat({IOv2::base_ft<IOv2::monetary>::value,
-                                  IOv2::base_ft<IOv2::monetary>::symbol,
-                                  IOv2::base_ft<IOv2::monetary>::sign,
-                                  IOv2::base_ft<IOv2::monetary>::none});
+    tmp_io_b->set_neg_format_nat({IOv2::base_ft<IOv2::monetary>::part::value,
+                                  IOv2::base_ft<IOv2::monetary>::part::symbol,
+                                  IOv2::base_ft<IOv2::monetary>::part::sign,
+                                  IOv2::base_ft<IOv2::monetary>::part::none});
 
     auto tmp_io_c = std::make_shared<MoneyIO>("C");
     tmp_io_c->set_curr_symbol_nat(u8"&");
     tmp_io_c->set_positive_sign_nat(u8"");
     tmp_io_c->set_negative_sign_nat(u8"");
-    tmp_io_c->set_neg_format_nat({IOv2::base_ft<IOv2::monetary>::value,
-                                  IOv2::base_ft<IOv2::monetary>::space,
-                                  IOv2::base_ft<IOv2::monetary>::symbol,
-                                  IOv2::base_ft<IOv2::monetary>::sign});
+    tmp_io_c->set_neg_format_nat({IOv2::base_ft<IOv2::monetary>::part::value,
+                                  IOv2::base_ft<IOv2::monetary>::part::space,
+                                  IOv2::base_ft<IOv2::monetary>::part::symbol,
+                                  IOv2::base_ft<IOv2::monetary>::part::sign});
                                 
     IOv2::monetary<char8_t> obj_a(tmp_io_a);
     IOv2::monetary<char8_t> obj_b(tmp_io_b);
@@ -1235,10 +1235,10 @@ void test_monetary_char8_t_get_21()
     auto tmp_io = std::make_shared<MoneyIO>("C");
     tmp_io->set_grouping({1});
     tmp_io->set_thousands_sep(L'#');
-    tmp_io->set_neg_format_nat({IOv2::base_ft<IOv2::monetary>::symbol,
-                                IOv2::base_ft<IOv2::monetary>::none,
-                                IOv2::base_ft<IOv2::monetary>::sign,
-                                IOv2::base_ft<IOv2::monetary>::value});
+    tmp_io->set_neg_format_nat({IOv2::base_ft<IOv2::monetary>::part::symbol,
+                                IOv2::base_ft<IOv2::monetary>::part::none,
+                                IOv2::base_ft<IOv2::monetary>::part::sign,
+                                IOv2::base_ft<IOv2::monetary>::part::value});
                                   
     IOv2::monetary<char8_t> obj(tmp_io);
     std::u8string  buffer1(u8"00#0#1");

--- a/test/facet/monetary/test_monetary_wchar_t.cpp
+++ b/test/facet/monetary/test_monetary_wchar_t.cpp
@@ -261,10 +261,10 @@ void test_monetary_wchar_t_put_4()
     tmp_io->set_grouping({3});
     tmp_io->set_negative_sign_nat(L"()");
     tmp_io->set_frac_digits_nat(2);
-    tmp_io->set_neg_format_nat({IOv2::base_ft<IOv2::monetary>::symbol,
-                                IOv2::base_ft<IOv2::monetary>::space,
-                                IOv2::base_ft<IOv2::monetary>::sign,
-                                IOv2::base_ft<IOv2::monetary>::value});
+    tmp_io->set_neg_format_nat({IOv2::base_ft<IOv2::monetary>::part::symbol,
+                                IOv2::base_ft<IOv2::monetary>::part::space,
+                                IOv2::base_ft<IOv2::monetary>::part::sign,
+                                IOv2::base_ft<IOv2::monetary>::part::value});
 
     IOv2::monetary<wchar_t> obj(tmp_io);
     IOv2::ios_base<wchar_t> ios;
@@ -630,10 +630,10 @@ void test_monetary_wchar_t_get_6()
     tmp_io->set_positive_sign_nat(L"");
     tmp_io->set_negative_sign_nat(L"-");
     tmp_io->set_frac_digits_nat(2);
-    tmp_io->set_neg_format_nat({IOv2::base_ft<IOv2::monetary>::symbol,
-                                IOv2::base_ft<IOv2::monetary>::none,
-                                IOv2::base_ft<IOv2::monetary>::sign,
-                                IOv2::base_ft<IOv2::monetary>::value});
+    tmp_io->set_neg_format_nat({IOv2::base_ft<IOv2::monetary>::part::symbol,
+                                IOv2::base_ft<IOv2::monetary>::part::none,
+                                IOv2::base_ft<IOv2::monetary>::part::sign,
+                                IOv2::base_ft<IOv2::monetary>::part::value});
 
     IOv2::monetary<wchar_t> obj(tmp_io);
     
@@ -719,10 +719,10 @@ void test_monetary_wchar_t_get_8()
     tmp_io_a->set_curr_symbol_nat(L"$");
     tmp_io_a->set_positive_sign_nat(L"()");
     tmp_io_a->set_frac_digits_nat(2);
-    tmp_io_a->set_neg_format_nat({IOv2::base_ft<IOv2::monetary>::sign,
-                                  IOv2::base_ft<IOv2::monetary>::value,
-                                  IOv2::base_ft<IOv2::monetary>::space,
-                                  IOv2::base_ft<IOv2::monetary>::symbol});
+    tmp_io_a->set_neg_format_nat({IOv2::base_ft<IOv2::monetary>::part::sign,
+                                  IOv2::base_ft<IOv2::monetary>::part::value,
+                                  IOv2::base_ft<IOv2::monetary>::part::space,
+                                  IOv2::base_ft<IOv2::monetary>::part::symbol});
 
     auto tmp_io_b = std::make_shared<MoneyIO>("C");
     tmp_io_b->set_decimal_point(L'.');
@@ -730,10 +730,10 @@ void test_monetary_wchar_t_get_8()
     tmp_io_b->set_curr_symbol_nat(L"$");
     tmp_io_b->set_positive_sign_nat(L"()");
     tmp_io_b->set_frac_digits_nat(2);
-    tmp_io_b->set_neg_format_nat({IOv2::base_ft<IOv2::monetary>::sign,
-                                  IOv2::base_ft<IOv2::monetary>::value,
-                                  IOv2::base_ft<IOv2::monetary>::symbol,
-                                  IOv2::base_ft<IOv2::monetary>::none});
+    tmp_io_b->set_neg_format_nat({IOv2::base_ft<IOv2::monetary>::part::sign,
+                                  IOv2::base_ft<IOv2::monetary>::part::value,
+                                  IOv2::base_ft<IOv2::monetary>::part::symbol,
+                                  IOv2::base_ft<IOv2::monetary>::part::none});
                                 
     IOv2::monetary<wchar_t> obj_a(tmp_io_a);
     IOv2::monetary<wchar_t> obj_b(tmp_io_b);
@@ -1152,28 +1152,28 @@ void test_monetary_wchar_t_get_19()
     tmp_io_a->set_curr_symbol_nat(L"$");
     tmp_io_a->set_positive_sign_nat(L"");
     tmp_io_a->set_negative_sign_nat(L"");
-    tmp_io_a->set_neg_format_nat({IOv2::base_ft<IOv2::monetary>::value,
-                                  IOv2::base_ft<IOv2::monetary>::symbol,
-                                  IOv2::base_ft<IOv2::monetary>::none,
-                                  IOv2::base_ft<IOv2::monetary>::sign});
+    tmp_io_a->set_neg_format_nat({IOv2::base_ft<IOv2::monetary>::part::value,
+                                  IOv2::base_ft<IOv2::monetary>::part::symbol,
+                                  IOv2::base_ft<IOv2::monetary>::part::none,
+                                  IOv2::base_ft<IOv2::monetary>::part::sign});
 
     auto tmp_io_b = std::make_shared<MoneyIO>("C");
     tmp_io_b->set_curr_symbol_nat(L"%");
     tmp_io_b->set_positive_sign_nat(L"");
     tmp_io_b->set_negative_sign_nat(L"-");
-    tmp_io_b->set_neg_format_nat({IOv2::base_ft<IOv2::monetary>::value,
-                                  IOv2::base_ft<IOv2::monetary>::symbol,
-                                  IOv2::base_ft<IOv2::monetary>::sign,
-                                  IOv2::base_ft<IOv2::monetary>::none});
+    tmp_io_b->set_neg_format_nat({IOv2::base_ft<IOv2::monetary>::part::value,
+                                  IOv2::base_ft<IOv2::monetary>::part::symbol,
+                                  IOv2::base_ft<IOv2::monetary>::part::sign,
+                                  IOv2::base_ft<IOv2::monetary>::part::none});
 
     auto tmp_io_c = std::make_shared<MoneyIO>("C");
     tmp_io_c->set_curr_symbol_nat(L"&");
     tmp_io_c->set_positive_sign_nat(L"");
     tmp_io_c->set_negative_sign_nat(L"");
-    tmp_io_c->set_neg_format_nat({IOv2::base_ft<IOv2::monetary>::value,
-                                  IOv2::base_ft<IOv2::monetary>::space,
-                                  IOv2::base_ft<IOv2::monetary>::symbol,
-                                  IOv2::base_ft<IOv2::monetary>::sign});
+    tmp_io_c->set_neg_format_nat({IOv2::base_ft<IOv2::monetary>::part::value,
+                                  IOv2::base_ft<IOv2::monetary>::part::space,
+                                  IOv2::base_ft<IOv2::monetary>::part::symbol,
+                                  IOv2::base_ft<IOv2::monetary>::part::sign});
                                 
     IOv2::monetary<wchar_t> obj_a(tmp_io_a);
     IOv2::monetary<wchar_t> obj_b(tmp_io_b);
@@ -1234,10 +1234,10 @@ void test_monetary_wchar_t_get_21()
     auto tmp_io = std::make_shared<MoneyIO>("C");
     tmp_io->set_grouping({1});
     tmp_io->set_thousands_sep(L'#');
-    tmp_io->set_neg_format_nat({IOv2::base_ft<IOv2::monetary>::symbol,
-                                IOv2::base_ft<IOv2::monetary>::none,
-                                IOv2::base_ft<IOv2::monetary>::sign,
-                                IOv2::base_ft<IOv2::monetary>::value});
+    tmp_io->set_neg_format_nat({IOv2::base_ft<IOv2::monetary>::part::symbol,
+                                IOv2::base_ft<IOv2::monetary>::part::none,
+                                IOv2::base_ft<IOv2::monetary>::part::sign,
+                                IOv2::base_ft<IOv2::monetary>::part::value});
                                   
     IOv2::monetary<wchar_t> obj(tmp_io);
     std::wstring buffer1(L"00#0#1");


### PR DESCRIPTION


Bring monetary{,_details}.h and messages{,_details}.h up to the project's zero-warning clang-tidy bar (bugprone/performance/modernize/cppcoreguidelines) and add them to the clang-tidy job in ci.yml.

Real fixes:
- monetary: enum part -> enum class part : uint8_t (with `using enum`); s_construct_pattern's three int8_t flags -> pattern_spec struct; pattern members value-initialized; vec/s_atoms -> std::array; signed/unsigned compares via std::cmp_greater; sign_ptr initialized.
- messages: bundle (dirname, domain) into a text_domain struct across the lookup helpers; lock_guard -> scoped_lock; buff -> std::array; push_back -> emplace_back; file_closer gets deleted move ops; `end` initialized.
- [[nodiscard]] on all facet getters.

NOLINT only where a clean fix is impossible, each with a reason comment: messages_conf<char>'s public ctor/init (the extra cvt_ft string is stable public API), fopen/fclose owning-memory, do-while, and the const m_dict member.

The part enum is now scoped, so the monetary tests reference its enumerators as part::xxx.

Verified: full CI clang-tidy invocation is clean; make test-facet and make all pass.

Note: the lone `#include <utility>` line in messages.h was already present in the working tree before this change.