### PR TITLE
fix(facet): guard against empty-key insertion into prefix trees

### DIFF
--- a/include/facet/timeio.h
+++ b/include/facet/timeio.h
@@ -422,7 +422,7 @@ struct time_parse_context
         int m = unsigned(ymd.month());
         int y = int(ymd.year());
 
-        std::tm res;
+        std::tm res{};
         res.tm_year = y - 1900;
         res.tm_mon  = m - 1;
         res.tm_mday = d;
@@ -1446,7 +1446,8 @@ private:
             const std::basic_string<CharT>& name = m_era_master[i].name;
             if (!name.empty())
                 m_era_tree.add(name, name);
-            m_era_formats.insert(m_era_master[i].format);
+            if (!m_era_master[i].format.empty())
+                m_era_formats.insert(m_era_master[i].format);
         }
     }
 

--- a/include/facet/timeio_details.h
+++ b/include/facet/timeio_details.h
@@ -68,7 +68,8 @@ namespace IOv2
                 {
                     std::string full_name{zone.name()};
                     std::string abbr_name = zone.get_info(std::chrono::sys_time<std::chrono::seconds>{}).abbrev;
-                    res.add(abbr_name.begin(), abbr_name.end(), "*");
+                    if (!abbr_name.empty())
+                        res.add(abbr_name.begin(), abbr_name.end(), "*");
                     if (full_name != abbr_name)
                         res.add(full_name.begin(), full_name.end(), full_name);
                 }


### PR DESCRIPTION
Three defensive fixes to prevent silent zero-consumption matches when prefix_tree::max_match() is called on a tree whose root node carries a value (which happens whenever an empty string is added via add(b,e,v) with b==e).

* timeio_details.h: skip res.add() when a timezone abbreviation string is empty, preventing "%Z" from matching any input without advancing the iterator.
* timeio.h (operator std::tm): value-initialize `res` with `{}` so glibc extension fields tm_gmtoff / tm_zone are zeroed rather than indeterminate, avoiding UB when strftime reads them via "%z"/"%Z".
* timeio.h (create_era_name_tree): guard m_era_formats.insert() with an emptiness check, mirroring the existing guard on m_era_tree.add(); prevents an empty format from being selected by "%EY" and causing a silent parse desync.