### PR TITLE
fix(facet): harden timeio locale validation and static-init safety

### DIFF
--- a/include/facet/timeio.h
+++ b/include/facet/timeio.h
@@ -370,7 +370,7 @@ struct time_zone_parse_helper<true>
         {
             try
             {
-                return std::chrono::current_zone();
+                return std::chrono::locate_zone("UTC");
             }
             catch(...)
             {
@@ -490,6 +490,14 @@ public:
         m_era_date_time_zone_format = p_obj->era_date_time_zone_format();
         m_am_pm_format = p_obj->am_pm_format();
         m_era_master = p_obj->era_items();
+
+        // Validate the locale name tables up front, so malformed locale data
+        // fails here with one clear error instead of a cryptic prefix_tree
+        // "duplicate items" throw deep inside add(), or a silent zero-length
+        // mis-match at parse time. Day/month names must be non-empty and must
+        // not map one spelling to two different indices; AM/PM may legitimately
+        // be empty (e.g. de_DE / fr_FR / ru_RU) and is tolerated.
+        validate_locale_names();
 
         for (int i = 0; i < 7; ++i)
         {
@@ -1396,12 +1404,48 @@ private:
                c == static_cast<CharT>('\f') || c == static_cast<CharT>('\r');
     }
 
+    // Throws std::runtime_error if any of the 2*N names is empty, or if one
+    // spelling is shared by two *different* indices. full[i] == abbr[i] (same
+    // index, e.g. "May" in en_US) is allowed.
+    template <size_t N>
+    static void check_unique_nonempty(const std::array<std::basic_string<CharT>, N>& full,
+                                      const std::array<std::basic_string<CharT>, N>& abbr,
+                                      const char* what)
+    {
+        std::array<const std::basic_string<CharT>*, 2 * N> names{};
+        for (size_t i = 0; i < N; ++i)
+        {
+            if (full[i].empty() || abbr[i].empty())
+                throw std::runtime_error(std::string("timeio: empty ") + what + " name in locale data");
+            names[2 * i]     = &full[i];
+            names[2 * i + 1] = &abbr[i];
+        }
+        // names[p] belongs to index p / 2.
+        for (size_t a = 0; a < names.size(); ++a)
+            for (size_t b = a + 1; b < names.size(); ++b)
+                if ((a / 2) != (b / 2) && *names[a] == *names[b])
+                    throw std::runtime_error(std::string("timeio: duplicate ") + what + " name in locale data");
+    }
+
+    void validate_locale_names() const
+    {
+        check_unique_nonempty<7>(m_day, m_abbr_day, "day");
+        check_unique_nonempty<12>(m_month, m_abbr_month, "month");
+
+        // AM/PM is empty in locales that do not use 12-hour designators
+        // (de_DE / fr_FR / ru_RU); that is tolerated and simply leaves %p
+        // unmatched. Only a non-empty AM == PM collision is genuinely invalid.
+        if (!m_am.empty() && m_am == m_pm)
+            throw std::runtime_error("timeio: AM and PM designators are identical in locale data");
+    }
+
     void create_era_name_tree()
     {
         for (size_t i = 0; i < m_era_master.size(); ++i)
         {
             const std::basic_string<CharT>& name = m_era_master[i].name;
-            m_era_tree.add(name, name);
+            if (!name.empty())
+                m_era_tree.add(name, name);
             m_era_formats.insert(m_era_master[i].format);
         }
     }

--- a/include/facet/timeio_details.h
+++ b/include/facet/timeio_details.h
@@ -60,15 +60,27 @@ namespace IOv2
         {
             prefix_tree<CharT, std::string> res;
 
-            const auto& tzdb = std::chrono::get_tzdb();
-
-            for (const auto& zone : tzdb.zones)
+            try
             {
-                std::string full_name{zone.name()};
-                std::string abbr_name = zone.get_info(std::chrono::sys_time<std::chrono::seconds>{}).abbrev;
-                res.add(abbr_name.begin(), abbr_name.end(), "*");
-                if (full_name != abbr_name)
-                    res.add(full_name.begin(), full_name.end(), full_name);
+                const auto& tzdb = std::chrono::get_tzdb();
+
+                for (const auto& zone : tzdb.zones)
+                {
+                    std::string full_name{zone.name()};
+                    std::string abbr_name = zone.get_info(std::chrono::sys_time<std::chrono::seconds>{}).abbrev;
+                    res.add(abbr_name.begin(), abbr_name.end(), "*");
+                    if (full_name != abbr_name)
+                        res.add(full_name.begin(), full_name.end(), full_name);
+                }
+            }
+            catch (...)
+            {
+                // tz database unavailable or malformed at static-init time:
+                // degrade to an empty/partial tree instead of letting the
+                // exception escape this static initializer (which would call
+                // std::terminate). %Z then simply fails to match and reports a
+                // catchable stream_error at parse time, matching the defensive
+                // behaviour of time_zone_parse_helper.
             }
             return res;
         }();


### PR DESCRIPTION
Three classes of defect addressed:

1. Empty locale name → prefix_tree root-value pollution An empty day/month/era name passed to prefix_tree::add() would set the root node's value, causing max_match() to return an engaged result for any input while consuming zero characters.  The era tree now skips empty names; day/month names are guaranteed non-empty by the new init-time check (see point 2).

2. Malformed locale data detected at construction time validate_locale_names() / check_unique_nonempty<N>() are called in the timeio constructor before any tree is built.  They throw std::runtime_error if a day or month name is empty or if one spelling is shared by two different indices (cross-index duplicate).  full[i] == abbr[i] for the same index (e.g. "May" in en_US) is explicitly allowed.  Empty AM/PM is also tolerated because many locales (de_DE, fr_FR, ru_RU) do not use 12-hour designators; only a non-empty AM == PM collision is rejected.

3. s_timezone_tree static initializer could call std::terminate If std::chrono::get_tzdb() or zone.get_info() throws during static initialisation, the exception would escape the inline-static IIFE and invoke std::terminate.  The IIFE body is now wrapped in catch(...) which degrades to an empty/partial tree; %Z then reports a catchable stream_error at parse time instead of terminating the process.

   Also fixes the time_zone_parse_helper UTC fallback: use locate_zone("UTC") instead of current_zone() so the fallback is not subject to TZ env changes.