### PR TITLE
docs(facet): add bilingual Doxygen comments to messages and monetary headers

### DIFF
--- a/include/facet/messages.h
+++ b/include/facet/messages.h
@@ -1,3 +1,20 @@
+/**
+ * @file messages.h
+ * @lang{ZH}
+ * 定义了 `messages<CharT>` 类，这是 gettext 风格消息翻译的用户端 facet。
+ * 它封装了一个 `messages_conf<CharT>` 实例，并提供三个 `translate` 重载，
+ * 通过值类别（lvalue / rvalue / const rvalue）区分，在避免悬空引用的同时
+ * 将不必要的拷贝降至最低。
+ * @endif
+ *
+ * @lang{EN}
+ * Defines the `messages<CharT>` class, the user-facing facet for gettext-style
+ * message translation. It wraps a `messages_conf<CharT>` instance and provides
+ * three `translate` overloads distinguished by value category
+ * (lvalue / rvalue / const rvalue), minimizing unnecessary copies while
+ * preventing dangling references.
+ * @endif
+ */
 #pragma once
 #include <common/metafunctions.h>
 #include <facet/facet_common.h>
@@ -10,25 +27,95 @@
 
 namespace IOv2
 {
+/**
+ * @lang{ZH}
+ * @brief gettext 风格消息翻译的用户端 facet。
+ *
+ * `messages<CharT>` 持有一个指向 `messages_conf<CharT>` 的共享指针，
+ * 后者负责从 `.mo` 文件加载翻译字典。`translate` 提供三个重载，
+ * 分别处理 lvalue、rvalue 和 const rvalue 输入：
+ * - **lvalue**：借用语义（零拷贝），返回对字典或原始参数的引用，
+ *   调用者需保证参数在结果的生命周期内有效。
+ * - **rvalue** 与 **const rvalue**：按值返回，结果始终持有独立数据，不会悬空。
+ *
+ * @tparam CharT 字符类型，由所用的 `messages_conf` 特化决定。
+ * @endif
+ *
+ * @lang{EN}
+ * @brief User-facing facet for gettext-style message translation.
+ *
+ * `messages<CharT>` holds a shared pointer to a `messages_conf<CharT>` that
+ * loads the translation dictionary from a `.mo` file. Three `translate`
+ * overloads cover lvalue, rvalue, and const rvalue inputs:
+ * - **lvalue**: borrowing semantics (zero copy) — returns a reference into
+ *   the dictionary or to the original argument; the caller must keep the
+ *   argument alive for as long as the result is used.
+ * - **rvalue** and **const rvalue**: return by value so the result always
+ *   owns its data and can never dangle.
+ *
+ * @tparam CharT The character type, determined by the `messages_conf` specialization used.
+ * @endif
+ */
 template <typename CharT>
 class messages
 {
 public:
+    /// @cond
     using create_rules = facet_create_rule<messages_conf<CharT>>;
+    /// @endcond
 
-    using char_type = CharT;
+    using char_type = CharT; ///< @lang{ZH} 此 facet 使用的字符类型。 @endif @lang{EN} The character type used by this facet. @endif
 
+    /**
+     * @lang{ZH}
+     * @brief 构造函数，从指向 `messages_conf<CharT>` 的共享指针创建 facet。
+     *
+     * @tparam TConfPtr 满足 `shared_ptr_to<messages_conf<CharT>>` 约束的指针类型。
+     * @param p_obj 指向已初始化的 `messages_conf<CharT>` 的非空共享指针。
+     * @throw std::runtime_error 如果 `p_obj` 为空。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Constructor that creates the facet from a shared pointer to `messages_conf<CharT>`.
+     *
+     * @tparam TConfPtr A pointer type satisfying `shared_ptr_to<messages_conf<CharT>>`.
+     * @param p_obj A non-null shared pointer to an initialized `messages_conf<CharT>`.
+     * @throw std::runtime_error If `p_obj` is empty.
+     * @endif
+     */
     template <shared_ptr_to<messages_conf<CharT>> TConfPtr>
     messages(TConfPtr p_obj)
         : m_obj(p_obj)
     { if (!m_obj) throw std::runtime_error("shared_ptr is empty"); }
 
-    // Gettext pass-through: the translation on a hit, otherwise the original
-    // `ori`. The lvalue overload borrows (zero copy): the result aliases either
-    // the dictionary (stable for the facet's lifetime) or `ori` itself on a miss,
-    // so the caller's lvalue must outlive it. Only an lvalue selects this
-    // overload; every rvalue — including a `const` one — routes to a by-value
-    // overload below, so a temporary argument can never dangle.
+    /**
+     * @lang{ZH}
+     * @brief 翻译 lvalue 字符串（借用语义，零拷贝）。
+     *
+     * gettext 传递语义：命中时返回翻译，未命中时返回原始 `ori`。
+     * 返回值是对字典条目（在 facet 生命周期内稳定）或 `ori` 本身的引用，
+     * 因此调用者的 lvalue 必须在返回值的生命周期内保持有效。
+     * 只有 lvalue 会选择此重载；所有 rvalue（包括 `const` rvalue）
+     * 均路由到下方的按值返回重载，从而保证临时参数不会悬空。
+     *
+     * @param ori 原始字符串（`msgid`）的 lvalue 引用。
+     * @return 对翻译字符串或 `ori` 的 const 引用。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Translates an lvalue string with borrowing semantics (zero copy).
+     *
+     * Gettext pass-through: returns the translation on a hit, otherwise the
+     * original `ori`. The result aliases either the dictionary (stable for the
+     * facet's lifetime) or `ori` itself on a miss, so the caller's lvalue must
+     * outlive the result. Only an lvalue selects this overload; every rvalue —
+     * including a `const` one — routes to a by-value overload below, so a
+     * temporary argument can never dangle.
+     *
+     * @param ori An lvalue reference to the original string (`msgid`).
+     * @return A const reference to the translated string or to `ori`.
+     * @endif
+     */
     const std::basic_string<char_type>& translate(const std::basic_string<char_type>& ori) const
     {
         const static std::basic_string<char_type> empty_res;
@@ -38,10 +125,29 @@ public:
         return p ? *p : ori;
     }
 
-    // Rvalue input returns by value, so the result owns its data and can never
-    // dangle: a miss moves the caller's temporary out (no copy), a hit copies the
-    // dictionary entry out. This makes the common literal/temporary call shape
-    // safe without forbidding it.
+    /**
+     * @lang{ZH}
+     * @brief 翻译 rvalue 字符串，按值返回以确保结果不悬空。
+     *
+     * 按值返回，结果始终持有独立数据：未命中时将调用者的临时对象移出（无拷贝），
+     * 命中时从字典条目拷贝。这使得以字面量或临时对象调用此函数是安全的，
+     * 而不需要禁止这种用法。
+     *
+     * @param ori 原始字符串（`msgid`）的 rvalue 引用。
+     * @return 翻译字符串或原始字符串（按值）。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Translates an rvalue string, returning by value so the result cannot dangle.
+     *
+     * Returns by value so the result always owns its data: a miss moves the
+     * caller's temporary out (no copy), a hit copies the dictionary entry out.
+     * This makes the common literal/temporary call shape safe without forbidding it.
+     *
+     * @param ori An rvalue reference to the original string (`msgid`).
+     * @return The translated string or the original string (by value).
+     * @endif
+     */
     std::basic_string<char_type> translate(std::basic_string<char_type>&& ori) const
     {
         if (ori.empty()) return {};
@@ -50,12 +156,34 @@ public:
         return p ? *p : std::move(ori);
     }
 
-    // A `const` rvalue cannot bind to the non-const `&&` overload above; without
-    // this overload it would fall back to the borrowing lvalue overload and, on a
-    // miss, dangle (the result would reference the caller's expiring temporary).
-    // Return by value here too: being const it cannot be moved from, so a miss
-    // copies `ori` out and a hit copies the dictionary entry — either way the
-    // result owns its data.
+    /**
+     * @lang{ZH}
+     * @brief 翻译 const rvalue 字符串，按值返回以确保结果不悬空。
+     *
+     * `const` rvalue 无法绑定到上方的非 `const` `&&` 重载；若没有此重载，
+     * 它将回退到借用语义的 lvalue 重载，并在未命中时悬空
+     * （返回值将引用调用者即将销毁的临时对象）。
+     * 此处也按值返回：由于是 `const` 无法移出，未命中时拷贝 `ori`，
+     * 命中时拷贝字典条目——无论哪种情况结果都持有独立数据。
+     *
+     * @param ori 原始字符串（`msgid`）的 const rvalue 引用。
+     * @return 翻译字符串或原始字符串（按值）。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Translates a const rvalue string, returning by value so the result cannot dangle.
+     *
+     * A `const` rvalue cannot bind to the non-const `&&` overload above; without
+     * this overload it would fall back to the borrowing lvalue overload and, on a
+     * miss, dangle (the result would reference the caller's expiring temporary).
+     * Return by value here too: being `const` it cannot be moved from, so a miss
+     * copies `ori` out and a hit copies the dictionary entry — either way the
+     * result owns its data.
+     *
+     * @param ori A const rvalue reference to the original string (`msgid`).
+     * @return The translated string or the original string (by value).
+     * @endif
+     */
     std::basic_string<char_type> translate(const std::basic_string<char_type>&& ori) const
     {
         if (ori.empty()) return {};
@@ -64,17 +192,69 @@ public:
         return p ? *p : ori;
     }
 
+    /**
+     * @lang{ZH}
+     * @brief 返回构造时确定的有效语言标识符。
+     * @return 过滤后的语言字符串。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the effective language identifier determined at construction.
+     * @return The filtered language string.
+     * @endif
+     */
     [[nodiscard]] const std::string& filtered_lang() const
     {
         return m_obj->filtered_lang();
     }
 
+    /**
+     * @lang{ZH}
+     * @brief 返回描述该 facet 实例的域信息字符串。
+     *
+     * 格式为 `[domain] [lang(filtered_lang)] [dirname]`，可用于调试和日志记录。
+     *
+     * @return 包含域、语言和目录信息的字符串。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns a string describing this facet instance's domain information.
+     *
+     * The format is `[domain] [lang(filtered_lang)] [dirname]`, useful for
+     * debugging and logging.
+     *
+     * @return A string containing domain, language, and directory information.
+     * @endif
+     */
     [[nodiscard]] const std::string& domain_info() const
     {
         return m_obj->domain_info();
     }
 
-    // The .mo header is stored as the entry whose msgid is the empty string.
+    /**
+     * @lang{ZH}
+     * @brief 返回 `.mo` 文件的头部条目。
+     *
+     * 在 GNU gettext 的 `.mo` 格式中，`msgid` 为空字符串的条目存储文件头，
+     * 其 `msgstr` 包含版本、字符集、复数规则等元数据。若头部条目不存在，
+     * 则返回空字符串。
+     *
+     * @return 对头部条目（`msgid` 为空字符串对应的 `msgstr`）的 const 引用，
+     *         若不存在则为空字符串。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the header entry of the `.mo` file.
+     *
+     * In the GNU gettext `.mo` format, the entry whose `msgid` is the empty
+     * string stores the file header, whose `msgstr` contains metadata such as
+     * version, charset, and plural-form rules. Returns an empty string if no
+     * header entry is present.
+     *
+     * @return A const reference to the header entry (`msgstr` for the empty-string `msgid`),
+     *         or an empty string if absent.
+     * @endif
+     */
     const std::basic_string<char_type>& head_entry() const
     {
         const static std::basic_string<char_type> empty_msgid;
@@ -86,6 +266,8 @@ private:
     std::shared_ptr<const messages_conf<CharT>> m_obj;
 };
 
+/// @cond
 template<typename TConfPtr>
 messages(TConfPtr) -> messages<typename TConfPtr::element_type::char_type>;
+/// @endcond
 }

--- a/include/facet/messages_details.h
+++ b/include/facet/messages_details.h
@@ -1,3 +1,21 @@
+/**
+ * @file messages_details.h
+ * @lang{ZH}
+ * 定义了 `messages` facet 的实现细节，包括 `base_ft<messages>` 基类和
+ * `messages_conf` 的各字符类型特化。`base_ft<messages>` 负责管理 gettext
+ * 文本域绑定、语言解析和 `.mo` 文件的加载与解析；`messages_conf` 的各特化
+ * 在此基础上提供具体字符类型的翻译字典。
+ * @endif
+ *
+ * @lang{EN}
+ * Defines the implementation details of the `messages` facet, including
+ * the `base_ft<messages>` base class and per-character-type specializations
+ * of `messages_conf`. `base_ft<messages>` manages gettext text-domain
+ * binding, language resolution, and loading and parsing of `.mo` files;
+ * the `messages_conf` specializations build per-character-type translation
+ * dictionaries on top of that base.
+ * @endif
+ */
 #pragma once
 #include <common/defs.h>
 #include <common/metafunctions.h>
@@ -24,9 +42,37 @@ namespace IOv2
 {
 template <typename CharT> class messages;
 
+/**
+ * @lang{ZH}
+ * @brief `messages` facet 的基类，提供 gettext 文本域管理和 `.mo` 文件解析功能。
+ *
+ * 该类维护一个全局的文本域与目录的映射（`s_domain_dirs`），支持线程安全地
+ * 绑定和查询域目录，并提供语言过滤（`filter_lang`）和 `.mo` 文件可用性检查
+ * （`available`）等静态工具函数。`messages_conf` 的各特化类继承此基类，
+ * 在构造时通过 `get_translate_dictionary` 加载翻译字典。
+ *
+ * @note 该类不直接实例化，仅作为 `messages_conf` 的基类使用。
+ * @endif
+ *
+ * @lang{EN}
+ * @brief Base class for the `messages` facet, providing gettext text-domain
+ *        management and `.mo` file parsing.
+ *
+ * This class maintains a global mapping of text domains to directories
+ * (`s_domain_dirs`), supports thread-safe binding and lookup of domain
+ * directories, and provides static helpers for language filtering
+ * (`filter_lang`) and `.mo` file availability checking (`available`).
+ * The `messages_conf` specializations inherit this class and load their
+ * translation dictionaries via `get_translate_dictionary` at construction.
+ *
+ * @note This class is not instantiated directly; it serves only as the
+ *       base for `messages_conf`.
+ * @endif
+ */
 template <>
 class base_ft<messages> : public abs_ft
 {
+    /// @cond
     struct file_closer
     {
         file_closer(std::FILE* fp)
@@ -39,8 +85,30 @@ class base_ft<messages> : public abs_ft
     private:
         std::FILE* m_fp;
     };
+    /// @endcond
 
 public:
+    /**
+     * @lang{ZH}
+     * @brief 将文本域绑定到指定目录。
+     *
+     * 如果该域已存在，则更新其目录；否则插入新条目。此操作是线程安全的。
+     *
+     * @param domain 文本域名称（`.mo` 文件的基名）。
+     * @param dirname 存放该域本地化文件的目录路径（gettext 的 `dirname`）。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Binds a text domain to a specified directory.
+     *
+     * If the domain already exists, its directory is updated; otherwise a new
+     * entry is inserted. This operation is thread-safe.
+     *
+     * @param domain The text domain name (the `.mo` file's basename).
+     * @param dirname The directory path holding the locale files for this domain
+     *                (gettext's `dirname`).
+     * @endif
+     */
     static void bind_text_domain(const std::string& domain, const std::string& dirname)
     {
         std::scoped_lock guard(s_domain_mutex);
@@ -51,19 +119,98 @@ public:
             s_domain_dirs.insert({domain, dirname});
     }
 
-    // Resolve the domain's dirname once, then delegate to the snapshot-taking
-    // overload so a single public call observes one consistent dirname even if
-    // another thread rebinds the domain via bind_text_domain() concurrently.
+    /**
+     * @lang{ZH}
+     * @brief 检查指定域和语言对应的 `.mo` 文件是否可用。
+     *
+     * 先原子性地快照域的目录名，再委托给内部重载，以确保在调用期间
+     * 即使另一线程通过 `bind_text_domain` 修改了目录绑定，
+     * 单次调用也只观察到一致的目录名。
+     *
+     * @param domain 文本域名称。
+     * @param lang 语言标识符，或 `:` 分隔的候选语言列表，或空字符串（使用环境变量）。
+     * @return 如果对应的 `.mo` 文件存在，则返回 `true`。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Checks whether the `.mo` file for the given domain and language is available.
+     *
+     * The domain's dirname is resolved once (atomically snapshotted) and then
+     * delegated to the internal overload, so that even if another thread
+     * rebinds the domain via `bind_text_domain` concurrently, a single call
+     * observes only one consistent dirname.
+     *
+     * @param domain The text domain name.
+     * @param lang A language identifier, a `:` -separated list of candidate languages,
+     *             or an empty string (falls back to environment variables).
+     * @return `true` if the corresponding `.mo` file exists.
+     * @endif
+     */
     static bool available(const std::string& domain, const std::string& lang)
     {
         return available({.dirname = get_dirname(domain), .domain = domain}, lang);
     }
 
+    /**
+     * @lang{ZH}
+     * @brief 从候选语言列表中找出第一个可用的语言。
+     *
+     * 对域的目录名进行一次快照，然后委托给内部重载。
+     *
+     * @param domain 文本域名称。
+     * @param p_lang 语言标识符或 `:` 分隔的候选列表，或空字符串（使用环境变量）。
+     * @return 第一个可用的语言字符串，若均不可用则返回空字符串。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the first available language from a list of candidates.
+     *
+     * The domain's dirname is snapshotted once and then delegated to the
+     * internal overload.
+     *
+     * @param domain The text domain name.
+     * @param p_lang A language identifier, a `:` -separated candidate list,
+     *               or an empty string (falls back to environment variables).
+     * @return The first available language string, or an empty string if none is available.
+     * @endif
+     */
     static std::string filter_lang(const std::string& domain, const std::string& p_lang)
     {
         return filter_lang({.dirname = get_dirname(domain), .domain = domain}, p_lang);
     }
 
+    /**
+     * @lang{ZH}
+     * @brief 构造函数，快照域目录名并初始化域信息。
+     *
+     * 在初始化列表中，`m_dirname` 先于 `m_filtered_lang` 和 `m_domain_info`
+     * 初始化（按声明顺序），确保对 `filter_lang` 和域信息字符串的计算都使用
+     * 同一个目录快照，从而避免与并发的 `bind_text_domain` 调用产生竞争。
+     * `messages_conf::init` 通过 `dirname()` 读回该快照，因此整个构造过程
+     * 从同一个 dirname 解析 `.mo` 文件位置，`domain_info()` 与实际加载的
+     * 字典永远不会不一致。
+     *
+     * @param id facet 的唯一标识符。
+     * @param p_domain 文本域名称。
+     * @param p_lang 候选语言字符串。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Constructor that snapshots the domain dirname and initializes domain info.
+     *
+     * In the member initializer list, `m_dirname` is initialized before
+     * `m_filtered_lang` and `m_domain_info` (in declaration order), ensuring
+     * that both `filter_lang` and the domain-info string computation use the
+     * same dirname snapshot, avoiding races with concurrent `bind_text_domain`
+     * calls. `messages_conf::init` reads the snapshot back via `dirname()`, so
+     * the whole construction resolves the `.mo` location from one dirname and
+     * `domain_info()` can never disagree with the dictionary actually loaded.
+     *
+     * @param id The unique identifier for the facet.
+     * @param p_domain The text domain name.
+     * @param p_lang The candidate language string.
+     * @endif
+     */
     base_ft(size_t id, const std::string& p_domain, const std::string& p_lang)
         : abs_ft(id)
         // Snapshot the dirname first (declared before the members below, so it
@@ -78,27 +225,110 @@ public:
                         m_dirname + "]")
     {}
 
+    /**
+     * @lang{ZH}
+     * @brief 返回描述该 facet 实例的域信息字符串。
+     *
+     * 格式为 `[domain] [lang(filtered_lang)] [dirname]`，可用于调试和日志记录。
+     *
+     * @return 包含域、语言和目录信息的字符串。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns a string describing this facet instance's domain information.
+     *
+     * The format is `[domain] [lang(filtered_lang)] [dirname]`, useful for
+     * debugging and logging.
+     *
+     * @return A string containing domain, language, and directory information.
+     * @endif
+     */
     [[nodiscard]] const std::string& domain_info() const { return m_domain_info; }
+
+    /**
+     * @lang{ZH}
+     * @brief 返回构造时确定的有效语言标识符。
+     * @return 过滤后的语言字符串。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the effective language identifier determined at construction.
+     * @return The filtered language string.
+     * @endif
+     */
     [[nodiscard]] const std::string& filtered_lang() const { return m_filtered_lang; }
 
 protected:
-    // The directory bound to this domain (gettext's `dirname`), snapshotted at
-    // construction. Derived configs read this so their dictionary load uses the
-    // same directory that domain_info() reports.
+    /**
+     * @lang{ZH}
+     * @brief 返回构造时快照的域目录名。
+     *
+     * 派生类（`messages_conf` 的各特化）通过此函数获取目录名，
+     * 以确保字典加载使用的目录与 `domain_info()` 报告的目录一致。
+     *
+     * @return 绑定到此域的目录路径。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the domain dirname snapshotted at construction.
+     *
+     * Derived classes (`messages_conf` specializations) read this so their
+     * dictionary load uses the same directory that `domain_info()` reports.
+     *
+     * @return The directory path bound to this domain.
+     * @endif
+     */
     [[nodiscard]] const std::string& dirname() const { return m_dirname; }
 
-    // The bound text domain and its directory. These two same-typed strings are
-    // always passed together to the lookup helpers below; bundling them here (vs
-    // two positional std::string parameters) makes them impossible to swap by
-    // mistake (bugprone-easily-swappable-parameters). The language stays a
-    // separate argument because it varies independently — filter_lang() probes
-    // several candidate languages against one fixed (dirname, domain) pair.
+    /**
+     * @lang{ZH}
+     * @brief 捆绑文本域名称与其目录的辅助结构体。
+     *
+     * `dirname` 和 `domain` 这两个类型相同的字符串在所有查找辅助函数中总是成对传递。
+     * 将它们捆绑在一起（而非使用两个位置相同的 `std::string` 参数）可以避免意外交换
+     * （解决 bugprone-easily-swappable-parameters 警告）。语言字符串保持独立参数，
+     * 因为它会变化 —— `filter_lang()` 会针对一个固定的 `(dirname, domain)` 对
+     * 测试多个候选语言。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Helper struct that bundles a text domain name with its directory.
+     *
+     * The two same-typed strings `dirname` and `domain` are always passed
+     * together to lookup helpers. Bundling them here (rather than two
+     * positional `std::string` parameters) makes them impossible to swap by
+     * mistake (addressing bugprone-easily-swappable-parameters). The language
+     * stays a separate argument because it varies independently — `filter_lang()`
+     * probes several candidate languages against one fixed `(dirname, domain)` pair.
+     * @endif
+     */
     struct text_domain
     {
-        std::string dirname;  // gettext dirname: the directory holding the locale tree
-        std::string domain;   // text domain: the .mo file's basename
+        std::string dirname;  ///< @lang{ZH} gettext 目录名：存放本地化文件树的目录。 @endif @lang{EN} gettext dirname: the directory holding the locale tree. @endif
+        std::string domain;   ///< @lang{ZH} 文本域名：`.mo` 文件的基名。 @endif @lang{EN} text domain: the `.mo` file's basename. @endif
     };
 
+    /**
+     * @lang{ZH}
+     * @brief 构建 `.mo` 文件的完整路径。
+     *
+     * 返回路径格式为 `<dirname>/<lang>/LC_MESSAGES/<domain>.mo`。
+     *
+     * @param td 包含目录名和域名的 `text_domain` 结构体。
+     * @param lang 语言标识符。
+     * @return `.mo` 文件的完整路径字符串。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Builds the full path to a `.mo` file.
+     *
+     * The returned path follows the format `<dirname>/<lang>/LC_MESSAGES/<domain>.mo`.
+     *
+     * @param td A `text_domain` struct containing the dirname and domain name.
+     * @param lang The language identifier.
+     * @return The full path string to the `.mo` file.
+     * @endif
+     */
     static std::string get_domain_file(const text_domain& td, const std::string& lang)
     {
         std::filesystem::path dom{td.dirname};
@@ -106,35 +336,75 @@ protected:
         return dom.string();
     }
 
-    // Scope: this only implements gettext()/dgettext() semantics, i.e. a
-    // plain one-to-one (msgid -> msgstr) lookup.
-    //
-    // Each .mo string is therefore read as a NUL-terminated C string: the
-    // record's stored `length` may be longer (GNU gettext packs extra data
-    // into a single record using embedded NUL/EOT separators), but anything
-    // past the first '\0' is intentionally ignored here. That matches gettext's
-    // own lookup, which compares msgids with strcmp() and so stops at the first
-    // NUL, and it keeps the map key identical to what a caller passes in.
-    //
-    // Encoding: strings are assumed to be UTF-8 (the default that GNU gettext
-    // >= 0.22's msgfmt produces). The .mo charset declared in the header
-    // entry's "Content-Type: ...; charset=..." is neither read nor honoured
-    // here, so a .mo in another encoding (a legacy file, or one built with
-    // msgfmt --no-convert) is NOT transcoded: its non-ASCII msgstrs would be
-    // misdecoded. msgids are unaffected, as gettext recommends they be US-ASCII.
-    //
-    // Consequently the following are NOT supported (their extra payload is
-    // dropped on purpose, not by accident):
-    //   - ngettext()/dngettext() plural forms: the original is stored as
-    //     "msgid\0msgid_plural" and the translation as "msgstr[0]\0msgstr[1]..".
-    //     Supporting them needs the header's "Plural-Forms:" rule, length-based
-    //     (not C-string) record storage, and an n-aware lookup API.
-    //   - pgettext() message contexts: the original is stored as
-    //     "msgctxt\x04msgid" (EOT-separated, no NUL), so the key here is the
-    //     whole "msgctxt\x04msgid" blob; a context-aware API would need to
-    //     assemble that key explicitly.
-    // Revisit this function (and the lookup API) if ngettext/msgctxt support is
-    // ever required.
+    /**
+     * @lang{ZH}
+     * @brief 解析 GNU gettext `.mo` 文件并返回翻译字典。
+     *
+     * 此函数仅实现 `gettext()`/`dgettext()` 语义，即简单的一对一
+     * （`msgid` → `msgstr`）查找。
+     *
+     * **字符串读取方式：** 每个 `.mo` 字符串作为 NUL 终止的 C 字符串读取。
+     * 条目的 `length` 字段可能更长（GNU gettext 使用嵌入的 NUL/EOT 分隔符将
+     * 额外数据打包到同一记录中），但第一个 `'\0'` 之后的内容在此处被忽略，
+     * 与 `gettext` 本身使用 `strcmp()` 比较 `msgid` 的行为一致，且映射键与调用者传入的值相同。
+     *
+     * **编码：** 假定字符串为 UTF-8 编码（GNU gettext >= 0.22 的 `msgfmt` 默认生成）。
+     * `.mo` 文件头中 `Content-Type: ...; charset=...` 声明的字符集不被读取或处理，
+     * 因此非 UTF-8 编码的 `.mo` 文件（旧版文件或使用 `msgfmt --no-convert` 构建的文件）
+     * 的非 ASCII `msgstr` 将被错误解码。`msgid` 不受影响，因为 gettext 建议其使用 US-ASCII。
+     *
+     * **不支持的特性**（有意丢弃额外数据，而非疏忽）：
+     * - `ngettext()`/`dngettext()` 复数形式：原文存储为 `"msgid\0msgid_plural"`，
+     *   译文为 `"msgstr[0]\0msgstr[1].."`。支持它需要头部的 `Plural-Forms:` 规则、
+     *   基于长度（而非 C 字符串）的记录存储，以及支持 `n` 的查找 API。
+     * - `pgettext()` 消息上下文：原文存储为 `"msgctxt\x04msgid"`（EOT 分隔，无 NUL），
+     *   因此此处的键为整个 `"msgctxt\x04msgid"` 块；支持上下文的 API 需要显式拼接该键。
+     *
+     * 如需支持 `ngettext`/`msgctxt`，需修改此函数及查找 API。
+     *
+     * @param filename `.mo` 文件的路径。
+     * @return 从 `msgid`（UTF-8）到 `msgstr`（UTF-8）的翻译字典。
+     * @throw stream_error 如果文件无法打开、格式非法，或字符串数量/长度超出合理范围。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Parses a GNU gettext `.mo` file and returns a translation dictionary.
+     *
+     * This function only implements `gettext()`/`dgettext()` semantics, i.e. a
+     * plain one-to-one (`msgid` → `msgstr`) lookup.
+     *
+     * **String reading:** Each `.mo` string is read as a NUL-terminated C string.
+     * The record's stored `length` may be longer (GNU gettext packs extra data
+     * using embedded NUL/EOT separators), but anything past the first `'\0'` is
+     * intentionally ignored here, matching gettext's own behaviour of comparing
+     * `msgid`s with `strcmp()` and keeping the map key identical to what a caller passes in.
+     *
+     * **Encoding:** Strings are assumed to be UTF-8 (the default that GNU gettext
+     * >= 0.22's `msgfmt` produces). The `.mo` charset declared in the header
+     * entry's `Content-Type: ...; charset=...` is neither read nor honoured, so a
+     * `.mo` in another encoding (a legacy file, or one built with
+     * `msgfmt --no-convert`) will have its non-ASCII `msgstr`s misdecoded.
+     * `msgid`s are unaffected, as gettext recommends they be US-ASCII.
+     *
+     * **Unsupported features** (extra payload dropped intentionally, not by accident):
+     * - `ngettext()`/`dngettext()` plural forms: the original is stored as
+     *   `"msgid\0msgid_plural"` and the translation as `"msgstr[0]\0msgstr[1].."`.
+     *   Supporting them needs the header's `Plural-Forms:` rule, length-based
+     *   (not C-string) record storage, and an `n`-aware lookup API.
+     * - `pgettext()` message contexts: the original is stored as
+     *   `"msgctxt\x04msgid"` (EOT-separated, no NUL), so the key here is the
+     *   whole `"msgctxt\x04msgid"` blob; a context-aware API would need to
+     *   assemble that key explicitly.
+     *
+     * Revisit this function (and the lookup API) if `ngettext`/`msgctxt` support
+     * is ever required.
+     *
+     * @param filename The path to the `.mo` file.
+     * @return A translation dictionary mapping `msgid` (UTF-8) to `msgstr` (UTF-8).
+     * @throw stream_error If the file cannot be opened, has an invalid format, or
+     *                     the string count or length exceeds a reasonable bound.
+     * @endif
+     */
     static std::unordered_map<std::u8string, std::u8string> get_translate_dictionary(const std::string& filename)
     {
         std::FILE* fp = fopen(filename.c_str(), "rb"); // NOLINT(cppcoreguidelines-owning-memory)
@@ -266,9 +536,30 @@ protected:
     }
 
 private:
-    // Snapshot-taking implementations: the dirname is resolved once by the
-    // caller and threaded through here, so neither recursion into available()
-    // nor the language scan re-reads s_domain_dirs.
+    /**
+     * @lang{ZH}
+     * @brief `available` 的内部重载，接受已快照的 `text_domain`。
+     *
+     * 调用者负责在外部解析目录名，此处不再访问 `s_domain_dirs`，
+     * 从而避免在语言扫描时重复加锁或递归进入公开重载的 `available()`。
+     *
+     * @param td 包含已快照目录名和域名的 `text_domain` 结构体。
+     * @param lang 语言标识符。
+     * @return 如果对应的 `.mo` 文件存在，则返回 `true`。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Internal overload of `available` that accepts an already-snapshotted `text_domain`.
+     *
+     * The caller resolves the dirname before calling here, so `s_domain_dirs`
+     * is not accessed, avoiding repeated locking or recursion back into the
+     * public overload of `available()` during the language scan.
+     *
+     * @param td A `text_domain` struct with an already-snapshotted dirname and domain name.
+     * @param lang The language identifier.
+     * @return `true` if the corresponding `.mo` file exists.
+     * @endif
+     */
     static bool available(const text_domain& td, const std::string& lang)
     {
         if (lang.empty() || lang.find(':') != std::string::npos)
@@ -281,6 +572,51 @@ private:
         return std::filesystem::exists(get_domain_file(td, lang));
     }
 
+    /**
+     * @lang{ZH}
+     * @brief `filter_lang` 的内部重载，接受已快照的 `text_domain`。
+     *
+     * 如果 `p_lang` 非空，则在 `:` 分隔的候选列表中找出第一个可用的语言。
+     * 如果 `p_lang` 为空，则依次查询环境变量 `LANGUAGE`（按 `:` 分隔），
+     * 然后是 `LC_ALL`、`LC_MESSAGES`、`LANG`（均视为单一语言名称，镜像 gettext 的行为），
+     * 返回第一个可用的语言字符串。
+     *
+     * @note `std::getenv` 在与 `setenv()`/`putenv()` 并发执行时不是线程安全的——
+     *       无论是返回的指针还是其所指向的字节，都可能在读取过程中被另一线程置为无效——
+     *       而 C++ 和 POSIX 均不提供可移植的线程安全环境变量读取方式，
+     *       因此此处的锁无法关闭与其他修改线程之间的竞争。
+     *       本代码假定进程环境在 `messages` facet 构造期间不会被并发修改
+     *       （对于"在启动时配置 locale 一次"的常见用法，此假定成立）。
+     *       每个值在读取后立即复制到 `std::string` 中，以将读取窗口降至最低。
+     *
+     * @param td 包含已快照目录名和域名的 `text_domain` 结构体。
+     * @param p_lang 候选语言字符串，或空字符串（使用环境变量）。
+     * @return 第一个可用的语言字符串，若均不可用则返回空字符串。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Internal overload of `filter_lang` that accepts an already-snapshotted `text_domain`.
+     *
+     * If `p_lang` is non-empty, scans it as a `:` -separated candidate list and
+     * returns the first available language. If `p_lang` is empty, queries the
+     * environment variables `LANGUAGE` (`:` -separated list), then `LC_ALL`,
+     * `LC_MESSAGES`, and `LANG` (each treated as a single locale name, mirroring
+     * gettext), and returns the first available one.
+     *
+     * @note `std::getenv` is not thread-safe against concurrent `setenv()`/`putenv()` calls —
+     *       the returned pointer and the bytes it addresses may be invalidated mid-read —
+     *       and neither C++ nor POSIX offers a portable thread-safe environment read,
+     *       so a lock here could not close the race against mutators elsewhere.
+     *       This code therefore assumes the process environment is not modified
+     *       concurrently during `messages` facet construction (true for the typical
+     *       "configure locale once at startup" usage). Each value is copied into a
+     *       `std::string` at once to keep the read window minimal.
+     *
+     * @param td A `text_domain` struct with an already-snapshotted dirname and domain name.
+     * @param p_lang The candidate language string, or empty (use environment variables).
+     * @return The first available language string, or empty if none is available.
+     * @endif
+     */
     static std::string filter_lang(const text_domain& td, const std::string& p_lang)
     {
         auto match_lang = [&td](const std::string& str_lang)
@@ -342,9 +678,31 @@ private:
             return match_lang(p_lang);
     }
 
+    // Global mapping from text domain name to its directory path.
+    // Protected by s_domain_mutex; read/write only while holding the lock.
     inline static std::unordered_map<std::string, std::string> s_domain_dirs;
     inline static std::mutex s_domain_mutex;
 
+    /**
+     * @lang{ZH}
+     * @brief 线程安全地查询指定域绑定的目录名。
+     *
+     * 如果域未绑定，则返回默认目录 `/usr/share/locale`。
+     *
+     * @param domain 文本域名称。
+     * @return 该域绑定的目录路径，或默认目录。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Thread-safely looks up the dirname bound to the given domain.
+     *
+     * Returns the default directory `/usr/share/locale` if the domain has
+     * not been bound.
+     *
+     * @param domain The text domain name.
+     * @return The directory path bound to the domain, or the default directory.
+     * @endif
+     */
     static std::string get_dirname(const std::string& domain)
     {
         const static std::string def_dir = "/usr/share/locale";
@@ -355,8 +713,9 @@ private:
     }
 
 private:
-    // Declared first: initialised before m_filtered_lang / m_domain_info, both of
-    // which depend on this snapshot.
+    // Declared first: initialised before m_filtered_lang and m_domain_info (both
+    // of which depend on this snapshot) because members are initialised in
+    // declaration order. See the constructor for the full rationale.
     const std::string m_dirname;
     const std::string m_filtered_lang;
     const std::string m_domain_info;
@@ -364,22 +723,79 @@ private:
 
 template <typename CharT> class messages_conf;
 
+/**
+ * @lang{ZH}
+ * @brief `messages_conf` 的 `char8_t` 特化，以 UTF-8 字符串为键的翻译 facet。
+ *
+ * 从 `.mo` 文件加载翻译字典，直接使用 `char8_t` 字符串作为键和值，
+ * 无需任何编码转换。
+ * @endif
+ *
+ * @lang{EN}
+ * @brief Specialization of `messages_conf` for `char8_t`, a translation facet
+ *        keyed on UTF-8 strings.
+ *
+ * Loads the translation dictionary from a `.mo` file using `char8_t` strings
+ * directly as keys and values, with no encoding conversion.
+ * @endif
+ */
 template <>
 class messages_conf<char8_t> : public ft_basic<messages<char8_t>>
 {
 public:
+    /**
+     * @lang{ZH}
+     * @brief 构造函数，加载指定域和语言的翻译字典。
+     *
+     * @param domain 文本域名称。
+     * @param lang 候选语言字符串，或空字符串（使用环境变量）。
+     * @param throw_if_fail 如果为 `true`（默认），加载失败时抛出异常；
+     *                      否则静默地使翻译字典为空。
+     * @throw stream_error 如果 `throw_if_fail` 为 `true` 且字典加载失败。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Constructor that loads the translation dictionary for the given domain and language.
+     *
+     * @param domain The text domain name.
+     * @param lang The candidate language string, or empty (use environment variables).
+     * @param throw_if_fail If `true` (default), throws on failure; otherwise silently
+     *                      leaves the dictionary empty.
+     * @throw stream_error If `throw_if_fail` is `true` and dictionary loading fails.
+     * @endif
+     */
     messages_conf(const std::string& domain, const std::string& lang, bool throw_if_fail = true)
         : ft_basic<messages<char8_t>>(domain, lang)
         , m_dict(init(this->dirname(), domain, this->filtered_lang(), throw_if_fail))
     {}
 
-    // Returns a pointer to the translation, or nullptr when `ori` is not in the
-    // dictionary. Returning a pointer (rather than `ori` on a miss) keeps this
-    // lookup from ever aliasing the caller's argument, so it neither dangles nor
-    // copies; the messages facet layers the gettext pass-through (return the
-    // original on a miss) on top, where it can do so safely per value category.
-    // nullptr unambiguously means "not found", distinct from a found translation
-    // that happens to be empty.
+    /**
+     * @lang{ZH}
+     * @brief 查找 `ori` 的翻译。
+     *
+     * 返回指向字典中翻译的指针，而非翻译字符串本身，以避免与调用者参数产生别名
+     * 关系（不会悬空，也不会产生额外拷贝）。`messages` facet 在此之上处理 gettext
+     * 的"未命中时返回原文"语义（按值类别安全地进行）。`nullptr` 明确表示"未找到"，
+     * 与找到了但翻译恰好为空的情况不同。
+     *
+     * @param ori 原始字符串（`msgid`）。
+     * @return 指向字典中翻译字符串的指针，若未找到则为 `nullptr`。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Looks up the translation for `ori`.
+     *
+     * Returns a pointer to the translation rather than the string by value, so
+     * it never aliases the caller's argument (no dangling, no copy). The
+     * `messages` facet layers the gettext pass-through (return the original on
+     * a miss) on top, where it can do so safely per value category.
+     * `nullptr` unambiguously means "not found", distinct from a found
+     * translation that happens to be empty.
+     *
+     * @param ori The original string (`msgid`).
+     * @return A pointer to the translation in the dictionary, or `nullptr` if not found.
+     * @endif
+     */
     virtual const std::u8string* translate(const std::u8string& ori) const
     {
         auto it = m_dict.find(ori);
@@ -387,6 +803,28 @@ public:
     }
 
 private:
+    /**
+     * @lang{ZH}
+     * @brief 加载翻译字典的私有工厂函数。
+     *
+     * @param dirname 域目录名。
+     * @param domain 文本域名称。
+     * @param lang 过滤后的语言字符串。
+     * @param throw_if_fail 失败时是否抛出异常。
+     * @return 已加载的翻译字典；若 `throw_if_fail` 为 `false` 且失败，则返回空字典。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Private factory function that loads the translation dictionary.
+     *
+     * @param dirname The domain directory name.
+     * @param domain The text domain name.
+     * @param lang The filtered language string.
+     * @param throw_if_fail Whether to throw on failure.
+     * @return The loaded translation dictionary, or an empty dictionary on failure
+     *         (if `throw_if_fail` is `false`).
+     * @endif
+     */
     static std::unordered_map<std::u8string, std::u8string> init(const std::string& dirname, const std::string& domain, const std::string& lang, bool throw_if_fail)
     {
         try
@@ -408,6 +846,26 @@ private:
     const std::unordered_map<std::u8string, std::u8string> m_dict;
 };
 
+/**
+ * @lang{ZH}
+ * @brief `messages_conf` 的 `char32_t`/UTF-32 `wchar_t` 特化。
+ *
+ * 从 `.mo` 文件加载 UTF-8 翻译字典，再将所有字符串转换为 `CharT` 类型。
+ * 仅当 `CharT` 为 `char32_t`，或 `wchar_t` 且其编码为 UTF-32 时启用此特化。
+ *
+ * @tparam CharT 字符类型，必须为 `char32_t` 或 UTF-32 的 `wchar_t`。
+ * @endif
+ *
+ * @lang{EN}
+ * @brief Specialization of `messages_conf` for `char32_t` / UTF-32 `wchar_t`.
+ *
+ * Loads the UTF-8 translation dictionary from a `.mo` file and converts all
+ * strings to `CharT`. This specialization is enabled only when `CharT` is
+ * `char32_t`, or `wchar_t` with UTF-32 encoding.
+ *
+ * @tparam CharT The character type; must be `char32_t` or UTF-32 `wchar_t`.
+ * @endif
+ */
 template <typename CharT>
     requires std::is_same_v<CharT, char32_t> ||
                 (std::is_same_v<CharT, wchar_t> &&
@@ -416,12 +874,56 @@ class messages_conf<CharT> : public ft_basic<messages<CharT>>
 {
     using TString = std::basic_string<CharT>;
 public:
+    /**
+     * @lang{ZH}
+     * @brief 构造函数，加载指定域和语言的翻译字典。
+     *
+     * @param domain 文本域名称。
+     * @param lang 候选语言字符串，或空字符串（使用环境变量）。
+     * @param throw_if_fail 如果为 `true`（默认），加载失败时抛出异常；
+     *                      否则静默地使翻译字典为空。
+     * @throw stream_error 如果 `throw_if_fail` 为 `true` 且字典加载失败。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Constructor that loads the translation dictionary for the given domain and language.
+     *
+     * @param domain The text domain name.
+     * @param lang The candidate language string, or empty (use environment variables).
+     * @param throw_if_fail If `true` (default), throws on failure; otherwise silently
+     *                      leaves the dictionary empty.
+     * @throw stream_error If `throw_if_fail` is `true` and dictionary loading fails.
+     * @endif
+     */
     messages_conf(const std::string& domain, const std::string& lang, bool throw_if_fail = true)
         : ft_basic<messages<CharT>>(domain, lang)
         , m_dict(init(this->dirname(), domain, this->filtered_lang(), throw_if_fail))
     {}
 
 private:
+    /**
+     * @lang{ZH}
+     * @brief 加载翻译字典并将 UTF-8 字符串转换为 `CharT` 编码的私有工厂函数。
+     *
+     * @param dirname 域目录名。
+     * @param domain 文本域名称。
+     * @param lang 过滤后的语言字符串。
+     * @param throw_if_fail 失败时是否抛出异常。
+     * @return 已加载并转换的翻译字典；若 `throw_if_fail` 为 `false` 且失败，则返回空字典。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Private factory function that loads the translation dictionary and
+     *        converts UTF-8 strings to `CharT`.
+     *
+     * @param dirname The domain directory name.
+     * @param domain The text domain name.
+     * @param lang The filtered language string.
+     * @param throw_if_fail Whether to throw on failure.
+     * @return The loaded and converted translation dictionary, or an empty dictionary
+     *         on failure (if `throw_if_fail` is `false`).
+     * @endif
+     */
     static std::unordered_map<TString, TString> init(const std::string& dirname, const std::string& domain, const std::string& lang, bool throw_if_fail)
     {
         try
@@ -449,7 +951,22 @@ private:
     }
 
 public:
-    // See the char8_t specialization: nullptr means "not found".
+    /**
+     * @lang{ZH}
+     * @brief 查找 `ori` 的翻译。参见 `char8_t` 特化：`nullptr` 表示"未找到"。
+     *
+     * @param ori 原始字符串（`msgid`）。
+     * @return 指向字典中翻译字符串的指针，若未找到则为 `nullptr`。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Looks up the translation for `ori`. See the `char8_t` specialization:
+     *        `nullptr` means "not found".
+     *
+     * @param ori The original string (`msgid`).
+     * @return A pointer to the translation in the dictionary, or `nullptr` if not found.
+     * @endif
+     */
     virtual const TString* translate(const TString& ori) const
     {
         auto it = m_dict.find(ori);
@@ -460,22 +977,83 @@ private:
     const std::unordered_map<TString, TString> m_dict; // NOLINT(cppcoreguidelines-avoid-const-or-ref-data-members)
 };
 
+/**
+ * @lang{ZH}
+ * @brief `messages_conf` 的 `char` 特化，通过 `wchar_t` 转换器进行编码转换。
+ *
+ * 从 `.mo` 文件加载 UTF-8 翻译字典，再通过指定的 `char`↔`wchar_t` 转换 facet
+ * 将字符串转换为当前 `char` 编码。仅在 `wchar_t` 为 UTF-32 的平台上支持。
+ * @endif
+ *
+ * @lang{EN}
+ * @brief Specialization of `messages_conf` for `char`, with encoding conversion
+ *        via a `wchar_t` converter.
+ *
+ * Loads the UTF-8 translation dictionary from a `.mo` file, then converts
+ * strings to the current `char` encoding using the specified `char`↔`wchar_t`
+ * converter facet. Only supported on platforms where `wchar_t` is UTF-32.
+ * @endif
+ */
 template <>
 class messages_conf<char> : public ft_basic<messages<char>>
 {
 public:
-    // domain, lang and cvt_ft are three distinct strings the caller must supply
-    // (cvt_ft names the char<->wchar_t converter facet, absent from the other
-    // specializations). This is the public, stable construction API, so the
-    // arguments cannot be bundled into a struct without breaking callers or
-    // diverging from the sibling specializations' (domain, lang) shape.
+    /**
+     * @lang{ZH}
+     * @brief 构造函数，加载翻译字典并进行编码转换。
+     *
+     * 与其他特化相比，此特化需要额外的 `cvt_ft` 参数来指定
+     * `char`↔`wchar_t` 转换 facet 的名称。这是公开、稳定的构造 API，
+     * 因此不能将参数打包到结构体中，否则会破坏调用者，或与兄弟特化的
+     * `(domain, lang)` 参数形式产生不一致。
+     *
+     * @param domain 文本域名称。
+     * @param lang 候选语言字符串，或空字符串（使用环境变量）。
+     * @param cvt_ft `char`↔`wchar_t` 转换 facet 的名称。
+     * @param throw_if_fail 如果为 `true`（默认），加载失败时抛出异常；
+     *                      否则静默地使翻译字典为空。
+     * @throw stream_error 如果 `throw_if_fail` 为 `true` 且字典加载失败。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Constructor that loads the translation dictionary with encoding conversion.
+     *
+     * Unlike other specializations, this one requires an extra `cvt_ft` parameter
+     * naming the `char`↔`wchar_t` converter facet. This is the public, stable
+     * construction API, so the arguments cannot be bundled into a struct without
+     * breaking callers or diverging from the sibling specializations'
+     * `(domain, lang)` argument shape.
+     *
+     * @param domain The text domain name.
+     * @param lang The candidate language string, or empty (use environment variables).
+     * @param cvt_ft The name of the `char`↔`wchar_t` converter facet.
+     * @param throw_if_fail If `true` (default), throws on failure; otherwise silently
+     *                      leaves the dictionary empty.
+     * @throw stream_error If `throw_if_fail` is `true` and dictionary loading fails.
+     * @endif
+     */
     // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
     messages_conf(const std::string& domain, const std::string& lang, const std::string& cvt_ft, bool throw_if_fail = true)
         : ft_basic<messages<char>>(domain, lang)
         , m_dict(init(this->dirname(), domain, this->filtered_lang(), cvt_ft, throw_if_fail))
     {}
 
-    // See the char8_t specialization: nullptr means "not found".
+    /**
+     * @lang{ZH}
+     * @brief 查找 `ori` 的翻译。参见 `char8_t` 特化：`nullptr` 表示"未找到"。
+     *
+     * @param ori 原始字符串（`msgid`）。
+     * @return 指向字典中翻译字符串的指针，若未找到则为 `nullptr`。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Looks up the translation for `ori`. See the `char8_t` specialization:
+     *        `nullptr` means "not found".
+     *
+     * @param ori The original string (`msgid`).
+     * @return A pointer to the translation in the dictionary, or `nullptr` if not found.
+     * @endif
+     */
     virtual const std::string* translate(const std::string& ori) const
     {
         auto it = m_dict.find(ori);
@@ -483,9 +1061,39 @@ public:
     }
 
 private:
-    // Mirrors the public ctor's argument shape (see above): dirname/domain are
-    // bundled into a text_domain only where get_domain_file is called below;
-    // lang and cvt_ft remain distinct strings inherent to this char-only API.
+    /**
+     * @lang{ZH}
+     * @brief 加载翻译字典并将 UTF-8 字符串转换为 `char` 编码的私有工厂函数。
+     *
+     * 参数形式与公开构造函数一致：`dirname`/`domain` 仅在调用 `get_domain_file`
+     * 时才打包为 `text_domain`；`lang` 和 `cvt_ft` 保持独立字符串，
+     * 这是 `char` 专属 API 的固有参数形式。
+     *
+     * @param dirname 域目录名。
+     * @param domain 文本域名称。
+     * @param lang 过滤后的语言字符串。
+     * @param cvt_ft `char`↔`wchar_t` 转换 facet 的名称。
+     * @param throw_if_fail 失败时是否抛出异常。
+     * @return 已加载并转换的翻译字典；若 `throw_if_fail` 为 `false` 且失败，则返回空字典。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Private factory function that loads the translation dictionary and
+     *        converts UTF-8 strings to `char` encoding.
+     *
+     * The argument shape mirrors the public constructor: `dirname`/`domain` are
+     * bundled into a `text_domain` only where `get_domain_file` is called;
+     * `lang` and `cvt_ft` remain distinct strings inherent to this `char`-only API.
+     *
+     * @param dirname The domain directory name.
+     * @param domain The text domain name.
+     * @param lang The filtered language string.
+     * @param cvt_ft The name of the `char`↔`wchar_t` converter facet.
+     * @param throw_if_fail Whether to throw on failure.
+     * @return The loaded and converted translation dictionary, or an empty dictionary
+     *         on failure (if `throw_if_fail` is `false`).
+     * @endif
+     */
     // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
     static std::unordered_map<std::string, std::string> init(const std::string& dirname, const std::string& domain, const std::string& lang, const std::string& cvt_ft, bool throw_if_fail)
     {

--- a/include/facet/monetary.h
+++ b/include/facet/monetary.h
@@ -1,3 +1,20 @@
+/**
+ * @file monetary.h
+ * @lang{ZH}
+ * 定义了 `monetary<CharT>` 类，这是货币格式化与解析的用户端 facet。
+ * 它在构造时从 `monetary_conf<CharT>` 快照所有区域设置数据，并提供
+ * `put` 和 `get` 重载，分别用于输出和解析货币字符序列，
+ * 同时支持本地（national）和国际（international）两种格式模式。
+ * @endif
+ *
+ * @lang{EN}
+ * Defines the `monetary<CharT>` class, the user-facing facet for monetary
+ * formatting and parsing. It snapshots all locale data from
+ * `monetary_conf<CharT>` at construction and provides `put` and `get`
+ * overloads for outputting and parsing monetary character sequences,
+ * supporting both national and international format modes.
+ * @endif
+ */
 #pragma once
 #include <common/defs.h>
 #include <common/metafunctions.h>
@@ -22,9 +39,45 @@
 
 namespace IOv2
 {
+/**
+ * @lang{ZH}
+ * @brief 货币格式化与解析的用户端 facet。
+ *
+ * `monetary<CharT>` 在构造时从 `monetary_conf<CharT>` 复制所有区域设置字段
+ * （分组规则、货币符号、符号字符串、格式 pattern、小数点和千位分隔符），
+ * 并以快照方式存储于内部，之后不再依赖 `monetary_conf` 对象。
+ *
+ * - **`put`**：将整数值或预格式化数字字符串格式化为货币字符序列，
+ *   写入输出迭代器。`intl=true` 使用国际格式（如 `"USD 1,234.56"`），
+ *   `intl=false` 使用本地格式（如 `"$1,234.56"`）。
+ * - **`get`**：从字符序列中解析货币字符串，结果存入整数值或数字字符串。
+ *   解析失败时抛出 `stream_error`。
+ *
+ * @tparam CharT 字符类型，由所用的 `monetary_conf` 特化决定。
+ * @endif
+ *
+ * @lang{EN}
+ * @brief User-facing facet for monetary formatting and parsing.
+ *
+ * `monetary<CharT>` copies all locale fields from `monetary_conf<CharT>`
+ * (grouping, currency symbols, sign strings, format patterns, decimal point,
+ * and thousands separator) at construction and stores them as a snapshot,
+ * no longer depending on the `monetary_conf` object afterward.
+ *
+ * - **`put`**: Formats an integral value or a pre-formatted digit string as
+ *   a monetary character sequence written to an output iterator.
+ *   `intl=true` uses the international format (e.g. `"USD 1,234.56"`);
+ *   `intl=false` uses the national format (e.g. `"$1,234.56"`).
+ * - **`get`**: Parses a monetary string from a character sequence into an
+ *   integral value or a digit string. Throws `stream_error` on parse failure.
+ *
+ * @tparam CharT The character type, determined by the `monetary_conf` specialization used.
+ * @endif
+ */
 template <typename CharT>
 class monetary
 {
+    /// @cond
     struct split_info
     {
         std::basic_string<CharT>        m_curr_symbol;
@@ -34,12 +87,44 @@ class monetary
         base_ft<monetary>::pattern      m_neg_format;
         int                             m_frac_digits;
     };
+    /// @endcond
 
 public:
+    /// @cond
     using create_rules = facet_create_rule<monetary_conf<CharT>>;
+    /// @endcond
 
-    using char_type = CharT;
+    using char_type = CharT; ///< @lang{ZH} 此 facet 使用的字符类型。 @endif @lang{EN} The character type used by this facet. @endif
 
+    /**
+     * @lang{ZH}
+     * @brief 构造函数，从指向 `monetary_conf<CharT>` 的共享指针创建 facet。
+     *
+     * 将 `monetary_conf` 中的所有字段一次性复制到内部存储，之后不再访问
+     * 该配置对象。`grouping()` 约定返回**内部约定**格式的分组规则
+     * （1–255 为组大小，0 表示停止，最后一个元素隐式重复）；
+     * POSIX 风格的规范化已在 `monetary_conf` 的 POSIX 边界处完成，此处不再进行。
+     *
+     * @tparam TConfPtr 满足 `shared_ptr_to<monetary_conf<CharT>>` 约束的指针类型。
+     * @param p_obj 指向已初始化的 `monetary_conf<CharT>` 的非空共享指针。
+     * @throw std::runtime_error 如果 `p_obj` 为空。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Constructor that creates the facet from a shared pointer to `monetary_conf<CharT>`.
+     *
+     * Copies all fields from the `monetary_conf` into internal storage in one
+     * shot and does not access the config object afterward. `grouping()` is
+     * contracted to return grouping data in the **internal convention**
+     * (1–255 = group size, 0 = stop, last element implicitly repeats);
+     * POSIX-style normalisation is performed at the POSIX boundary in
+     * `monetary_conf`, not here.
+     *
+     * @tparam TConfPtr A pointer type satisfying `shared_ptr_to<monetary_conf<CharT>>`.
+     * @param p_obj A non-null shared pointer to an initialized `monetary_conf<CharT>`.
+     * @throw std::runtime_error If `p_obj` is empty.
+     * @endif
+     */
     template <shared_ptr_to<monetary_conf<CharT>> TConfPtr>
     monetary(TConfPtr p_obj)
     {
@@ -71,22 +156,238 @@ public:
         // POSIX boundary in monetary_conf, not here.
     }
 
+    /**
+     * @lang{ZH}
+     * @brief 返回数字分组规则（内部约定）。
+     * @return 描述每组位数的字节向量（1–255 为组大小，0 表示停止，最后一个元素隐式重复）。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the digit-grouping specification (internal convention).
+     * @return A byte vector where 1–255 is a group size, 0 means stop, and the
+     *         last element repeats implicitly.
+     * @endif
+     */
     [[nodiscard]] const std::vector<uint8_t>& grouping() const { return m_grouping; }
+
+    /**
+     * @lang{ZH}
+     * @brief 返回国际货币符号字符串（如 `"USD "`）。
+     * @return 国际货币符号。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the international currency symbol string (e.g. `"USD "`).
+     * @return The international currency symbol.
+     * @endif
+     */
     [[nodiscard]] const std::basic_string<CharT>& curr_symbol_int() const { return m_int.m_curr_symbol; }
+
+    /**
+     * @lang{ZH}
+     * @brief 返回本地货币符号字符串（如 `"$"`）。
+     * @return 本地货币符号。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the local (national) currency symbol string (e.g. `"$"`).
+     * @return The local currency symbol.
+     * @endif
+     */
     [[nodiscard]] const std::basic_string<CharT>& curr_symbol_nat() const { return m_nat.m_curr_symbol; }
+
+    /**
+     * @lang{ZH}
+     * @brief 返回国际格式的正数符号字符串。
+     * @return 正数符号（通常为空字符串）。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the positive sign string for the international format.
+     * @return The positive sign (usually an empty string).
+     * @endif
+     */
     [[nodiscard]] const std::basic_string<CharT>& positive_sign_int() const { return m_int.m_positive_sign; }
+
+    /**
+     * @lang{ZH}
+     * @brief 返回本地格式的正数符号字符串。
+     * @return 正数符号（通常为空字符串）。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the positive sign string for the national format.
+     * @return The positive sign (usually an empty string).
+     * @endif
+     */
     [[nodiscard]] const std::basic_string<CharT>& positive_sign_nat() const { return m_nat.m_positive_sign; }
+
+    /**
+     * @lang{ZH}
+     * @brief 返回国际格式的负数符号字符串。
+     * @return 负数符号（如 `"-"` 或 `"()"`）。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the negative sign string for the international format.
+     * @return The negative sign (e.g. `"-"` or `"()"`).
+     * @endif
+     */
     [[nodiscard]] const std::basic_string<CharT>& negative_sign_int() const { return m_int.m_negative_sign; }
+
+    /**
+     * @lang{ZH}
+     * @brief 返回本地格式的负数符号字符串。
+     * @return 负数符号（如 `"-"` 或 `"()"`）。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the negative sign string for the national format.
+     * @return The negative sign (e.g. `"-"` or `"()"`).
+     * @endif
+     */
     [[nodiscard]] const std::basic_string<CharT>& negative_sign_nat() const { return m_nat.m_negative_sign; }
+
+    /**
+     * @lang{ZH}
+     * @brief 返回国际格式正数的排列 pattern。
+     * @return 描述货币符号、符号字符串和数值顺序的 `pattern`。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the positive format pattern for the international format.
+     * @return A `pattern` describing the ordering of symbol, sign string, and value.
+     * @endif
+     */
     [[nodiscard]] const base_ft<monetary>::pattern& pos_format_int() const { return m_int.m_pos_format; }
+
+    /**
+     * @lang{ZH}
+     * @brief 返回本地格式正数的排列 pattern。
+     * @return 描述货币符号、符号字符串和数值顺序的 `pattern`。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the positive format pattern for the national format.
+     * @return A `pattern` describing the ordering of symbol, sign string, and value.
+     * @endif
+     */
     [[nodiscard]] const base_ft<monetary>::pattern& pos_format_nat() const { return m_nat.m_pos_format; }
+
+    /**
+     * @lang{ZH}
+     * @brief 返回国际格式负数的排列 pattern。
+     * @return 描述货币符号、符号字符串和数值顺序的 `pattern`。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the negative format pattern for the international format.
+     * @return A `pattern` describing the ordering of symbol, sign string, and value.
+     * @endif
+     */
     [[nodiscard]] const base_ft<monetary>::pattern& neg_format_int() const { return m_int.m_neg_format; }
+
+    /**
+     * @lang{ZH}
+     * @brief 返回本地格式负数的排列 pattern。
+     * @return 描述货币符号、符号字符串和数值顺序的 `pattern`。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the negative format pattern for the national format.
+     * @return A `pattern` describing the ordering of symbol, sign string, and value.
+     * @endif
+     */
     [[nodiscard]] const base_ft<monetary>::pattern& neg_format_nat() const { return m_nat.m_neg_format; }
+
+    /**
+     * @lang{ZH}
+     * @brief 返回国际货币格式的小数位数。
+     * @return 小数点后的位数。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the number of fractional digits for the international format.
+     * @return The number of digits after the decimal point.
+     * @endif
+     */
     [[nodiscard]] int frac_digits_int() const { return m_int.m_frac_digits; }
+
+    /**
+     * @lang{ZH}
+     * @brief 返回本地货币格式的小数位数。
+     * @return 小数点后的位数。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the number of fractional digits for the national format.
+     * @return The number of digits after the decimal point.
+     * @endif
+     */
     [[nodiscard]] int frac_digits_nat() const { return m_nat.m_frac_digits; }
+
+    /**
+     * @lang{ZH}
+     * @brief 返回货币小数点字符。
+     * @return 小数点字符。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the monetary decimal point character.
+     * @return The decimal point character.
+     * @endif
+     */
     [[nodiscard]] CharT decimal_point() const { return m_decimal_point; }
+
+    /**
+     * @lang{ZH}
+     * @brief 返回千位分隔符字符。
+     * @return 千位分隔符字符。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the thousands separator character.
+     * @return The thousands separator character.
+     * @endif
+     */
     [[nodiscard]] CharT thousands_sep() const { return m_thousands_sep; }
 
+    /**
+     * @lang{ZH}
+     * @brief 将整数货币值格式化为字符序列，写入输出迭代器。
+     *
+     * 先将整数值转换为以 `char_type` 表示的十进制数字字符串
+     * （有符号负数以 `-` 前缀标记），再委托给 `insert` 完成
+     * 货币符号、符号字符串、分组和小数点的组装。
+     *
+     * @tparam TIter 输出迭代器类型。
+     * @tparam TVal 整数类型（不含 `bool`）。
+     * @param s 输出迭代器。
+     * @param intl 若为 `true`，使用国际格式；否则使用本地格式。
+     * @param io 提供格式标志（`showbase`、`adjustfield`）和字段宽度的流对象。
+     * @param v 要格式化的整数货币值。
+     * @return 指向写入结束位置的迭代器。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Formats an integral monetary value as a character sequence written
+     *        to an output iterator.
+     *
+     * Converts the integral value to a decimal digit string represented in
+     * `char_type` (with a `-` prefix for signed negatives), then delegates to
+     * `insert` for assembling the currency symbol, sign string, grouping, and
+     * decimal point.
+     *
+     * @tparam TIter The output iterator type.
+     * @tparam TVal The integral type (not `bool`).
+     * @param s The output iterator.
+     * @param intl If `true`, use the international format; otherwise use national.
+     * @param io The stream object providing format flags (`showbase`, `adjustfield`)
+     *           and field width.
+     * @param v The integral monetary value to format.
+     * @return An iterator pointing past the last written character.
+     * @endif
+     */
     template <typename TIter, std::integral TVal>
         requires (!std::same_as<TVal, bool>)
     TIter put(TIter s, bool intl, ios_base<char_type>& io, TVal v) const
@@ -122,6 +423,37 @@ public:
                     : insert<false>(s, io, p);
     }
 
+    /**
+     * @lang{ZH}
+     * @brief 将预格式化的数字字符串格式化为货币字符序列，写入输出迭代器。
+     *
+     * 数字字符串中的每个字符应为 `s_atoms` 中的元素（`'-'`、`'0'`–`'9'` 的
+     * `char_type` 表示）。直接委托给 `insert` 完成货币格式组装。
+     *
+     * @tparam TIter 输出迭代器类型。
+     * @param s 输出迭代器。
+     * @param intl 若为 `true`，使用国际格式；否则使用本地格式。
+     * @param io 提供格式标志和字段宽度的流对象。
+     * @param digits 以 `char_type` 表示的数字字符串。
+     * @return 指向写入结束位置的迭代器。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Formats a pre-formatted digit string as a monetary character sequence
+     *        written to an output iterator.
+     *
+     * Each character in the digit string should be an element of `s_atoms`
+     * (`char_type` representations of `'-'`, `'0'`–`'9'`). Delegates directly
+     * to `insert` for monetary format assembly.
+     *
+     * @tparam TIter The output iterator type.
+     * @param s The output iterator.
+     * @param intl If `true`, use the international format; otherwise use national.
+     * @param io The stream object providing format flags and field width.
+     * @param digits The digit string represented in `char_type`.
+     * @return An iterator pointing past the last written character.
+     * @endif
+     */
     template <typename TIter>
     TIter put(TIter s, bool intl, ios_base<char_type>& io, const std::basic_string<char_type>& digits) const
     {
@@ -129,6 +461,44 @@ public:
                     : insert<false>(s, io, digits);
     }
 
+    /**
+     * @lang{ZH}
+     * @brief 从字符序列中解析货币字符串并将结果存入整数值。
+     *
+     * 先通过 `extract` 解析出 ASCII 数字字符串，再通过 `str_to_v` 转换为整数。
+     * 任一步骤失败则抛出异常。
+     *
+     * @tparam TIter 输入迭代器类型。
+     * @tparam TSent 哨兵类型。
+     * @tparam TVal 整数类型（不含 `bool`）。
+     * @param beg 指向待解析字符序列起始位置的迭代器。
+     * @param end 序列末尾的哨兵。
+     * @param intl 若为 `true`，按国际格式解析；否则按本地格式解析。
+     * @param io 提供格式标志（`showbase` 等）的流对象。
+     * @param units 解析成功后存储结果的整数引用。
+     * @return 指向已消耗字符之后位置的迭代器。
+     * @throw stream_error 如果解析失败或数值超出 `TVal` 范围。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Parses a monetary string from a character sequence and stores the
+     *        result in an integral value.
+     *
+     * Calls `extract` to parse an ASCII digit string, then converts it to an
+     * integer via `str_to_v`. Throws on failure at either step.
+     *
+     * @tparam TIter The input iterator type.
+     * @tparam TSent The sentinel type.
+     * @tparam TVal The integral type (not `bool`).
+     * @param beg An iterator to the start of the character sequence to parse.
+     * @param end The sentinel marking the end of the sequence.
+     * @param intl If `true`, parse as international format; otherwise as national.
+     * @param io The stream object providing format flags (e.g. `showbase`).
+     * @param units A reference to the integral variable that receives the result.
+     * @return An iterator pointing past the last consumed character.
+     * @throw stream_error If parsing fails or the value is out of range for `TVal`.
+     * @endif
+     */
     template <typename TIter, std::sentinel_for<TIter> TSent, std::integral TVal>
         requires (!std::same_as<TVal, bool>)
     TIter get(TIter beg, TSent end, bool intl, ios_base<char_type>& io, TVal& units) const
@@ -147,6 +517,45 @@ public:
         return beg;
     }
 
+    /**
+     * @lang{ZH}
+     * @brief 从字符序列中解析货币字符串并将结果存入数字字符串。
+     *
+     * 解析完成后，结果字符串中的每个字符为 `s_atoms` 中对应的 `char_type`
+     * 元素（`'-'` 对应索引 0，`'0'`–`'9'` 对应索引 1–10）。
+     * 解析失败时抛出异常；解析成功但未提取到数字时不修改 `digits`。
+     *
+     * @tparam TIter 输入迭代器类型。
+     * @tparam TSent 哨兵类型。
+     * @param beg 指向待解析字符序列起始位置的迭代器。
+     * @param end 序列末尾的哨兵。
+     * @param intl 若为 `true`，按国际格式解析；否则按本地格式解析。
+     * @param io 提供格式标志的流对象。
+     * @param digits 解析成功后存储结果数字字符串的引用；若无数字则保持不变。
+     * @return 指向已消耗字符之后位置的迭代器。
+     * @throw stream_error 如果解析失败。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Parses a monetary string from a character sequence and stores the
+     *        result in a digit string.
+     *
+     * In the result string each character is a `char_type` element from `s_atoms`
+     * (`'-'` at index 0, `'0'`–`'9'` at indices 1–10). Throws on parse failure;
+     * leaves `digits` unmodified if parsing succeeds but no digits were extracted.
+     *
+     * @tparam TIter The input iterator type.
+     * @tparam TSent The sentinel type.
+     * @param beg An iterator to the start of the character sequence to parse.
+     * @param end The sentinel marking the end of the sequence.
+     * @param intl If `true`, parse as international format; otherwise as national.
+     * @param io The stream object providing format flags.
+     * @param digits A reference to the digit string that receives the result;
+     *               left unchanged if no digits are extracted.
+     * @return An iterator pointing past the last consumed character.
+     * @throw stream_error If parsing fails.
+     * @endif
+     */
     template <typename TIter, std::sentinel_for<TIter> TSent>
     TIter get(TIter beg, TSent end, bool intl, ios_base<char_type>& io, std::basic_string<char_type>& digits) const
     {
@@ -176,6 +585,60 @@ public:
     }
 
 private:
+    /**
+     * @lang{ZH}
+     * @brief 将数字字符串按货币格式组装为结果字符串并写入输出迭代器。
+     *
+     * 模板参数 `isIntl` 静态选择国际（`m_int`）或本地（`m_nat`）格式数据。
+     * 函数先捕获并清零字段宽度（宽度是一次性的，必须在任何可能抛出的操作之前清零，
+     * 以防宽度泄漏到下一次输出），再按以下步骤组装：
+     * - 检测首字符是否为负数符号，选择正/负 pattern 及符号字符串。
+     * - 扫描有效的数字字符（基于 `s_atoms`），得到数字部分长度。
+     * - 对整数部分按分组规则插入千位分隔符。
+     * - 按 `m_frac_digits` 添加小数点和小数部分，不足时补零。
+     * - 遍历 pattern，将 `symbol`、`sign`、`value`、`space`/`none` 按序拼接，
+     *   在 `ios_defs::internal` 模式下于 `space`/`none` 位置插入填充字符。
+     * - 追加多字符符号字符串的剩余部分。
+     * - 对整体结果应用左对齐或右对齐填充。
+     *
+     * @tparam isIntl 若为 `true`，使用国际格式数据；否则使用本地格式数据。
+     * @tparam TIter 输出迭代器类型。
+     * @param s 输出迭代器。
+     * @param io 提供格式标志和字段宽度的流对象。
+     * @param digits 以 `char_type` 表示的数字字符串（可含前导 `-`）。
+     * @return 指向写入结束位置的迭代器。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Assembles a digit string into a formatted monetary string and writes
+     *        it to an output iterator.
+     *
+     * The template parameter `isIntl` statically selects international (`m_int`)
+     * or national (`m_nat`) format data. The function first captures and clears
+     * the field width (width is one-shot and must be cleared before any
+     * potentially-throwing operation to prevent it leaking into the next output),
+     * then proceeds as follows:
+     * - Detects whether the first character is a negative sign to select
+     *   the positive/negative pattern and sign string.
+     * - Scans valid digit characters (based on `s_atoms`) to determine the
+     *   digit-part length.
+     * - Inserts thousands separators into the integer part per grouping rules.
+     * - Appends the decimal point and fractional part (zero-padded if needed)
+     *   according to `m_frac_digits`.
+     * - Traverses the pattern, concatenating `symbol`, `sign`, `value`, and
+     *   `space`/`none` in order, inserting fill characters at `space`/`none`
+     *   positions in `ios_defs::internal` mode.
+     * - Appends remaining characters of a multi-character sign string.
+     * - Applies left or right alignment padding to the overall result.
+     *
+     * @tparam isIntl If `true`, use international format data; otherwise national.
+     * @tparam TIter The output iterator type.
+     * @param s The output iterator.
+     * @param io The stream object providing format flags and field width.
+     * @param digits The digit string in `char_type` (may have a leading `-`).
+     * @return An iterator pointing past the last written character.
+     * @endif
+     */
     template <bool isIntl, typename TIter>
     TIter insert(TIter s, ios_base<char_type>& io, const std::basic_string<char_type>& digits) const
     {
@@ -328,6 +791,74 @@ private:
         return s;
     }
 
+    /**
+     * @lang{ZH}
+     * @brief 从字符序列中按货币格式解析数字字符串。
+     *
+     * 模板参数 `isIntl` 静态选择国际（`m_int`）或本地（`m_nat`）格式数据。
+     * 始终按负数 pattern 遍历，逐段处理：
+     * - **`symbol`**：当 `showbase` 置位、或其他因素使符号为必须时进行匹配；
+     *   否则可选，仅在不影响其他 part 解析的情况下消耗。
+     * - **`sign`**：消耗正/负符号的第一个字符，记录符号极性和长度；
+     *   若正符号存在而负符号为空，则按 C++ 标准将缺失的符号解读为负号。
+     * - **`value`**：提取数字字符（基于 `s_atoms`），处理千位分隔符（计入
+     *   分组向量供后续验证）和小数点。首个未知字符终止提取。
+     * - **`space`/`none`**：消耗填充字符，`space` 至少需要一个。
+     *
+     * 全部 pattern 处理完毕后：
+     * - 消耗多字符符号字符串的剩余部分。
+     * - 去除前导零（保留至少一位）。
+     * - 对负值在首位插入 `'-'`。
+     * - 验证千位分组是否与 `m_grouping` 一致。
+     * - 检查小数部分的位数是否与 `m_frac_digits` 相符。
+     *
+     * @tparam isIntl 若为 `true`，使用国际格式数据；否则使用本地格式数据。
+     * @tparam TIter 输入迭代器类型。
+     * @tparam TSent 哨兵类型。
+     * @param beg 指向待解析字符序列起始位置的迭代器。
+     * @param end 序列末尾的哨兵。
+     * @param io 提供格式标志（`showbase` 等）和填充字符的流对象。
+     * @param units 解析出的 ASCII 数字字符串（含可选前导 `'-'`）的输出引用。
+     * @return 包含成功标志和已消耗字符末尾迭代器的 `std::pair`。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Parses a digit string from a character sequence according to
+     *        a monetary format.
+     *
+     * The template parameter `isIntl` statically selects international (`m_int`)
+     * or national (`m_nat`) format data. Always traverses the negative pattern,
+     * processing each part:
+     * - **`symbol`**: Matched when `showbase` is set or other conditions require
+     *   it; otherwise optional, consumed only if it does not prevent parsing
+     *   other parts.
+     * - **`sign`**: Consumes the first character of the positive/negative sign,
+     *   recording polarity and length; if the positive sign exists but the
+     *   negative sign is empty, a missing sign is interpreted as negative per
+     *   the C++ standard.
+     * - **`value`**: Extracts digit characters (based on `s_atoms`), handling
+     *   thousands separators (recorded in a grouping vector for later
+     *   verification) and the decimal point. The first unknown character stops
+     *   extraction.
+     * - **`space`/`none`**: Consumes fill characters; `space` requires at least one.
+     *
+     * After processing all pattern parts:
+     * - Consumes remaining characters of a multi-character sign string.
+     * - Strips leading zeros (keeping at least one digit).
+     * - Prepends `'-'` for negative values.
+     * - Verifies that thousands grouping matches `m_grouping`.
+     * - Checks that the fractional digit count matches `m_frac_digits`.
+     *
+     * @tparam isIntl If `true`, use international format data; otherwise national.
+     * @tparam TIter The input iterator type.
+     * @tparam TSent The sentinel type.
+     * @param beg An iterator to the start of the character sequence to parse.
+     * @param end The sentinel marking the end of the sequence.
+     * @param io The stream object providing format flags (e.g. `showbase`) and fill char.
+     * @param units Output reference for the parsed ASCII digit string (with optional leading `'-'`).
+     * @return A `std::pair` of a success flag and an iterator past the last consumed character.
+     * @endif
+     */
     template <bool isIntl, typename TIter, std::sentinel_for<TIter> TSent>
     std::pair<bool, TIter> extract(TIter beg, TSent end, ios_base<char_type>& io, std::string& units) const
     {
@@ -523,6 +1054,36 @@ private:
         return std::pair(succ, beg);
     }
 
+    /**
+     * @lang{ZH}
+     * @brief 将 ASCII 十进制数字字符串转换为整数值，含溢出检测。
+     *
+     * 支持有符号和无符号整数类型（通过 `if constexpr` 分支）。
+     * 对有符号类型，溢出检测基于 `min_value`/`max_value`；
+     * 对无符号类型，不接受前导 `'-'`。字符串为空或含非数字字符时返回 `false`。
+     *
+     * @tparam TVal 整数类型。
+     * @param s 以 ASCII 表示的十进制数字字符串（可含前导 `'-'` 或 `'+'`）。
+     * @param value 转换结果的输出引用。
+     * @return 转换成功返回 `true`，字符串为空/含非法字符/溢出时返回 `false`。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Converts an ASCII decimal digit string to an integral value with
+     *        overflow detection.
+     *
+     * Handles both signed and unsigned integral types via `if constexpr` branches.
+     * Overflow detection for signed types uses `min_value`/`max_value`; unsigned
+     * types do not accept a leading `'-'`. Returns `false` if the string is empty
+     * or contains non-digit characters.
+     *
+     * @tparam TVal The integral type.
+     * @param s An ASCII decimal digit string (may have a leading `'-'` or `'+'`).
+     * @param value Output reference for the conversion result.
+     * @return `true` on success; `false` if the string is empty, contains illegal
+     *         characters, or would overflow.
+     * @endif
+     */
     template <std::integral TVal>
     bool str_to_v(const std::string& s, TVal& value) const
     {
@@ -587,8 +1148,8 @@ private:
     }
 
 private:
-    static constexpr size_t s_minus = 0;
-    static constexpr size_t s_zero = 1;
+    static constexpr size_t s_minus = 0; // index into s_atoms for the '-' character
+    static constexpr size_t s_zero  = 1; // index into s_atoms for the '0' character
 
 private:
     std::vector<uint8_t>      m_grouping;
@@ -597,6 +1158,9 @@ private:
     CharT                     m_decimal_point;
     CharT                     m_thousands_sep;
 
+    // char_type representations of '-' and '0'-'9', indexed as:
+    //   s_atoms[0]    = '-'
+    //   s_atoms[1..10] = '0'..'9'
     static constexpr std::array<char_type, 11> s_atoms = {
             (char_type)'-', (char_type)'0', (char_type)'1', (char_type)'2',
             (char_type)'3', (char_type)'4', (char_type)'5', (char_type)'6',
@@ -604,6 +1168,8 @@ private:
         };
 };
 
+/// @cond
 template<typename TConfPtr>
 monetary(TConfPtr) -> monetary<typename TConfPtr::element_type::char_type>;
+/// @endcond
 }

--- a/include/facet/monetary_details.h
+++ b/include/facet/monetary_details.h
@@ -1,3 +1,21 @@
+/**
+ * @file monetary_details.h
+ * @lang{ZH}
+ * 定义了 `monetary` facet 的实现细节，包括 `base_ft<monetary>` 基类和
+ * `monetary_conf` 的各字符类型特化。`base_ft<monetary>` 提供基于 POSIX
+ * `lconv` 标志的货币格式 pattern 构造工具；`monetary_conf` 的各特化
+ * 在此基础上从区域设置名称读取 `lconv`，填充货币格式化所需的全部字段。
+ * @endif
+ *
+ * @lang{EN}
+ * Defines the implementation details of the `monetary` facet, including
+ * the `base_ft<monetary>` base class and per-character-type specializations
+ * of `monetary_conf`. `base_ft<monetary>` provides pattern-construction
+ * utilities driven by POSIX `lconv` flags; the `monetary_conf` specializations
+ * read `lconv` from a locale name and populate all fields required for
+ * monetary formatting.
+ * @endif
+ */
 #pragma once
 #include <common/clocale_wrapper.h>
 #include <common/metafunctions.h>
@@ -19,28 +37,152 @@ namespace IOv2
 {
 template <typename CharT> class monetary;
 
+/**
+ * @lang{ZH}
+ * @brief `monetary` facet 的基类，提供 POSIX `lconv` 到货币格式 pattern 的转换工具。
+ *
+ * 该类定义了表示货币格式组成部分的 `part` 枚举、描述完整格式顺序的 `pattern` 类型，
+ * 以及将 POSIX `*_cs_precedes`、`*_sep_by_space` 和 `*_sign_posn` 标志转换为
+ * `pattern` 的受保护静态工具函数。`monetary_conf` 的各特化继承此基类。
+ *
+ * @note 该类不直接实例化，仅作为 `monetary_conf` 的基类使用。
+ * @endif
+ *
+ * @lang{EN}
+ * @brief Base class for the `monetary` facet, providing POSIX `lconv`-to-pattern
+ *        conversion utilities.
+ *
+ * This class defines the `part` enum representing the components of a monetary
+ * format, the `pattern` type describing a complete format ordering, and
+ * protected static helpers that convert POSIX `*_cs_precedes`, `*_sep_by_space`,
+ * and `*_sign_posn` flags into a `pattern`. The `monetary_conf` specializations
+ * inherit from this class.
+ *
+ * @note This class is not instantiated directly; it serves only as the
+ *       base for `monetary_conf`.
+ * @endif
+ */
 template <>
 class base_ft<monetary> : public abs_ft
 {
 public:
     using abs_ft::abs_ft;
 
-    enum class part : std::uint8_t { none, space, symbol, sign, value };
+    /**
+     * @lang{ZH}
+     * @brief 货币格式 pattern 中各组成部分的枚举。
+     *
+     * 每个 `pattern` 由四个 `part` 值组成，依次描述货币字符串中
+     * 货币符号、符号与数值之间的空格、符号字符串和数值的排列顺序。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Enumeration of the components that make up a monetary format pattern.
+     *
+     * Each `pattern` consists of four `part` values that together describe the
+     * ordering of the currency symbol, optional space, sign string, and value
+     * within a formatted monetary string.
+     * @endif
+     */
+    enum class part : std::uint8_t
+    {
+        none,   ///< @lang{ZH} 占位槽，不输出任何内容（通常作为 pattern 末尾的填充）。 @endif @lang{EN} Padding slot that emits nothing (typically used at the end of a pattern). @endif
+        space,  ///< @lang{ZH} 货币符号与数值之间的空格。 @endif @lang{EN} Space separator between the currency symbol and the value. @endif
+        symbol, ///< @lang{ZH} 货币符号字符串。 @endif @lang{EN} Currency symbol string. @endif
+        sign,   ///< @lang{ZH} 正负符号字符串。 @endif @lang{EN} Sign string (positive or negative). @endif
+        value   ///< @lang{ZH} 货币数值部分。 @endif @lang{EN} Monetary value digits. @endif
+    };
+
+    /**
+     * @lang{ZH}
+     * @brief 描述货币字符串完整格式顺序的 pattern 类型。
+     *
+     * 由四个 `part` 值组成的固定长度数组，各元素依次指定输出的组成部分。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Pattern type describing the complete ordering of a monetary string.
+     *
+     * A fixed-length array of four `part` values, each specifying one output
+     * component in order.
+     * @endif
+     */
     using pattern = std::array<part, 4>;
 
-    // Groups the three POSIX lconv flags that drive s_construct_pattern into one
-    // named argument. They are all small integers and trivially swapped if passed
-    // positionally (bugprone-easily-swappable-parameters); naming the fields here
-    // makes each call site self-documenting and the swap impossible.
+    /**
+     * @lang{ZH}
+     * @brief 将驱动 `s_construct_pattern` 的三个 POSIX `lconv` 标志捆绑为一个具名参数。
+     *
+     * 这三个字段均为小整数，若以位置参数传递极易被意外交换
+     * （bugprone-easily-swappable-parameters）；在此将它们命名化，
+     * 使每处调用自我说明，且不可能发生参数交换。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Groups the three POSIX `lconv` flags that drive `s_construct_pattern`
+     *        into one named argument.
+     *
+     * These are all small integers and trivially swapped if passed positionally
+     * (bugprone-easily-swappable-parameters); naming the fields here makes each
+     * call site self-documenting and the swap impossible.
+     * @endif
+     */
     struct pattern_spec
     {
-        int8_t precedes;      // *_cs_precedes:  symbol precedes (1) or follows (0) the value
-        int8_t sep_by_space;  // *_sep_by_space: a space separates symbol and value
-        int    sign_posn;     // *_sign_posn:    sign placement (0..4)
+        int8_t precedes;     ///< @lang{ZH} `*_cs_precedes`：货币符号在数值之前（1）还是之后（0）。 @endif @lang{EN} `*_cs_precedes`: symbol precedes (1) or follows (0) the value. @endif
+        int8_t sep_by_space; ///< @lang{ZH} `*_sep_by_space`：货币符号与数值之间是否有空格。 @endif @lang{EN} `*_sep_by_space`: a space separates symbol and value. @endif
+        int    sign_posn;    ///< @lang{ZH} `*_sign_posn`：符号的位置（0..4）。 @endif @lang{EN} `*_sign_posn`: sign placement (0..4). @endif
     };
 
 protected:
+    /**
+     * @lang{ZH}
+     * @brief 当区域设置的 `sign_posn` 超出范围时使用的默认 pattern。
+     *
+     * 格式为 `symbol sign none value`，对应货币符号在前、符号字符串紧随其后的保守布局。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Default pattern used when the locale's `sign_posn` is out of range.
+     *
+     * The format is `symbol sign none value`, a conservative layout with the
+     * currency symbol first followed immediately by the sign string.
+     * @endif
+     */
     inline const static pattern s_default_pattern = {part::symbol, part::sign, part::none, part::value};
+
+    /**
+     * @lang{ZH}
+     * @brief 根据 POSIX `lconv` 标志构建货币格式 pattern。
+     *
+     * 依据 `pattern_spec` 中的三个标志（符号位置、空格、符号字符串位置）
+     * 组合出满足 `moneypunct` 约束的四元素 pattern。
+     * 基本不变量：
+     * - 若 `precedes`，则输出顺序中 `symbol` 在 `value` 之前；否则相反。
+     * - 若 `sep_by_space`，则在 `symbol` 与 `value` 之间插入 `space`；否则插入 `none`。
+     * - `none` 不能作为第一个元素；`space` 不能作为第一个或最后一个元素。
+     * - `sign_posn` 超出范围（默认分支）时回退到 `s_default_pattern`。
+     *
+     * @param spec 包含 `precedes`、`sep_by_space` 和 `sign_posn` 的规格结构体。
+     * @return 构造出的四元素 `pattern`。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Builds a monetary format pattern from POSIX `lconv` flags.
+     *
+     * Combines the three flags in `pattern_spec` (symbol position, space,
+     * sign-string position) into a four-element `pattern` that satisfies
+     * `moneypunct` constraints. Key invariants:
+     * - If `precedes`, `symbol` comes before `value` in the output; otherwise reversed.
+     * - If `sep_by_space`, a `space` is inserted between `symbol` and `value`;
+     *   otherwise `none` is used.
+     * - `none` is never the first element; `space` is never first or last.
+     * - An out-of-range `sign_posn` (default branch) falls back to `s_default_pattern`.
+     *
+     * @param spec A spec struct containing `precedes`, `sep_by_space`, and `sign_posn`.
+     * @return The constructed four-element `pattern`.
+     * @endif
+     */
     static pattern s_construct_pattern(pattern_spec spec)
     {
         using enum part;
@@ -204,27 +346,87 @@ protected:
         return ret;
     }
 
-    // POSIX fills lconv's *_cs_precedes / *_sep_by_space with CHAR_MAX when the
-    // field is "not available" in the locale. s_construct_pattern interprets
-    // these flags as booleans, where a raw CHAR_MAX would wrongly read as truthy
-    // (i.e. "symbol precedes" / "space present"); map the sentinel to 0 — the
-    // conservative default — mirroring the frac_digits handling. The test must
-    // happen before any narrowing, so callers pass the raw `char` lconv field
-    // here rather than the narrowed argument. (*_sign_posn needs no such helper:
-    // its CHAR_MAX is already funnelled to s_default_pattern by the switch's
-    // default branch.)
+    /**
+     * @lang{ZH}
+     * @brief 将 POSIX `lconv` 的布尔标志字段规范化，消除 `CHAR_MAX` 哨兵值。
+     *
+     * POSIX 规定，当区域设置不提供 `*_cs_precedes` 或 `*_sep_by_space` 字段时，
+     * `lconv` 将其填充为 `CHAR_MAX`。`s_construct_pattern` 把这些标志视为布尔值，
+     * 原始的 `CHAR_MAX` 将错误地被解读为真值（即"符号在前"或"有空格"）；
+     * 此函数将哨兵值映射为 0（保守默认值），与 `frac_digits` 的处理方式一致。
+     * 必须在任何窄化转换之前执行此检查，因此调用者应传入原始的 `char` 类型 `lconv`
+     * 字段，而非已窄化后的参数。（`*_sign_posn` 不需要此辅助函数：其 `CHAR_MAX`
+     * 已由 switch 的默认分支导向 `s_default_pattern`。）
+     *
+     * @param v 原始的 `char` 类型 `lconv` 标志字段。
+     * @return 规范化后的值：若 `v == CHAR_MAX` 则返回 `0`，否则返回 `static_cast<int8_t>(v)`。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Normalizes a POSIX `lconv` boolean-flag field by eliminating the
+     *        `CHAR_MAX` sentinel.
+     *
+     * POSIX fills `lconv`'s `*_cs_precedes` / `*_sep_by_space` with `CHAR_MAX`
+     * when the field is "not available" in the locale. `s_construct_pattern`
+     * interprets these flags as booleans, where a raw `CHAR_MAX` would wrongly
+     * read as truthy (i.e. "symbol precedes" / "space present"); this function
+     * maps the sentinel to 0 — the conservative default — mirroring the
+     * `frac_digits` handling. The test must happen before any narrowing, so
+     * callers pass the raw `char` `lconv` field here rather than the narrowed
+     * argument. (`*_sign_posn` needs no such helper: its `CHAR_MAX` is already
+     * funnelled to `s_default_pattern` by the switch's default branch.)
+     *
+     * @param v The raw `char` `lconv` flag field.
+     * @return The normalized value: `0` if `v == CHAR_MAX`, otherwise `static_cast<int8_t>(v)`.
+     * @endif
+     */
     static int8_t s_norm_flag(char v) { return (v == CHAR_MAX) ? int8_t{0} : static_cast<int8_t>(v); }
 };
 
 template <typename CharT> class monetary_conf;
 
+/**
+ * @lang{ZH}
+ * @brief `monetary_conf` 的 `char` 特化，从 POSIX `lconv` 直接读取货币格式化数据。
+ *
+ * 对于 `"C"` 和 `"POSIX"` 区域设置，使用硬编码的默认值；
+ * 对于其他区域设置，通过 `clocale_wrapper` 切换至目标区域设置并调用
+ * `localeconv()` 读取数据。所有 `lconv` 字段在任何转换操作之前整体快照，
+ * 以避免转换器内部的 `setlocale()`/`uselocale()` 调用使 `lconv` 指针失效。
+ * @endif
+ *
+ * @lang{EN}
+ * @brief Specialization of `monetary_conf` for `char`, reading monetary formatting
+ *        data directly from POSIX `lconv`.
+ *
+ * For the `"C"` and `"POSIX"` locales, hard-coded defaults are used.
+ * For other locales, the target locale is switched via `clocale_wrapper`
+ * and `localeconv()` is called to read the data. All `lconv` fields are
+ * snapshotted in bulk before any conversion operation, to prevent the
+ * converter's internal `setlocale()`/`uselocale()` calls from invalidating
+ * the `lconv` pointers.
+ * @endif
+ */
 template <>
 class monetary_conf<char> : public ft_basic<monetary<char>>
 {
 public:
-    using char_type = char;
+    using char_type = char; ///< @lang{ZH} 此特化使用的字符类型。 @endif @lang{EN} The character type used by this specialization. @endif
 
 public:
+    /**
+     * @lang{ZH}
+     * @brief 构造函数，从指定区域设置名称读取货币格式化数据。
+     *
+     * @param name 区域设置名称（如 `"en_US.UTF-8"`），或 `"C"`/`"POSIX"` 使用默认值。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Constructor that reads monetary formatting data from the named locale.
+     *
+     * @param name The locale name (e.g. `"en_US.UTF-8"`), or `"C"`/`"POSIX"` for defaults.
+     * @endif
+     */
     monetary_conf(const std::string& name)
         : ft_basic<monetary<char>>()
     {
@@ -340,20 +542,200 @@ public:
     }
 
 public:
+    /**
+     * @lang{ZH}
+     * @brief 返回数字分组规则。
+     * @return 描述每组位数的字节向量（POSIX 规范，末尾为 0 表示重复最后一组）。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the digit-grouping specification.
+     * @return A byte vector describing the number of digits per group (POSIX convention,
+     *         trailing 0 means repeat the last group).
+     * @endif
+     */
     [[nodiscard]] virtual const std::vector<uint8_t>& grouping() const { return m_grouping; }
+
+    /**
+     * @lang{ZH}
+     * @brief 返回国际货币符号字符串（如 `"USD "`）。
+     * @return 国际货币符号。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the international currency symbol string (e.g. `"USD "`).
+     * @return The international currency symbol.
+     * @endif
+     */
     [[nodiscard]] virtual const std::string& curr_symbol_int() const { return m_curr_symbol_int; }
+
+    /**
+     * @lang{ZH}
+     * @brief 返回本地货币符号字符串（如 `"$"`）。
+     * @return 本地货币符号。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the local (national) currency symbol string (e.g. `"$"`).
+     * @return The local currency symbol.
+     * @endif
+     */
     [[nodiscard]] virtual const std::string& curr_symbol_nat() const { return m_curr_symbol_nat; }
+
+    /**
+     * @lang{ZH}
+     * @brief 返回国际格式的正数符号字符串。
+     * @return 正数符号（通常为空字符串）。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the positive sign string for the international format.
+     * @return The positive sign (usually an empty string).
+     * @endif
+     */
     [[nodiscard]] virtual const std::string& positive_sign_int() const { return m_positive_sign_int; }
+
+    /**
+     * @lang{ZH}
+     * @brief 返回本地格式的正数符号字符串。
+     * @return 正数符号（通常为空字符串）。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the positive sign string for the national format.
+     * @return The positive sign (usually an empty string).
+     * @endif
+     */
     [[nodiscard]] virtual const std::string& positive_sign_nat() const { return m_positive_sign_nat; }
+
+    /**
+     * @lang{ZH}
+     * @brief 返回国际格式的负数符号字符串。
+     * @return 负数符号（如 `"-"` 或 `"()"`）。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the negative sign string for the international format.
+     * @return The negative sign (e.g. `"-"` or `"()"`).
+     * @endif
+     */
     [[nodiscard]] virtual const std::string& negative_sign_int() const { return m_negative_sign_int; }
+
+    /**
+     * @lang{ZH}
+     * @brief 返回本地格式的负数符号字符串。
+     * @return 负数符号（如 `"-"` 或 `"()"`）。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the negative sign string for the national format.
+     * @return The negative sign (e.g. `"-"` or `"()"`).
+     * @endif
+     */
     [[nodiscard]] virtual const std::string& negative_sign_nat() const { return m_negative_sign_nat; }
+
+    /**
+     * @lang{ZH}
+     * @brief 返回国际格式正数的排列 pattern。
+     * @return 描述货币符号、符号字符串和数值顺序的 `pattern`。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the positive format pattern for the international format.
+     * @return A `pattern` describing the ordering of symbol, sign string, and value.
+     * @endif
+     */
     [[nodiscard]] virtual const pattern& pos_format_int() const { return m_pos_format_int; }
+
+    /**
+     * @lang{ZH}
+     * @brief 返回本地格式正数的排列 pattern。
+     * @return 描述货币符号、符号字符串和数值顺序的 `pattern`。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the positive format pattern for the national format.
+     * @return A `pattern` describing the ordering of symbol, sign string, and value.
+     * @endif
+     */
     [[nodiscard]] virtual const pattern& pos_format_nat() const { return m_pos_format_nat; }
+
+    /**
+     * @lang{ZH}
+     * @brief 返回国际格式负数的排列 pattern。
+     * @return 描述货币符号、符号字符串和数值顺序的 `pattern`。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the negative format pattern for the international format.
+     * @return A `pattern` describing the ordering of symbol, sign string, and value.
+     * @endif
+     */
     [[nodiscard]] virtual const pattern& neg_format_int() const { return m_neg_format_int; }
+
+    /**
+     * @lang{ZH}
+     * @brief 返回本地格式负数的排列 pattern。
+     * @return 描述货币符号、符号字符串和数值顺序的 `pattern`。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the negative format pattern for the national format.
+     * @return A `pattern` describing the ordering of symbol, sign string, and value.
+     * @endif
+     */
     [[nodiscard]] virtual const pattern& neg_format_nat() const { return m_neg_format_nat; }
+
+    /**
+     * @lang{ZH}
+     * @brief 返回国际货币格式的小数位数。
+     * @return 小数点后的位数。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the number of fractional digits for the international format.
+     * @return The number of digits after the decimal point.
+     * @endif
+     */
     [[nodiscard]] virtual int frac_digits_int() const { return m_frac_digits_int; }
+
+    /**
+     * @lang{ZH}
+     * @brief 返回本地货币格式的小数位数。
+     * @return 小数点后的位数。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the number of fractional digits for the national format.
+     * @return The number of digits after the decimal point.
+     * @endif
+     */
     [[nodiscard]] virtual int frac_digits_nat() const { return m_frac_digits_nat; }
+
+    /**
+     * @lang{ZH}
+     * @brief 返回货币小数点字符。
+     * @return 小数点字符（如 `'.'`）。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the monetary decimal point character.
+     * @return The decimal point character (e.g. `'.'`).
+     * @endif
+     */
     [[nodiscard]] virtual char decimal_point() const { return m_decimal_point; }
+
+    /**
+     * @lang{ZH}
+     * @brief 返回千位分隔符字符。
+     * @return 千位分隔符字符（如 `','`）。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the thousands separator character.
+     * @return The thousands separator character (e.g. `','`).
+     * @endif
+     */
     [[nodiscard]] virtual char thousands_sep() const { return m_thousands_sep; }
 
 private:
@@ -374,6 +756,33 @@ private:
     char                    m_thousands_sep;
 };
 
+/**
+ * @lang{ZH}
+ * @brief `monetary_conf` 的 `wchar_t`/`char32_t` 特化，以宽字符存储货币格式化数据。
+ *
+ * 对于 `"C"` 和 `"POSIX"` 区域设置，使用硬编码的宽字符默认值；
+ * 对于其他区域设置，通过 `clocale_wrapper` 切换至目标区域设置，
+ * 从 `localeconv()` 读取所有窄字符字段并将其批量快照，再通过
+ * `detail::to_wstring` / `detail::to_u32string` 转换为宽字符。
+ * 仅当 `CharT` 为 `wchar_t`，或 `char32_t` 且 `wchar_t` 为 UTF-32 时启用此特化。
+ *
+ * @tparam CharT 字符类型，必须为 `wchar_t` 或（在 UTF-32 wchar_t 平台上的）`char32_t`。
+ * @endif
+ *
+ * @lang{EN}
+ * @brief Specialization of `monetary_conf` for `wchar_t` / `char32_t`, storing
+ *        monetary formatting data as wide characters.
+ *
+ * For the `"C"` and `"POSIX"` locales, hard-coded wide-character defaults are used.
+ * For other locales, the target locale is switched via `clocale_wrapper`,
+ * all narrow fields are read from `localeconv()` and snapshotted in bulk,
+ * then converted to wide characters via `detail::to_wstring` / `detail::to_u32string`.
+ * This specialization is enabled only when `CharT` is `wchar_t`, or `char32_t`
+ * on a platform where `wchar_t` is UTF-32.
+ *
+ * @tparam CharT The character type; must be `wchar_t` or (on a UTF-32 `wchar_t` platform) `char32_t`.
+ * @endif
+ */
 template <typename CharT>
     requires std::is_same_v<CharT, wchar_t> ||
                 (std::is_same_v<CharT, char32_t> &&
@@ -381,9 +790,23 @@ template <typename CharT>
 class monetary_conf<CharT> : public ft_basic<monetary<CharT>>
 {
 public:
-    using char_type = CharT;
+    using char_type = CharT; ///< @lang{ZH} 此特化使用的字符类型。 @endif @lang{EN} The character type used by this specialization. @endif
 
 public:
+    /**
+     * @lang{ZH}
+     * @brief 构造函数，从指定区域设置名称读取货币格式化数据并转换为宽字符。
+     *
+     * @param name 区域设置名称（如 `"zh_CN.UTF-8"`），或 `"C"`/`"POSIX"` 使用默认值。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Constructor that reads monetary formatting data from the named locale
+     *        and converts it to wide characters.
+     *
+     * @param name The locale name (e.g. `"zh_CN.UTF-8"`), or `"C"`/`"POSIX"` for defaults.
+     * @endif
+     */
     monetary_conf(const std::string& name)
         : ft_basic<monetary<CharT>>()
     {
@@ -551,20 +974,199 @@ public:
     }
 
 public:
+    /**
+     * @lang{ZH}
+     * @brief 返回数字分组规则。
+     * @return 描述每组位数的字节向量。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the digit-grouping specification.
+     * @return A byte vector describing the number of digits per group.
+     * @endif
+     */
     [[nodiscard]] virtual const std::vector<uint8_t>& grouping() const { return m_grouping; }
+
+    /**
+     * @lang{ZH}
+     * @brief 返回国际货币符号字符串。
+     * @return 国际货币符号。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the international currency symbol string.
+     * @return The international currency symbol.
+     * @endif
+     */
     [[nodiscard]] virtual const std::basic_string<CharT>& curr_symbol_int() const { return m_curr_symbol_int; }
+
+    /**
+     * @lang{ZH}
+     * @brief 返回本地货币符号字符串。
+     * @return 本地货币符号。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the local (national) currency symbol string.
+     * @return The local currency symbol.
+     * @endif
+     */
     [[nodiscard]] virtual const std::basic_string<CharT>& curr_symbol_nat() const { return m_curr_symbol_nat; }
+
+    /**
+     * @lang{ZH}
+     * @brief 返回国际格式的正数符号字符串。
+     * @return 正数符号（通常为空字符串）。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the positive sign string for the international format.
+     * @return The positive sign (usually an empty string).
+     * @endif
+     */
     [[nodiscard]] virtual const std::basic_string<CharT>& positive_sign_int() const { return m_positive_sign_int; }
+
+    /**
+     * @lang{ZH}
+     * @brief 返回本地格式的正数符号字符串。
+     * @return 正数符号（通常为空字符串）。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the positive sign string for the national format.
+     * @return The positive sign (usually an empty string).
+     * @endif
+     */
     [[nodiscard]] virtual const std::basic_string<CharT>& positive_sign_nat() const { return m_positive_sign_nat; }
+
+    /**
+     * @lang{ZH}
+     * @brief 返回国际格式的负数符号字符串。
+     * @return 负数符号（如 `L"-"` 或 `L"()"`）。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the negative sign string for the international format.
+     * @return The negative sign (e.g. `L"-"` or `L"()"`).
+     * @endif
+     */
     [[nodiscard]] virtual const std::basic_string<CharT>& negative_sign_int() const { return m_negative_sign_int; }
+
+    /**
+     * @lang{ZH}
+     * @brief 返回本地格式的负数符号字符串。
+     * @return 负数符号（如 `L"-"` 或 `L"()"`）。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the negative sign string for the national format.
+     * @return The negative sign (e.g. `L"-"` or `L"()"`).
+     * @endif
+     */
     [[nodiscard]] virtual const std::basic_string<CharT>& negative_sign_nat() const { return m_negative_sign_nat; }
+
+    /**
+     * @lang{ZH}
+     * @brief 返回国际格式正数的排列 pattern。
+     * @return 描述货币符号、符号字符串和数值顺序的 `pattern`。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the positive format pattern for the international format.
+     * @return A `pattern` describing the ordering of symbol, sign string, and value.
+     * @endif
+     */
     [[nodiscard]] virtual const base_ft<monetary>::pattern& pos_format_int() const { return m_pos_format_int; }
+
+    /**
+     * @lang{ZH}
+     * @brief 返回本地格式正数的排列 pattern。
+     * @return 描述货币符号、符号字符串和数值顺序的 `pattern`。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the positive format pattern for the national format.
+     * @return A `pattern` describing the ordering of symbol, sign string, and value.
+     * @endif
+     */
     [[nodiscard]] virtual const base_ft<monetary>::pattern& pos_format_nat() const { return m_pos_format_nat; }
+
+    /**
+     * @lang{ZH}
+     * @brief 返回国际格式负数的排列 pattern。
+     * @return 描述货币符号、符号字符串和数值顺序的 `pattern`。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the negative format pattern for the international format.
+     * @return A `pattern` describing the ordering of symbol, sign string, and value.
+     * @endif
+     */
     [[nodiscard]] virtual const base_ft<monetary>::pattern& neg_format_int() const { return m_neg_format_int; }
+
+    /**
+     * @lang{ZH}
+     * @brief 返回本地格式负数的排列 pattern。
+     * @return 描述货币符号、符号字符串和数值顺序的 `pattern`。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the negative format pattern for the national format.
+     * @return A `pattern` describing the ordering of symbol, sign string, and value.
+     * @endif
+     */
     [[nodiscard]] virtual const base_ft<monetary>::pattern& neg_format_nat() const { return m_neg_format_nat; }
+
+    /**
+     * @lang{ZH}
+     * @brief 返回国际货币格式的小数位数。
+     * @return 小数点后的位数。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the number of fractional digits for the international format.
+     * @return The number of digits after the decimal point.
+     * @endif
+     */
     [[nodiscard]] virtual int frac_digits_int() const { return m_frac_digits_int; }
+
+    /**
+     * @lang{ZH}
+     * @brief 返回本地货币格式的小数位数。
+     * @return 小数点后的位数。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the number of fractional digits for the national format.
+     * @return The number of digits after the decimal point.
+     * @endif
+     */
     [[nodiscard]] virtual int frac_digits_nat() const { return m_frac_digits_nat; }
+
+    /**
+     * @lang{ZH}
+     * @brief 返回货币小数点字符。
+     * @return 小数点字符。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the monetary decimal point character.
+     * @return The decimal point character.
+     * @endif
+     */
     [[nodiscard]] virtual CharT decimal_point() const { return m_decimal_point; }
+
+    /**
+     * @lang{ZH}
+     * @brief 返回千位分隔符字符。
+     * @return 千位分隔符字符。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the thousands separator character.
+     * @return The thousands separator character.
+     * @endif
+     */
     [[nodiscard]] virtual CharT thousands_sep() const { return m_thousands_sep; }
 
 private:
@@ -585,28 +1187,81 @@ private:
     CharT                       m_thousands_sep;
 };
 
-// This specialization delegates to monetary_conf<char32_t> to populate its data
-// (see init_from_u32 below), so it requires monetary_conf<char32_t> to be a
-// complete type when a char8_t conf is constructed for a non-"C"/"POSIX" locale.
-// That delegation lives in a member function template whose reference to
-// monetary_conf<char32_t> is dependent on a template parameter, so it is checked
-// only when actually instantiated (never eagerly, hence not IFNDR): merely
-// naming or default-constructing monetary_conf<char8_t> stays well-formed even
-// on platforms where monetary_conf<char32_t> is unavailable (wchar_t is not
-// UTF-32); there, only the non-"C"/"POSIX" construction path fails to compile,
-// which is intended.
-// The completeness requirement is deliberately NOT encoded as a constraint on
-// this class: a non-dependent sizeof(monetary_conf<char32_t>) in the
-// requires-clause is a hard error (not a soft constraint failure) and would
-// break partial-specialization resolution for unrelated monetary_conf<T>.
+/**
+ * @lang{ZH}
+ * @brief `monetary_conf` 的 `char8_t` 特化，以 UTF-8 字符串存储货币格式化数据。
+ *
+ * 对于非 `"C"`/`"POSIX"` 区域设置，此特化通过 `init_from_u32` 委托给
+ * `monetary_conf<char32_t>` 来填充数据：先构造一个临时的 `char32_t` conf，
+ * 再将各字段转换为 `char8_t`。
+ *
+ * @note **完整性要求：** 非 `"C"`/`"POSIX"` 路径要求 `monetary_conf<char32_t>`
+ *       在 `monetary_conf<char8_t>` 构造时已是完整类型。该委托位于成员函数模板
+ *       `init_from_u32` 中，其对 `monetary_conf<T>` 的引用依赖于模板参数，
+ *       因此整个函数体仅在该辅助函数被实例化时才检查（即仅在非 `"C"`/`"POSIX"`
+ *       构造路径上），而非提前检查（IFNDR）。仅命名或默认构造 `monetary_conf<char8_t>`
+ *       即使在 `monetary_conf<char32_t>` 不可用的平台（`wchar_t` 非 UTF-32）上
+ *       也是格式良好的；在这些平台上，只有非 `"C"`/`"POSIX"` 构造路径无法编译，
+ *       这是有意为之。该完整性要求有意**不**编码为此类上的约束（constraint）：
+ *       在 `requires` 子句中对 `sizeof(monetary_conf<char32_t>)` 的非依赖求值
+ *       是硬错误（而非软约束失败），会破坏无关 `monetary_conf<T>` 的偏特化解析。
+ *
+ * @endif
+ *
+ * @lang{EN}
+ * @brief Specialization of `monetary_conf` for `char8_t`, storing monetary
+ *        formatting data as UTF-8 strings.
+ *
+ * For non-`"C"`/`"POSIX"` locales, this specialization delegates to
+ * `monetary_conf<char32_t>` via `init_from_u32`: a temporary `char32_t` conf
+ * is constructed and its fields are then converted to `char8_t`.
+ *
+ * @note **Completeness requirement:** The non-`"C"`/`"POSIX"` path requires
+ *       `monetary_conf<char32_t>` to be a complete type when a `char8_t` conf
+ *       is constructed. The delegation lives in the member function template
+ *       `init_from_u32`, whose reference to `monetary_conf<T>` is dependent on
+ *       a template parameter, so the whole body is checked only upon instantiation
+ *       of that helper (i.e. only on the non-`"C"`/`"POSIX"` construction path),
+ *       never eagerly (hence not IFNDR). Merely naming or default-constructing
+ *       `monetary_conf<char8_t>` stays well-formed even on platforms where
+ *       `monetary_conf<char32_t>` is unavailable (`wchar_t` is not UTF-32);
+ *       there, only the non-`"C"`/`"POSIX"` construction path fails to compile,
+ *       which is intended. The completeness requirement is deliberately NOT
+ *       encoded as a constraint on this class: a non-dependent
+ *       `sizeof(monetary_conf<char32_t>)` in the `requires`-clause is a hard
+ *       error (not a soft constraint failure) and would break partial-specialization
+ *       resolution for unrelated `monetary_conf<T>`.
+ * @endif
+ */
 template <typename CharT>
     requires std::is_same_v<CharT, char8_t>
 class monetary_conf<CharT> : public ft_basic<monetary<char8_t>>
 {
 public:
-    using char_type = char8_t;
+    using char_type = char8_t; ///< @lang{ZH} 此特化使用的字符类型。 @endif @lang{EN} The character type used by this specialization. @endif
 
 public:
+    /**
+     * @lang{ZH}
+     * @brief 构造函数，从指定区域设置名称读取货币格式化数据。
+     *
+     * 对于 `"C"`/`"POSIX"` 区域设置，直接使用硬编码的 `char8_t` 默认值；
+     * 对于其他区域设置，委托给 `init_from_u32` 通过 `monetary_conf<char32_t>`
+     * 读取并转换数据。
+     *
+     * @param name 区域设置名称，或 `"C"`/`"POSIX"` 使用默认值。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Constructor that reads monetary formatting data from the named locale.
+     *
+     * For `"C"`/`"POSIX"` locales, hard-coded `char8_t` defaults are used directly.
+     * For other locales, delegates to `init_from_u32` which reads and converts
+     * data via `monetary_conf<char32_t>`.
+     *
+     * @param name The locale name, or `"C"`/`"POSIX"` for defaults.
+     * @endif
+     */
     monetary_conf(const std::string& name)
         : ft_basic<monetary<char8_t>>()
     {
@@ -628,10 +1283,37 @@ public:
     }
 
 private:
-    // T is defaulted/constrained to char32_t; templating it makes the
-    // monetary_conf<T> reference below dependent, so the whole body is checked
-    // only upon instantiation of this helper (i.e. only on the non-"C"/"POSIX"
-    // construction path), never eagerly.
+    /**
+     * @lang{ZH}
+     * @brief 委托给 `monetary_conf<char32_t>` 填充数据的私有辅助函数。
+     *
+     * `T` 默认为 `char32_t` 并受约束；将其模板化使函数体中对 `monetary_conf<T>`
+     * 的引用成为依赖名，从而整个函数体仅在此辅助函数被实例化时（即非 `"C"`/`"POSIX"`
+     * 构造路径）才检查，而非提前检查。
+     *
+     * 小数点和千位分隔符各为单个 `char8_t`（一个 UTF-8 码元），因此只有编码为
+     * 单字节（ASCII）的分隔符才能表示；更宽的分隔符将回退为 `'.'`/`','`。
+     *
+     * @tparam T 必须为 `char32_t`（默认值）。
+     * @param name 区域设置名称。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Private helper that delegates to `monetary_conf<char32_t>` to populate data.
+     *
+     * `T` is defaulted and constrained to `char32_t`; templating it makes the
+     * `monetary_conf<T>` reference in the body dependent, so the whole body is
+     * checked only upon instantiation of this helper (i.e. only on the
+     * non-`"C"`/`"POSIX"` construction path), never eagerly.
+     *
+     * The decimal point and thousands separator are each a single `char8_t`
+     * (one UTF-8 code unit), so only a separator that encodes to a single byte
+     * (ASCII) fits; anything wider regresses to `'.'` / `','`.
+     *
+     * @tparam T Must be `char32_t` (the default).
+     * @param name The locale name.
+     * @endif
+     */
     template <typename T = char32_t>
         requires std::is_same_v<T, char32_t>
     void init_from_u32(const std::string& name)
@@ -701,20 +1383,199 @@ private:
     }
 
 public:
+    /**
+     * @lang{ZH}
+     * @brief 返回数字分组规则。
+     * @return 描述每组位数的字节向量。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the digit-grouping specification.
+     * @return A byte vector describing the number of digits per group.
+     * @endif
+     */
     [[nodiscard]] virtual const std::vector<uint8_t>& grouping() const { return m_grouping; }
+
+    /**
+     * @lang{ZH}
+     * @brief 返回国际货币符号字符串（UTF-8）。
+     * @return 国际货币符号。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the international currency symbol string (UTF-8).
+     * @return The international currency symbol.
+     * @endif
+     */
     [[nodiscard]] virtual const std::basic_string<char8_t>& curr_symbol_int() const { return m_curr_symbol_int; }
+
+    /**
+     * @lang{ZH}
+     * @brief 返回本地货币符号字符串（UTF-8）。
+     * @return 本地货币符号。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the local (national) currency symbol string (UTF-8).
+     * @return The local currency symbol.
+     * @endif
+     */
     [[nodiscard]] virtual const std::basic_string<char8_t>& curr_symbol_nat() const { return m_curr_symbol_nat; }
+
+    /**
+     * @lang{ZH}
+     * @brief 返回国际格式的正数符号字符串（UTF-8）。
+     * @return 正数符号（通常为空字符串）。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the positive sign string for the international format (UTF-8).
+     * @return The positive sign (usually an empty string).
+     * @endif
+     */
     [[nodiscard]] virtual const std::basic_string<char8_t>& positive_sign_int() const { return m_positive_sign_int; }
+
+    /**
+     * @lang{ZH}
+     * @brief 返回本地格式的正数符号字符串（UTF-8）。
+     * @return 正数符号（通常为空字符串）。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the positive sign string for the national format (UTF-8).
+     * @return The positive sign (usually an empty string).
+     * @endif
+     */
     [[nodiscard]] virtual const std::basic_string<char8_t>& positive_sign_nat() const { return m_positive_sign_nat; }
+
+    /**
+     * @lang{ZH}
+     * @brief 返回国际格式的负数符号字符串（UTF-8）。
+     * @return 负数符号（如 `u8"-"` 或 `u8"()"`）。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the negative sign string for the international format (UTF-8).
+     * @return The negative sign (e.g. `u8"-"` or `u8"()"`).
+     * @endif
+     */
     [[nodiscard]] virtual const std::basic_string<char8_t>& negative_sign_int() const { return m_negative_sign_int; }
+
+    /**
+     * @lang{ZH}
+     * @brief 返回本地格式的负数符号字符串（UTF-8）。
+     * @return 负数符号（如 `u8"-"` 或 `u8"()"`）。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the negative sign string for the national format (UTF-8).
+     * @return The negative sign (e.g. `u8"-"` or `u8"()"`).
+     * @endif
+     */
     [[nodiscard]] virtual const std::basic_string<char8_t>& negative_sign_nat() const { return m_negative_sign_nat; }
+
+    /**
+     * @lang{ZH}
+     * @brief 返回国际格式正数的排列 pattern。
+     * @return 描述货币符号、符号字符串和数值顺序的 `pattern`。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the positive format pattern for the international format.
+     * @return A `pattern` describing the ordering of symbol, sign string, and value.
+     * @endif
+     */
     [[nodiscard]] virtual const base_ft<monetary>::pattern& pos_format_int() const { return m_pos_format_int; }
+
+    /**
+     * @lang{ZH}
+     * @brief 返回本地格式正数的排列 pattern。
+     * @return 描述货币符号、符号字符串和数值顺序的 `pattern`。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the positive format pattern for the national format.
+     * @return A `pattern` describing the ordering of symbol, sign string, and value.
+     * @endif
+     */
     [[nodiscard]] virtual const base_ft<monetary>::pattern& pos_format_nat() const { return m_pos_format_nat; }
+
+    /**
+     * @lang{ZH}
+     * @brief 返回国际格式负数的排列 pattern。
+     * @return 描述货币符号、符号字符串和数值顺序的 `pattern`。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the negative format pattern for the international format.
+     * @return A `pattern` describing the ordering of symbol, sign string, and value.
+     * @endif
+     */
     [[nodiscard]] virtual const base_ft<monetary>::pattern& neg_format_int() const { return m_neg_format_int; }
+
+    /**
+     * @lang{ZH}
+     * @brief 返回本地格式负数的排列 pattern。
+     * @return 描述货币符号、符号字符串和数值顺序的 `pattern`。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the negative format pattern for the national format.
+     * @return A `pattern` describing the ordering of symbol, sign string, and value.
+     * @endif
+     */
     [[nodiscard]] virtual const base_ft<monetary>::pattern& neg_format_nat() const { return m_neg_format_nat; }
+
+    /**
+     * @lang{ZH}
+     * @brief 返回国际货币格式的小数位数。
+     * @return 小数点后的位数。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the number of fractional digits for the international format.
+     * @return The number of digits after the decimal point.
+     * @endif
+     */
     [[nodiscard]] virtual int frac_digits_int() const { return m_frac_digits_int; }
+
+    /**
+     * @lang{ZH}
+     * @brief 返回本地货币格式的小数位数。
+     * @return 小数点后的位数。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the number of fractional digits for the national format.
+     * @return The number of digits after the decimal point.
+     * @endif
+     */
     [[nodiscard]] virtual int frac_digits_nat() const { return m_frac_digits_nat; }
+
+    /**
+     * @lang{ZH}
+     * @brief 返回货币小数点字符（UTF-8 码元）。
+     * @return 小数点字符。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the monetary decimal point character (UTF-8 code unit).
+     * @return The decimal point character.
+     * @endif
+     */
     [[nodiscard]] virtual char8_t decimal_point() const { return m_decimal_point; }
+
+    /**
+     * @lang{ZH}
+     * @brief 返回千位分隔符字符（UTF-8 码元）。
+     * @return 千位分隔符字符。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the thousands separator character (UTF-8 code unit).
+     * @return The thousands separator character.
+     * @endif
+     */
     [[nodiscard]] virtual char8_t thousands_sep() const { return m_thousands_sep; }
 
 private:


### PR DESCRIPTION


Add Chinese/English Doxygen documentation to four facet headers, following the comment style established in include/device/:

- messages_details.h: base_ft<messages> (bind_text_domain, available, filter_lang, get_translate_dictionary, .mo format constraints), messages_conf specializations for char8_t, char32_t/wchar_t, char
- messages.h: messages<CharT> class and all three translate() overloads, documenting the lvalue-borrow vs rvalue-by-value safety design
- monetary_details.h: base_ft<monetary> (part enum, pattern_spec, s_construct_pattern, s_norm_flag), monetary_conf specializations for char, wchar_t/char32_t, char8_t (including the init_from_u32 deferred- completeness design)
- monetary.h: monetary<CharT> class, all accessors, put/get overloads, and the insert/extract/str_to_v private implementation methods