### PR TITLE
fix(facet): match zero-or-more whitespace in get format string and fix %Ey negative sign

### DIFF
--- a/include/facet/timeio.h
+++ b/include/facet/timeio.h
@@ -1946,7 +1946,7 @@ private:
                             int64_t v = static_cast<int64_t>(era->offset)
                                 + (static_cast<int64_t>(static_cast<int>(ymd->year())) - era->from_year) * era->direction;
                             int iv = static_cast<int>(std::clamp<int64_t>(v,
-                                std::numeric_limits<int>::min(), std::numeric_limits<int>::max()));
+                                -static_cast<int64_t>(std::numeric_limits<int>::max()), std::numeric_limits<int>::max()));
                             if (iv < 0) { *out++ = static_cast<CharT>('-'); iv = -iv; }
                             out = put_dec<0>(out, iv);
                         }

--- a/include/facet/timeio.h
+++ b/include/facet/timeio.h
@@ -717,6 +717,13 @@ private:
         {
             if (*fmt != static_cast<CharT>('%'))
             {
+                if (is_space(*fmt))
+                {
+                    ++fmt;
+                    while (rp != rp_end && is_space(*rp))
+                        ++rp;
+                    continue;
+                }
                 if (*fmt != *rp)
                 {
                     succ = false;
@@ -1440,11 +1447,13 @@ private:
             ++fmt;
         }
 
-        // A format tail consisting solely of %n / %t matches zero-or-more
-        // whitespace and is satisfied even at end of input, matching POSIX
-        // strptime and std::get_time. Skip such a tail before judging failure.
+        // A format tail consisting solely of whitespace / %n / %t matches
+        // zero-or-more whitespace and is satisfied even at end of input,
+        // matching POSIX strptime and std::get_time. Skip such a tail before
+        // judging failure.
         while (fmt != _fmt.cend())
         {
+            if (is_space(*fmt)) { ++fmt; continue; }
             auto next = fmt + 1;
             if ((*fmt != static_cast<CharT>('%')) || (next == _fmt.cend()))
                 break;
@@ -1936,8 +1945,10 @@ private:
                         {
                             int64_t v = static_cast<int64_t>(era->offset)
                                 + (static_cast<int64_t>(static_cast<int>(ymd->year())) - era->from_year) * era->direction;
-                            out = put_dec<0>(out, static_cast<int>(std::clamp<int64_t>(v,
-                                std::numeric_limits<int>::min(), std::numeric_limits<int>::max())));
+                            int iv = static_cast<int>(std::clamp<int64_t>(v,
+                                std::numeric_limits<int>::min(), std::numeric_limits<int>::max()));
+                            if (iv < 0) { *out++ = static_cast<CharT>('-'); iv = -iv; }
+                            out = put_dec<0>(out, iv);
                         }
                         else
                             out = put_dec<2>(out, val);

--- a/include/facet/timeio_details.h
+++ b/include/facet/timeio_details.h
@@ -270,14 +270,17 @@ public:
                 // UNCHECKED, so malformed or unterminated locale data could read
                 // out of bounds. It is bounded in practice only by the empty-string
                 // sentinel and the 100-entry cap. System locale data is treated as
-                // trusted, so no defensive validation is performed; if ALT_DIGITS
-                // could ever come from an untrusted source, harden this here.
-                char* ptr = nl_langinfo(ALT_DIGITS);
-                for (size_t i = 0; i < 100; ++i)
+                // trusted; if ALT_DIGITS could ever come from an untrusted source,
+                // harden this here. nl_langinfo() is POSIX-guaranteed non-null, but
+                // the null guard below protects against non-conforming platforms.
+                if (char* ptr = nl_langinfo(ALT_DIGITS); ptr)
                 {
-                    if (*ptr == '\0') break;
-                    m_alt_digits[i] = ptr;
-                    ptr += m_alt_digits[i].size() + 1;
+                    for (size_t i = 0; i < 100; ++i)
+                    {
+                        if (*ptr == '\0') break;
+                        m_alt_digits[i] = ptr;
+                        ptr += m_alt_digits[i].size() + 1;
+                    }
                 }
             }
             // Must run with the target locale active on this thread (the


### PR DESCRIPTION


Format-string literal whitespace now matches zero or more whitespace characters in input (POSIX strptime semantics) rather than requiring an exact single-character match. The tail-skip logic is extended to also tolerate literal whitespace after input is exhausted.

For %Ey put, output a leading '-' before passing the absolute value to put_dec<0>, matching glibc strftime which uses printf "%d" semantics.