### PR TITLE
fix(facet): validate ymd in get path, fix %e space-pad, and resolve tz abbreviations

### DIFF
--- a/include/facet/timeio.h
+++ b/include/facet/timeio.h
@@ -50,6 +50,14 @@ struct date_parse_helper<CharT, true>
 
     explicit operator std::chrono::year_month_day() const
     {
+        auto ymd = compute_ymd();
+        if (!ymd.ok())
+            throw stream_error("timeio get error: year_month_day is not a valid calendar date");
+        return ymd;
+    }
+
+    std::chrono::year_month_day compute_ymd() const
+    {
         using namespace std::chrono;
         if (m_have_year && m_have_mon && m_have_mday)
             return year_month_day{ year{m_year}, month{static_cast<uint8_t>(m_month)}, day{m_mday} };
@@ -279,12 +287,12 @@ struct date_parse_helper<CharT, true>
     int m_year_of_era = 0;
 
     int     m_year = 0;
-    uint8_t m_month = 1;        // months since January – [​1, 12]
+    uint8_t m_month = 1;        // months since January – [1, 12]
     uint8_t m_iso_8601_week = 0;
     uint8_t m_week_no = 0;
-    uint8_t m_mday = 1;         // day of the month – [​1​, 31]
-    uint8_t m_wday = 0;         // days since Sunday – [​0​, 6]
-    unsigned short m_yday = 0;  // days since January 1 – [​0​, 365]
+    uint8_t m_mday = 1;         // day of the month – [1, 31]
+    uint8_t m_wday = 0;         // days since Sunday – [0, 6]
+    unsigned short m_yday = 0;  // days since January 1 – [0, 365]
 
     bool is_init : 1 = false;
     bool m_have_century : 1 = false;
@@ -355,9 +363,9 @@ struct time_parse_helper<true>
         return std::chrono::hh_mm_ss{time_sec};
     }
 
-    uint8_t m_hour = 0;         // hours since midnight – [​0​, 23]
-    uint8_t m_minute = 0;       // minutes after the hour – [​0​, 59]
-    uint8_t m_second = 0;       // seconds after the minute – [​0​, 59]
+    uint8_t m_hour = 0;         // hours since midnight – [0, 23]
+    uint8_t m_minute = 0;       // minutes after the hour – [0, 59]
+    uint8_t m_second = 0;       // seconds after the minute – [0, 59]
     bool m_have_I : 1 = false;
     bool m_is_pm : 1 = false;
 };
@@ -373,24 +381,23 @@ struct time_zone_parse_helper<true>
     bool operator==(const time_zone_parse_helper&) const = default;  // for test
     explicit operator const std::chrono::time_zone*() const
     {
-        try
+        if (!m_zone_name.empty())
         {
-            return std::chrono::locate_zone(m_zone_name);
+            try { return std::chrono::locate_zone(m_zone_name); }
+            catch (...) {}
         }
-        catch(...)
+        if (!m_zone_abbrev.empty())
+            throw stream_error(
+                "timeio get error: timezone abbreviation '" + m_zone_abbrev + "' is ambiguous");
+        try { return std::chrono::locate_zone("UTC"); }
+        catch (...)
         {
-            try
-            {
-                return std::chrono::locate_zone("UTC");
-            }
-            catch(...)
-            {
-                throw stream_error(
-                    "timeio parse error: no usable time zone (tz database unavailable)");
-            }
+            throw stream_error(
+                "timeio parse error: no usable time zone (tz database unavailable)");
         }
     }
     std::string m_zone_name;
+    std::string m_zone_abbrev;
 };
 
 template <typename CharT, bool HaveDate = true, bool HaveTime = true, bool HaveTimeZone = true>
@@ -848,12 +855,29 @@ private:
                 break;
 
             case static_cast<CharT>('d'):
+                if constexpr (!HaveDate) goto bad_parse_format;
+                else if (modifier == static_cast<CharT>('E')) goto bad_parse_format;
+                else
+                {
+                    int mem = -1;
+                    if (modifier == static_cast<CharT>('O'))
+                        rp = extract_num_with_alt_digits(rp, rp_end, mem, 1, 31, 2, succ);
+                    else
+                        rp = extract_num(rp, rp_end, mem, 1, 31, 2, succ);
+                    if (!succ) return rp;
+                    ctx.m_mday = mem;
+                    ctx.m_have_mday = true;
+                }
+                break;
+
             case static_cast<CharT>('e'):
                 if constexpr (!HaveDate) goto bad_parse_format;
                 else if (modifier == static_cast<CharT>('E')) goto bad_parse_format;
                 else
                 {
                     int mem = -1;
+                    if (rp != rp_end && *rp == static_cast<CharT>(' '))
+                        ++rp;
                     if (modifier == static_cast<CharT>('O'))
                         rp = extract_num_with_alt_digits(rp, rp_end, mem, 1, 31, 2, succ);
                     else
@@ -1053,6 +1077,8 @@ private:
                 else if (modifier == static_cast<CharT>('E')) goto bad_parse_format;
                 else
                 {
+                    // Upper bound is 59, not C's 60: leap seconds are not supported
+                    // (hh_mm_ss cannot represent them); see put() for rationale.
                     int mem = -1;
                     if (modifier == static_cast<CharT>('O'))
                         rp = extract_num_with_alt_digits(rp, rp_end, mem, 0, 59, 2, succ);
@@ -1367,7 +1393,6 @@ private:
             case static_cast<CharT>('Z'):
                 if constexpr (!HaveTimeZone) goto bad_parse_format;
                 else if (modifier) goto bad_parse_format;
-                /* Read timezone but perform no conversion.  */
                 else
                 {
                     typename decltype(ft_basic<timeio<CharT>>::s_timezone_tree)::match_out_type zone_res;
@@ -1377,8 +1402,10 @@ private:
                         succ = false;
                         return rp;
                     }
-                    else if ((*zone_res)[0] != (CharT)'*')
+                    else if ((*zone_res)[0] != '*')
                         ctx.m_zone_name = *zone_res;
+                    else
+                        ctx.m_zone_abbrev = zone_res->substr(1);
                 }
                 break;
 

--- a/include/facet/timeio_details.h
+++ b/include/facet/timeio_details.h
@@ -12,6 +12,7 @@
 #include <cstring>
 #include <cwchar>
 #include <limits>
+#include <set>
 #include <string>
 #include <type_traits>
 #include <utility>
@@ -63,12 +64,35 @@ namespace IOv2
             {
                 const auto& tzdb = std::chrono::get_tzdb();
 
+                // Collect all abbreviations (deduplicated across zones).
+                std::set<std::string> abbrevs;
+                for (const auto& zone : tzdb.zones)
+                {
+                    std::string abbr = zone.get_info(std::chrono::sys_time<std::chrono::seconds>{}).abbrev;
+                    if (!abbr.empty())
+                        abbrevs.insert(std::move(abbr));
+                }
+
+                // Resolve each abbreviation: if locate_zone succeeds (e.g. "EST"
+                // is an IANA link), store the canonical name; otherwise mark "*".
+                for (const auto& abbr : abbrevs)
+                {
+                    try
+                    {
+                        std::string canonical{std::chrono::locate_zone(abbr)->name()};
+                        res.add(abbr.begin(), abbr.end(), canonical);
+                    }
+                    catch (...)
+                    {
+                        res.add(abbr.begin(), abbr.end(), "*" + abbr);
+                    }
+                }
+
+                // Add full zone names that differ from their own abbreviation.
                 for (const auto& zone : tzdb.zones)
                 {
                     std::string full_name{zone.name()};
                     std::string abbr_name = zone.get_info(std::chrono::sys_time<std::chrono::seconds>{}).abbrev;
-                    if (!abbr_name.empty())
-                        res.add(abbr_name.begin(), abbr_name.end(), "*");
                     if (full_name != abbr_name)
                         res.add(full_name.begin(), full_name.end(), full_name);
                 }

--- a/test/facet/timeio/test_timeio_char.cpp
+++ b/test/facet/timeio/test_timeio_char.cpp
@@ -2738,7 +2738,7 @@ void test_timeio_char_get_1()
     CheckGet(obj, "Y",   'Y', 'O', IOv2::ios_defs::strfailbit, 0);
 
     VERIFY(CheckGet(obj, "America/Los_Angeles", 'Z', 0, IOv2::ios_defs::eofbit).m_zone_name == "America/Los_Angeles");
-    VERIFY(CheckGet(obj, "PST", 'Z', 0, IOv2::ios_defs::eofbit).m_zone_name == "");
+    { auto r = CheckGet(obj, "PST", 'Z', 0, IOv2::ios_defs::eofbit); VERIFY(r.m_zone_name == "" && r.m_zone_abbrev == "PST"); }
     CheckGet(obj, "America/Los_Angexes", 'Z', 0, IOv2::ios_defs::strfailbit);
     CheckGet(obj, "%EZ", 'Z', 'E', IOv2::ios_defs::eofbit);
     CheckGet(obj, "Z",   'Z', 'E', IOv2::ios_defs::strfailbit, 0);
@@ -3013,7 +3013,7 @@ void test_timeio_char_get_2()
     CheckGet(obj, "Y",   'Y', 'O', IOv2::ios_defs::strfailbit, 0);
 
     VERIFY(CheckGet(obj, "America/Los_Angeles", 'Z', 0, IOv2::ios_defs::eofbit).m_zone_name == "America/Los_Angeles");
-    VERIFY(CheckGet(obj, "PST", 'Z', 0, IOv2::ios_defs::eofbit).m_zone_name == "");
+    { auto r = CheckGet(obj, "PST", 'Z', 0, IOv2::ios_defs::eofbit); VERIFY(r.m_zone_name == "" && r.m_zone_abbrev == "PST"); }
     CheckGet(obj, "America/Los_Angexes", 'Z', 0, IOv2::ios_defs::strfailbit);
     CheckGet(obj, "%EZ", 'Z', 'E', IOv2::ios_defs::eofbit);
     CheckGet(obj, "Z",   'Z', 'E', IOv2::ios_defs::strfailbit, 0);
@@ -3303,7 +3303,7 @@ void test_timeio_char_get_3()
     CheckGet(obj, "Y",   'Y', 'O', IOv2::ios_defs::strfailbit, 0);
 
     VERIFY(CheckGet(obj, "America/Los_Angeles", 'Z', 0, IOv2::ios_defs::eofbit).m_zone_name == "America/Los_Angeles");
-    VERIFY(CheckGet(obj, "PST", 'Z', 0, IOv2::ios_defs::eofbit).m_zone_name == "");
+    { auto r = CheckGet(obj, "PST", 'Z', 0, IOv2::ios_defs::eofbit); VERIFY(r.m_zone_name == "" && r.m_zone_abbrev == "PST"); }
     CheckGet(obj, "America/Los_Angexes", 'Z', 0, IOv2::ios_defs::strfailbit);
     CheckGet(obj, "%EZ", 'Z', 'E', IOv2::ios_defs::eofbit);
     CheckGet(obj, "Z",   'Z', 'E', IOv2::ios_defs::strfailbit, 0);
@@ -5649,7 +5649,7 @@ void test_timeio_char_get_16()
     FOri("Y",   'Y', 'O', IOv2::ios_defs::strfailbit, 0);
 
     VERIFY(FOri("America/Los_Angeles", 'Z', 0, IOv2::ios_defs::eofbit).m_zone_name == "America/Los_Angeles");
-    VERIFY(FOri("PST", 'Z', 0, IOv2::ios_defs::eofbit).m_zone_name == "");
+    { auto r = FOri("PST", 'Z', 0, IOv2::ios_defs::eofbit); VERIFY(r.m_zone_name == "" && r.m_zone_abbrev == "PST"); }
     FOri("America/Los_Angexes", 'Z', 0, IOv2::ios_defs::strfailbit);
     FOri("%EZ", 'Z', 'E', IOv2::ios_defs::eofbit);
     FOri("Z",   'Z', 'E', IOv2::ios_defs::strfailbit, 0);


### PR DESCRIPTION


- Remove 13 zero-width space (U+200B) characters embedded in range comments in timeio.h field declarations
- Add leap-second comment to %S get case (mirroring put() rationale)
- Introduce compute_ymd() helper so operator year_month_day() validates ok() in one place; operator zoned_time() and operator tm() rely on that single check rather than duplicating it
- Split %d/%e get cases: %e now skips one optional leading space to match put_dec<2,' '> output and round-trip correctly
- Rebuild s_timezone_tree in two passes: resolve each abbreviation via locate_zone (e.g. "EST" -> "America/Panama"); store ambiguous ones as "*<abbr>" so the matched abbreviation is recoverable from the tree value without iterating input (fixing istreambuf_iterator round-trip)
- Add m_zone_abbrev to time_zone_parse_helper<true>; operator time_zone* now throws with the abbreviation name instead of silently using UTC