### PR TITLE
fix(facet): correct timeio includes and drop dead %I branch

### DIFF
--- a/include/facet/timeio.h
+++ b/include/facet/timeio.h
@@ -1,9 +1,11 @@
 #pragma once
+#include <common/defs.h>
 #include <common/metafunctions.h>
 #include <common/prefix_tree.h>
 #include <common/stamp_input_iterator.h>
 #include <common/streambuf_defs.h>
 #include <facet/ctype.h>
+#include <facet/facet_common.h>
 #include <facet/timeio_details.h>
 
 #include <algorithm>
@@ -331,10 +333,11 @@ struct time_parse_helper<true>
     explicit operator std::chrono::hh_mm_ss<std::chrono::seconds>() const
     {
         uint8_t hour_in_24 = m_hour;
+        // When %I sets m_have_I, m_hour was stored as (mem % 12), so 12 AM is
+        // already normalised to 0 at parse time and m_hour is always in [0,11]
+        // here; only the PM (+12) adjustment remains.
         if (m_have_I && m_is_pm && hour_in_24 < 12)
             hour_in_24 += 12;
-        else if (m_have_I && !m_is_pm && hour_in_24 == 12)
-            hour_in_24 = 0;
 
         std::chrono::seconds time_sec =
             std::chrono::hours{hour_in_24} +

--- a/include/facet/timeio_details.h
+++ b/include/facet/timeio_details.h
@@ -4,7 +4,6 @@
 #include <common/prefix_tree.h>
 #include <cvt/cvt_facilities.h>
 #include <facet/facet_common.h>
-#include <facet/facet_helper.h>
 
 #include <array>
 #include <chrono>


### PR DESCRIPTION
timeio.h: add direct includes of <common/defs.h> (stream_error) and <facet/facet_common.h> (base_ft), which were only available transitively; this matches the convention in the sibling numeric/monetary facets.

timeio_details.h: remove the unused <facet/facet_helper.h> include; none of its FacetHelper symbols are referenced and the project headers it would pull in are already included directly.

timeio.h: remove the unreachable `m_have_I && !m_is_pm && hour_in_24 == 12` branch in time_parse_helper's hh_mm_ss conversion. %I stores m_hour as (mem % 12), so 12 AM is already normalised to 0 at parse time and m_hour is always in [0,11] whenever m_have_I is set; the branch could never fire. A comment documents why the 12->0 handling is unnecessary here.