### PR TITLE
fix(facet): add direct includes and harden timeio time-zone handling

### DIFF
--- a/include/facet/timeio.h
+++ b/include/facet/timeio.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <common/metafunctions.h>
+#include <common/prefix_tree.h>
 #include <common/stamp_input_iterator.h>
 #include <common/streambuf_defs.h>
 #include <facet/ctype.h>
@@ -367,7 +368,15 @@ struct time_zone_parse_helper<true>
         }
         catch(...)
         {
-            return std::chrono::current_zone();
+            try
+            {
+                return std::chrono::current_zone();
+            }
+            catch(...)
+            {
+                throw stream_error(
+                    "timeio parse error: no usable time zone (tz database unavailable)");
+            }
         }
     }
     std::string m_zone_name;
@@ -1855,8 +1864,7 @@ private:
                     std::chrono::local_time<std::chrono::seconds> lt{
                         std::chrono::local_days{*ymd} + hms->to_duration()
                     };
-                    auto st = tz->to_sys(lt);
-                    int val = tz->get_info(st).offset.count();
+                    int val = tz->get_info(lt).first.offset.count();
                     if (val < 0)
                     {
                         *out++ = static_cast<CharT>('-');

--- a/include/facet/timeio_details.h
+++ b/include/facet/timeio_details.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <common/clocale_wrapper.h>
 #include <common/metafunctions.h>
 #include <common/prefix_tree.h>
 #include <cvt/cvt_facilities.h>


### PR DESCRIPTION
- timeio.h: include <common/prefix_tree.h> directly (was relying on a transitive include via timeio_details.h despite using prefix_tree).
- timeio_details.h: include <common/clocale_wrapper.h> directly (was relying on a transitive include via facet/facet_helper.h despite using clocale_wrapper / clocale_user). Both kept in local group, alphabetical.
- time_zone_parse_helper: wrap the current_zone() fallback so a failure (no usable tz database) throws a clear stream_error instead of letting a raw exception escape the catch or returning a null time_zone* that would be dereferenced when constructing zoned_time.
- do_put %z: compute the UTC offset via get_info(local_time).first.offset instead of to_sys(local_time); the latter throws nonexistent_local_time / ambiguous_local_time at DST transitions, so formatting an otherwise valid zoned_time with %z could throw. get_info() reports rather than throws.