### PR TITLE
test(facet): improve coverage for monetary and messages facets

### DIFF
--- a/test/facet/messages/test_messages.cpp
+++ b/test/facet/messages/test_messages.cpp
@@ -6,6 +6,8 @@ void test_messages_char_translate_3();
 void test_messages_facet_char8_t_common_1();
 void test_messages_char8_t_translate_1();
 void test_messages_char8_t_translate_2();
+void test_messages_char8_t_translate_3();
+void test_messages_char8_t_translate_4();
 
 void test_messages_facet_char32_t_common_1();
 void test_messages_char32_t_translate_1();
@@ -25,6 +27,8 @@ void test_messages()
     test_messages_facet_char8_t_common_1();
     test_messages_char8_t_translate_1();
     test_messages_char8_t_translate_2();
+    test_messages_char8_t_translate_3();
+    test_messages_char8_t_translate_4();
 
     test_messages_facet_char32_t_common_1();
     test_messages_char32_t_translate_1();

--- a/test/facet/messages/test_messages_char8_t.cpp
+++ b/test/facet/messages/test_messages_char8_t.cpp
@@ -3,6 +3,7 @@
 #include <limits>
 #include <stdexcept>
 #include <type_traits>
+#include <cstdlib>
 
 #include <common/dump_info.h>
 #include <common/exe_path.h>
@@ -46,6 +47,101 @@ void test_messages_char8_t_translate_2()
     VERIFY(obj.translate(u8"thank you") == u8"thank you");
     VERIFY(obj.translate(u8"") == u8"");
     VERIFY(obj.head_entry() == u8"");
+
+    dump_info("Done\n");
+}
+
+void test_messages_char8_t_translate_3()
+{
+    dump_info("Test messages<char8_t>::translate case 3 (colon-separated language list)...");
+    std::filesystem::path mo_path = exe_path();
+    mo_path = mo_path.remove_filename() / ".." / "IOv2TestResources";
+    mo_path = std::filesystem::canonical(mo_path);
+    IOv2::base_ft<IOv2::messages>::bind_text_domain("messages", mo_path.string());
+
+    // "fr_XX:zh_CN": fr_XX unavailable -> the while loop in match_lang advances
+    // past the ':' (line 631: start = end + 1), then zh_CN is returned via the
+    // trailing last_str path.
+    {
+        const IOv2::messages<char8_t> obj(
+            std::make_shared<IOv2::messages_conf<char8_t>>("messages", "fr_XX:zh_CN"));
+        VERIFY(obj.filtered_lang() == "zh_CN");
+        VERIFY(obj.translate(u8"please") == u8"\xe8\xaf\xb7");
+    }
+
+    // "zh_CN:fr_XX": zh_CN is available so it is returned immediately from
+    // inside the while loop (line 630: return cur_lang).
+    {
+        const IOv2::messages<char8_t> obj(
+            std::make_shared<IOv2::messages_conf<char8_t>>("messages", "zh_CN:fr_XX"));
+        VERIFY(obj.filtered_lang() == "zh_CN");
+    }
+
+    // available() with a colon-containing lang exercises the private
+    // available(td, lang) overload's colon branch (the lang.find(':') path).
+    VERIFY(IOv2::base_ft<IOv2::messages>::available("messages", "zh_CN:fr_XX"));
+    VERIFY(!IOv2::base_ft<IOv2::messages>::available("messages", "fr_XX:zh_HK"));
+
+    dump_info("Done\n");
+}
+
+void test_messages_char8_t_translate_4()
+{
+    dump_info("Test messages<char8_t>::translate case 4 (environment variable language fallback)...");
+    std::filesystem::path mo_path = exe_path();
+    mo_path = mo_path.remove_filename() / ".." / "IOv2TestResources";
+    mo_path = std::filesystem::canonical(mo_path);
+    IOv2::base_ft<IOv2::messages>::bind_text_domain("messages", mo_path.string());
+
+    // Save the current state of the four env vars that filter_lang inspects.
+    const bool had_language    = (std::getenv("LANGUAGE")    != nullptr);
+    const bool had_lc_all      = (std::getenv("LC_ALL")      != nullptr);
+    const bool had_lc_messages = (std::getenv("LC_MESSAGES") != nullptr);
+    const bool had_lang        = (std::getenv("LANG")        != nullptr);
+    const std::string saved_language    = had_language    ? std::getenv("LANGUAGE")    : "";
+    const std::string saved_lc_all      = had_lc_all      ? std::getenv("LC_ALL")      : "";
+    const std::string saved_lc_messages = had_lc_messages ? std::getenv("LC_MESSAGES") : "";
+    const std::string saved_lang        = had_lang        ? std::getenv("LANG")        : "";
+
+    unsetenv("LANGUAGE");
+    unsetenv("LC_ALL");
+    unsetenv("LC_MESSAGES");
+    unsetenv("LANG");
+
+    // LANGUAGE colon-list: "fr_XX:zh_CN" -> fr_XX fails, zh_CN succeeds.
+    // Covers getenv("LANGUAGE") path (lines 655-658) plus match_lang line 631.
+    setenv("LANGUAGE", "fr_XX:zh_CN", 1);
+    {
+        const IOv2::messages<char8_t> obj(
+            std::make_shared<IOv2::messages_conf<char8_t>>("messages", ""));
+        VERIFY(obj.filtered_lang() == "zh_CN");
+        VERIFY(obj.translate(u8"please") == u8"\xe8\xaf\xb7");
+    }
+    unsetenv("LANGUAGE");
+
+    // LC_ALL fallback: covers the for-loop path (lines 661-671).
+    setenv("LC_ALL", "zh_CN", 1);
+    {
+        const IOv2::messages<char8_t> obj(
+            std::make_shared<IOv2::messages_conf<char8_t>>("messages", ""));
+        VERIFY(obj.filtered_lang() == "zh_CN");
+    }
+    unsetenv("LC_ALL");
+
+    // All fallbacks absent or unavailable -> filter_lang returns "" (line 675).
+    setenv("LANG", "fr_XX", 1);   // exists but no .mo file for this locale
+    {
+        const IOv2::messages<char8_t> obj(
+            std::make_shared<IOv2::messages_conf<char8_t>>("messages", "", false));
+        VERIFY(obj.filtered_lang() == "");
+    }
+    unsetenv("LANG");
+
+    // Restore original env vars.
+    if (had_language)    setenv("LANGUAGE",    saved_language.c_str(),    1);
+    if (had_lc_all)      setenv("LC_ALL",      saved_lc_all.c_str(),      1);
+    if (had_lc_messages) setenv("LC_MESSAGES", saved_lc_messages.c_str(), 1);
+    if (had_lang)        setenv("LANG",        saved_lang.c_str(),        1);
 
     dump_info("Done\n");
 }

--- a/test/facet/monetary/test_monetary.cpp
+++ b/test/facet/monetary/test_monetary.cpp
@@ -1,5 +1,6 @@
 void test_monetary_char_common_1();
 void test_monetary_char_common_2();
+void test_monetary_char_common_3();
 void test_monetary_char_put_1();
 void test_monetary_char_put_2();
 void test_monetary_char_put_3();
@@ -53,6 +54,7 @@ void test_monetary_char_get_43();
 void test_monetary_char_get_44();
 void test_monetary_char_get_45();
 void test_monetary_char_get_46();
+void test_monetary_char_get_47();
 
 void test_monetary_wchar_t_common_1();
 void test_monetary_wchar_t_common_2();
@@ -89,6 +91,7 @@ void test_monetary_wchar_t_get_23();
 
 void test_monetary_char32_t_common_1();
 void test_monetary_char32_t_common_2();
+void test_monetary_char32_t_common_3();
 void test_monetary_char32_t_put_1();
 void test_monetary_char32_t_put_2();
 void test_monetary_char32_t_put_3();
@@ -157,6 +160,7 @@ void test_monetary()
 {
     test_monetary_char_common_1();
     test_monetary_char_common_2();
+    test_monetary_char_common_3();
     test_monetary_char_put_1();
     test_monetary_char_put_2();
     test_monetary_char_put_3();
@@ -210,7 +214,8 @@ void test_monetary()
     test_monetary_char_get_44();
     test_monetary_char_get_45();
     test_monetary_char_get_46();
-    
+    test_monetary_char_get_47();
+
     test_monetary_wchar_t_common_1();
     test_monetary_wchar_t_common_2();
     test_monetary_wchar_t_put_1();
@@ -245,6 +250,7 @@ void test_monetary()
 
     test_monetary_char32_t_common_1();
     test_monetary_char32_t_common_2();
+    test_monetary_char32_t_common_3();
     test_monetary_char32_t_put_1();
     test_monetary_char32_t_put_2();
     test_monetary_char32_t_put_3();

--- a/test/facet/monetary/test_monetary_char.cpp
+++ b/test/facet/monetary/test_monetary_char.cpp
@@ -2390,3 +2390,98 @@ void test_monetary_char_get_46()
 
     dump_info("Done\n");
 }
+
+void test_monetary_char_common_3()
+{
+    dump_info("Test monetary<char> common 3 (s_construct_pattern cases 2-4 and default)...");
+
+    using part = IOv2::base_ft<IOv2::monetary>::part;
+
+    // ar_AE.UTF-8: n_sign_posn=2, n_cs_precedes=1, n_sep_by_space=1
+    // -> case 2, sp=truthy, precedes=1 -> {symbol, space, value, sign}
+    IOv2::monetary obj_ar(std::make_shared<IOv2::monetary_conf<char>>("ar_AE.UTF-8"));
+    const IOv2::base_ft<IOv2::monetary>::pattern expected_ar =
+        {part::symbol, part::space, part::value, part::sign};
+    if (obj_ar.neg_format_nat() != expected_ar)
+        throw std::runtime_error("test_monetary_char_common_3: ar_AE neg_format_nat fails");
+
+    // nn_NO.UTF-8: n_sign_posn=3, n_cs_precedes=1, n_sep_by_space=0
+    // -> case 3, precedes=1, sp=0 -> {sign, symbol, value, none}
+    IOv2::monetary obj_no(std::make_shared<IOv2::monetary_conf<char>>("nn_NO.UTF-8"));
+    const IOv2::base_ft<IOv2::monetary>::pattern expected_no =
+        {part::sign, part::symbol, part::value, part::none};
+    if (obj_no.neg_format_nat() != expected_no)
+        throw std::runtime_error("test_monetary_char_common_3: nn_NO neg_format_nat fails");
+
+    // da_DK.UTF-8: n_sign_posn=4, n_cs_precedes=1, n_sep_by_space=2
+    // -> case 4, precedes=1, sp=truthy -> {symbol, sign, space, value}
+    IOv2::monetary obj_dk(std::make_shared<IOv2::monetary_conf<char>>("da_DK.UTF-8"));
+    const IOv2::base_ft<IOv2::monetary>::pattern expected_dk =
+        {part::symbol, part::sign, part::space, part::value};
+    if (obj_dk.neg_format_nat() != expected_dk)
+        throw std::runtime_error("test_monetary_char_common_3: da_DK neg_format_nat fails");
+
+    // bo_CN.UTF-8: n_sign_posn=4, n_cs_precedes=1, n_sep_by_space=0
+    // -> case 4, precedes=1, sp=0 (else-branch) -> {symbol, sign, value, none}
+    IOv2::monetary obj_bo(std::make_shared<IOv2::monetary_conf<char>>("bo_CN.UTF-8"));
+    const IOv2::base_ft<IOv2::monetary>::pattern expected_bo =
+        {part::symbol, part::sign, part::value, part::none};
+    if (obj_bo.neg_format_nat() != expected_bo)
+        throw std::runtime_error("test_monetary_char_common_3: bo_CN neg_format_nat fails");
+
+    // C.utf8: sign_posn=CHAR_MAX(127) -> default case -> {symbol, sign, none, value}
+    // Also: mon_decimal_point is empty -> empty mdp_raw branch -> frac_digits forced to 0
+    IOv2::monetary obj_cu(std::make_shared<IOv2::monetary_conf<char>>("C.utf8"));
+    const IOv2::base_ft<IOv2::monetary>::pattern expected_cu =
+        {part::symbol, part::sign, part::none, part::value};
+    if (obj_cu.neg_format_nat() != expected_cu)
+        throw std::runtime_error("test_monetary_char_common_3: C.utf8 neg_format_nat fails");
+    if (obj_cu.frac_digits_nat() != 0)
+        throw std::runtime_error("test_monetary_char_common_3: C.utf8 frac_digits_nat fails");
+    if (obj_cu.frac_digits_int() != 0)
+        throw std::runtime_error("test_monetary_char_common_3: C.utf8 frac_digits_int fails");
+
+    dump_info("Done\n");
+}
+
+void test_monetary_char_get_47()
+{
+    dump_info("Test monetary<char>::get 47 (mandatory_sign && p[3]==sign at symbol position)...");
+    IOv2::ios_base<char> ios;
+
+    auto tmp_io = std::make_shared<MoneyIO>("C");
+    tmp_io->set_positive_sign_nat("+");
+    tmp_io->set_negative_sign_nat("-");
+    // Pattern: {value, space, symbol, sign}.
+    // At pattern position i==2 (symbol), p[3]==sign and mandatory_sign==true;
+    // this covers the branch that checks
+    //   (mandatory_sign && (static_cast<part>(p[3]) == part::sign)).
+    tmp_io->set_neg_format_nat({
+        IOv2::base_ft<IOv2::monetary>::part::value,
+        IOv2::base_ft<IOv2::monetary>::part::space,
+        IOv2::base_ft<IOv2::monetary>::part::symbol,
+        IOv2::base_ft<IOv2::monetary>::part::sign
+    });
+    IOv2::monetary<char> obj(tmp_io);
+
+    std::string digits;
+
+    // Positive: "123 +" -> digits "123"
+    std::string input_pos = "123 +";
+    auto it_pos = obj.get(input_pos.begin(), input_pos.end(), false, ios, digits);
+    if (digits != "123")
+        throw std::runtime_error("test_monetary_char_get_47: positive value fails");
+    if (it_pos != input_pos.end())
+        throw std::runtime_error("test_monetary_char_get_47: positive iterator fails");
+
+    // Negative: "123 -" -> digits "-123"
+    digits.clear();
+    std::string input_neg = "123 -";
+    auto it_neg = obj.get(input_neg.begin(), input_neg.end(), false, ios, digits);
+    if (digits != "-123")
+        throw std::runtime_error("test_monetary_char_get_47: negative value fails");
+    if (it_neg != input_neg.end())
+        throw std::runtime_error("test_monetary_char_get_47: negative iterator fails");
+
+    dump_info("Done\n");
+}

--- a/test/facet/monetary/test_monetary_char32_t.cpp
+++ b/test/facet/monetary/test_monetary_char32_t.cpp
@@ -1302,11 +1302,30 @@ void test_monetary_char32_t_get_23()
     
     std::u32string  ss = U"123,456";
     std::u32string  digits;
-    
+
     auto it = obj.get(ss.begin(), ss.end(), false, ios, digits);
     if (it == ss.end()) throw std::runtime_error("IOv2::monetary<char32_t>::get fails");
     if (digits != U"123") throw std::runtime_error("IOv2::monetary<char32_t>::get fails");
     if (*it != L',') throw std::runtime_error("IOv2::monetary<char32_t>::get fails");
+
+    dump_info("Done\n");
+}
+
+void test_monetary_char32_t_common_3()
+{
+    dump_info("Test monetary<char32_t> common 3 (empty mon_decimal_point locale)...");
+
+    // C.utf8 has an empty mon_decimal_point string.  The wide-char constructor
+    // converts it to char32_t '\0', falls back to U'.', and — because the raw
+    // string was empty — sets both frac_digits fields to 0.
+    // This exercises the mon_dp_raw.empty() branch in monetary_conf<CharT>.
+    IOv2::monetary obj_cu(std::make_shared<IOv2::monetary_conf<char32_t>>("C.utf8"));
+    if (obj_cu.decimal_point() != U'.')
+        throw std::runtime_error("test_monetary_char32_t_common_3: C.utf8 decimal_point fails");
+    if (obj_cu.frac_digits_nat() != 0)
+        throw std::runtime_error("test_monetary_char32_t_common_3: C.utf8 frac_digits_nat fails");
+    if (obj_cu.frac_digits_int() != 0)
+        throw std::runtime_error("test_monetary_char32_t_common_3: C.utf8 frac_digits_int fails");
 
     dump_info("Done\n");
 }


### PR DESCRIPTION
Add targeted test cases to cover previously-uncovered code paths:

monetary_details.h (75.6% → 91.3%):
- test_monetary_char_common_3: construct monetary_conf<char> with locales that trigger s_construct_pattern cases 2 (ar_AE), 3 (nn_NO), 4 sp-truthy (da_DK), 4 sp-zero (bo_CN), and default (C.utf8); also covers the empty mon_decimal_point branch that forces frac_digits to 0
- test_monetary_char32_t_common_3: same C.utf8 path for monetary_conf<CharT>
  (wide-char constructor's mon_dp_raw.empty() branch)

monetary.h (95.6% → 100%):
- test_monetary_char_get_47: MoneyIO mock with both signs non-empty and pattern {value, space, symbol, sign} exercises the mandatory_sign && p[3]==sign branch at symbol position i==2

messages_details.h (80.3% → 100%):
- test_messages_char8_t_translate_3: colon-separated lang lists cover the while-loop return cur_lang (line 630) and start=end+1 (line 631) paths in match_lang, plus available() with colon-containing lang
- test_messages_char8_t_translate_4: env-var fallback path; saves and restores LANGUAGE/LC_ALL/LC_MESSAGES/LANG, then tests LANGUAGE colon list, LC_ALL single-value, and the return-empty fallback