### PR TITLE
docs(facet): add bilingual Doxygen comments to timeio and timeio_details

### DIFF
--- a/include/facet/timeio.h
+++ b/include/facet/timeio.h
@@ -1,3 +1,32 @@
+/**
+ * @file timeio.h
+ * @lang{ZH}
+ * 定义 `timeio` facet，提供对日期/时间值的格式化输出（`put`）与解析输入（`get`）功能，
+ * 支持 `strftime`/`strptime` 风格的格式说明符（包括 `E`/`O` 修饰符与纪元扩展）。
+ *
+ * 还定义了以下辅助类型：
+ * - `date_parse_helper`、`time_parse_helper`、`time_zone_parse_helper`：
+ *   按需激活的解析状态容器，作为 `time_parse_context` 的基类；
+ * - `time_parse_context`：聚合解析上下文，作为 `get()` 的输出参数，
+ *   并提供向 `std::chrono::year_month_day`、`std::chrono::hh_mm_ss` 及
+ *   `std::chrono::zoned_time` 的转换运算符。
+ * @endif
+ *
+ * @lang{EN}
+ * Defines the `timeio` facet, which provides locale-aware formatting (`put`) and
+ * parsing (`get`) of date/time values using `strftime`/`strptime`-style format
+ * specifiers, including `E`/`O` modifiers and era extensions.
+ *
+ * Also defines the following helper types:
+ * - `date_parse_helper`, `time_parse_helper`, `time_zone_parse_helper`:
+ *   conditionally activated parse-state containers that serve as base classes
+ *   of `time_parse_context`;
+ * - `time_parse_context`: an aggregate parse context used as the output argument
+ *   of `get()`, providing conversion operators to
+ *   `std::chrono::year_month_day`, `std::chrono::hh_mm_ss`, and
+ *   `std::chrono::zoned_time`.
+ * @endif
+ */
 #pragma once
 #include <common/defs.h>
 #include <common/metafunctions.h>
@@ -28,15 +57,44 @@
 
 namespace IOv2
 {
+/// @cond
 template <typename, bool> struct date_parse_helper
 {
     bool operator==(const date_parse_helper&) const = default;  // for test
 };
+/// @endcond
 
+/**
+ * @lang{ZH}
+ * @brief 解析日期字段的辅助结构（`HaveDate = true` 特化）。
+ *
+ * 作为 `time_parse_context` 的基类，负责累积从格式说明符解析到的日期字段
+ * （年、月、日、星期、一年中的第几天等），并在转换时通过 `compute_ymd()` 将
+ * 这些字段还原为 `std::chrono::year_month_day`。
+ *
+ * @note 此结构为内部实现细节；请通过 `time_parse_context` 访问其功能。
+ * @tparam CharT 字符类型，用于持有纪元条目的字符串。
+ * @endif
+ *
+ * @lang{EN}
+ * @brief Date-field accumulator helper struct (`HaveDate = true` specialization).
+ *
+ * Serves as a base class of `time_parse_context`, accumulating date fields
+ * parsed from format specifiers (year, month, day, weekday, day-of-year, etc.)
+ * and reconstructing a `std::chrono::year_month_day` via `compute_ymd()` on
+ * conversion.
+ *
+ * @note This struct is an internal implementation detail; access its functionality
+ *       through `time_parse_context`.
+ * @tparam CharT The character type, used for era entry strings.
+ * @endif
+ */
 template <typename CharT>
 struct date_parse_helper<CharT, true>
 {
+    /// @cond
     bool operator==(const date_parse_helper&) const = default;  // for test
+    /// @endcond
     date_parse_helper()
     {
         using namespace std::chrono;
@@ -48,6 +106,19 @@ struct date_parse_helper<CharT, true>
         m_mday = unsigned(ymd.day());
     }
 
+    /**
+     * @lang{ZH}
+     * @brief 将已累积的日期字段转换为 `std::chrono::year_month_day`。
+     * @return 还原出的日历日期。
+     * @throw stream_error 若还原结果不是有效的日历日期。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Converts the accumulated date fields to `std::chrono::year_month_day`.
+     * @return The reconstructed calendar date.
+     * @throw stream_error If the reconstructed date is not a valid calendar date.
+     * @endif
+     */
     explicit operator std::chrono::year_month_day() const
     {
         auto ymd = compute_ymd();
@@ -56,6 +127,32 @@ struct date_parse_helper<CharT, true>
         return ymd;
     }
 
+    /**
+     * @lang{ZH}
+     * @brief 根据已累积的字段推算 `std::chrono::year_month_day`（不做有效性检查）。
+     *
+     * 按以下优先级尝试各种推算路径：
+     * 1. 年 + 月 + 日；
+     * 2. 年 + 年内第几天（`%j`）；
+     * 3. ISO-8601 周日期（`%G`/`%Y` + `%V` + 星期）；
+     * 4. 根据周序号（`%U`/`%W`）和星期推算；
+     * 5. 仅根据年份或世纪等做尽力推算。
+     * @return 推算出的日历日期（可能无效，调用方需检查 `ok()`）。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Deduces a `std::chrono::year_month_day` from the accumulated fields
+     *        without validity checking.
+     *
+     * The following deduction paths are tried in priority order:
+     * 1. year + month + day;
+     * 2. year + day-of-year (`%j`);
+     * 3. ISO-8601 week date (`%G`/`%Y` + `%V` + weekday);
+     * 4. deduction from week-of-year (`%U`/`%W`) and weekday;
+     * 5. best-effort deduction from year or century alone.
+     * @return The deduced calendar date (may be invalid; caller must check `ok()`).
+     * @endif
+     */
     std::chrono::year_month_day compute_ymd() const
     {
         using namespace std::chrono;
@@ -337,15 +434,57 @@ private:
     }
 };
 
+/// @cond
 template <bool> struct time_parse_helper
 {
     bool operator==(const time_parse_helper&) const = default;  // for test
 };
+/// @endcond
 
+/**
+ * @lang{ZH}
+ * @brief 解析时间字段的辅助结构（`HaveTime = true` 特化）。
+ *
+ * 作为 `time_parse_context` 的基类，累积从格式说明符解析到的时、分、秒及 AM/PM 标志，
+ * 并在转换时还原为 `std::chrono::hh_mm_ss<std::chrono::seconds>`。
+ *
+ * @note 此结构为内部实现细节；请通过 `time_parse_context` 访问其功能。
+ * @endif
+ *
+ * @lang{EN}
+ * @brief Time-field accumulator helper struct (`HaveTime = true` specialization).
+ *
+ * Serves as a base class of `time_parse_context`, accumulating hour, minute,
+ * second, and AM/PM fields parsed from format specifiers, then reconstructing
+ * a `std::chrono::hh_mm_ss<std::chrono::seconds>` on conversion.
+ *
+ * @note This struct is an internal implementation detail; access its functionality
+ *       through `time_parse_context`.
+ * @endif
+ */
 template <>
 struct time_parse_helper<true>
 {
+    /// @cond
     bool operator==(const time_parse_helper&) const = default;  // for test
+    /// @endcond
+    /**
+     * @lang{ZH}
+     * @brief 将已累积的时间字段转换为 `std::chrono::hh_mm_ss<std::chrono::seconds>`。
+     *
+     * 若通过 `%I`（12 小时制）解析并设置了 PM 标志，则自动加上 12 小时。
+     * @return 还原出的 24 小时制时间。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Converts the accumulated time fields to
+     *        `std::chrono::hh_mm_ss<std::chrono::seconds>`.
+     *
+     * If the hour was parsed via `%I` (12-hour clock) and the PM flag is set,
+     * 12 hours are added automatically.
+     * @return The reconstructed 24-hour time-of-day.
+     * @endif
+     */
     explicit operator std::chrono::hh_mm_ss<std::chrono::seconds>() const
     {
         uint8_t hour_in_24 = m_hour;
@@ -370,15 +509,62 @@ struct time_parse_helper<true>
     bool m_is_pm : 1 = false;
 };
 
+/// @cond
 template <bool> struct time_zone_parse_helper
 {
     bool operator==(const time_zone_parse_helper&) const = default;  // for test
 };
+/// @endcond
 
+/**
+ * @lang{ZH}
+ * @brief 解析时区字段的辅助结构（`HaveTimeZone = true` 特化）。
+ *
+ * 作为 `time_parse_context` 的基类，累积从 `%Z` 格式说明符解析到的时区名称或
+ * 时区缩写，并在转换时还原为 `const std::chrono::time_zone*`。
+ *
+ * @note 此结构为内部实现细节；请通过 `time_parse_context` 访问其功能。
+ * @endif
+ *
+ * @lang{EN}
+ * @brief Time-zone-field accumulator helper struct (`HaveTimeZone = true` specialization).
+ *
+ * Serves as a base class of `time_parse_context`, accumulating the timezone name
+ * or abbreviation parsed from the `%Z` format specifier, then resolving it to a
+ * `const std::chrono::time_zone*` on conversion.
+ *
+ * @note This struct is an internal implementation detail; access its functionality
+ *       through `time_parse_context`.
+ * @endif
+ */
 template <>
 struct time_zone_parse_helper<true>
 {
+    /// @cond
     bool operator==(const time_zone_parse_helper&) const = default;  // for test
+    /// @endcond
+    /**
+     * @lang{ZH}
+     * @brief 将已解析的时区信息转换为 `const std::chrono::time_zone*`。
+     *
+     * 若已解析到完整 IANA 时区名称，则通过 `std::chrono::locate_zone` 定位；
+     * 若仅有时区缩写（有歧义），则抛出 `stream_error`；
+     * 若两者均无，则默认返回 UTC。
+     * @return 指向时区对象的指针（从不为 null）。
+     * @throw stream_error 若时区缩写有歧义或时区数据库不可用。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Converts the parsed timezone information to `const std::chrono::time_zone*`.
+     *
+     * If a full IANA timezone name was parsed, it is located via
+     * `std::chrono::locate_zone`. If only an abbreviation was parsed (ambiguous),
+     * a `stream_error` is thrown. If neither is present, UTC is returned as default.
+     * @return A non-null pointer to the timezone object.
+     * @throw stream_error If the timezone abbreviation is ambiguous or the tz
+     *        database is unavailable.
+     * @endif
+     */
     explicit operator const std::chrono::time_zone*() const
     {
         if (!m_zone_name.empty())
@@ -400,23 +586,109 @@ struct time_zone_parse_helper<true>
     std::string m_zone_abbrev;
 };
 
+/**
+ * @lang{ZH}
+ * @brief `timeio::get()` 的聚合解析上下文。
+ *
+ * 将日期、时间、时区三个辅助结构组合为统一的解析状态容器，作为 `get()` 的输出参数。
+ * 模板参数控制哪些字段被激活：
+ * - `HaveDate`：启用日期字段（年、月、日、星期等）；
+ * - `HaveTime`：启用时间字段（时、分、秒、AM/PM 等）；
+ * - `HaveTimeZone`：启用时区字段（`%Z`）。
+ *
+ * 典型用法：
+ * 1. 默认构造一个 `time_parse_context`；
+ * 2. 将其传入一次或多次 `get()` 调用（跨多次调用累积同一值的字段）；
+ * 3. 调用转换运算符提取结果；
+ * 4. 若要解析下一个不同的时间值，先调用 `reset()`。
+ *
+ * @tparam CharT       字符类型。
+ * @tparam HaveDate    为 `true` 时激活日期解析，默认 `true`。
+ * @tparam HaveTime    为 `true` 时激活时间解析，默认 `true`。
+ * @tparam HaveTimeZone 为 `true` 时激活时区解析，默认 `true`。
+ * @endif
+ *
+ * @lang{EN}
+ * @brief Aggregate parse context for `timeio::get()`.
+ *
+ * Combines the date, time, and time-zone helper structs into a single
+ * parse-state container used as the output argument of `get()`.
+ * Template parameters control which fields are activated:
+ * - `HaveDate`: enables date fields (year, month, day, weekday, etc.);
+ * - `HaveTime`: enables time fields (hour, minute, second, AM/PM, etc.);
+ * - `HaveTimeZone`: enables timezone fields (`%Z`).
+ *
+ * Typical usage:
+ * 1. Default-construct a `time_parse_context`;
+ * 2. Pass it to one or more `get()` calls (fields of the *same* value
+ *    accumulate across multiple calls);
+ * 3. Call a conversion operator to extract the result;
+ * 4. Call `reset()` before parsing a *different* time value.
+ *
+ * @tparam CharT        The character type.
+ * @tparam HaveDate     Activates date parsing when `true` (default `true`).
+ * @tparam HaveTime     Activates time parsing when `true` (default `true`).
+ * @tparam HaveTimeZone Activates timezone parsing when `true` (default `true`).
+ * @endif
+ */
 template <typename CharT, bool HaveDate = true, bool HaveTime = true, bool HaveTimeZone = true>
 struct time_parse_context
     : date_parse_helper<CharT, HaveDate>
     , time_parse_helper<HaveTime>
     , time_zone_parse_helper<HaveTimeZone>
 {
+    /// @cond
     bool operator==(const time_parse_context&) const = default;
+    /// @endcond
 
+    /**
+     * @lang{ZH}
+     * @brief 默认构造函数，所有字段初始化为默认值。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Default constructor; all fields are initialized to their defaults.
+     * @endif
+     */
     time_parse_context() = default;
 
-    // Clears all accumulated parse state (date / time / time-zone fields, the
-    // have_* flags, the era working set and the is_init guard), restoring the
-    // context to its default-constructed state. Call this before reusing one
-    // context to parse a *different* time value; skip it to keep accumulating
-    // fields of the *same* value across multiple get() calls.
+    /**
+     * @lang{ZH}
+     * @brief 清除所有已累积的解析状态，恢复到默认构造时的状态。
+     *
+     * 在复用同一上下文解析**不同**时间值之前调用此函数；
+     * 若要在多次 `get()` 调用中累积**同一**时间值的字段，则无需调用。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Clears all accumulated parse state, restoring the context to its
+     *        default-constructed state.
+     *
+     * Call this before reusing one context to parse a *different* time value;
+     * skip it to keep accumulating fields of the *same* value across multiple
+     * `get()` calls.
+     * @endif
+     */
     void reset() { *this = time_parse_context{}; }
 
+    /**
+     * @lang{ZH}
+     * @brief 将已累积的日期、时间和时区字段转换为 `std::chrono::zoned_time<seconds>`。
+     *
+     * 仅当 `HaveDate`、`HaveTime` 和 `HaveTimeZone` 均为 `true` 时可用。
+     * @return 还原出的带时区时间点。
+     * @throw stream_error 若日期无效或时区解析失败。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Converts the accumulated date, time, and timezone fields to
+     *        `std::chrono::zoned_time<seconds>`.
+     *
+     * Available only when `HaveDate`, `HaveTime`, and `HaveTimeZone` are all `true`.
+     * @return The reconstructed zoned time point.
+     * @throw stream_error If the date is invalid or the timezone lookup fails.
+     * @endif
+     */
     explicit operator const std::chrono::zoned_time<std::chrono::seconds>() const
         requires(HaveDate && HaveTime && HaveTimeZone)
     {
@@ -429,6 +701,23 @@ struct time_parse_context
         return zoned_time<seconds>{tz, lt};
     }
 
+    /**
+     * @lang{ZH}
+     * @brief 将已累积的日期和时间字段转换为 `std::tm`。
+     *
+     * 仅当 `HaveDate` 和 `HaveTime` 均为 `true` 时可用。
+     * @return 还原出的 `std::tm` 结构体。
+     * @throw stream_error 若日期无效。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Converts the accumulated date and time fields to `std::tm`.
+     *
+     * Available only when both `HaveDate` and `HaveTime` are `true`.
+     * @return The reconstructed `std::tm` struct.
+     * @throw stream_error If the date is invalid.
+     * @endif
+     */
     explicit operator std::tm() const
         requires(HaveDate && HaveTime)
     {
@@ -462,6 +751,58 @@ struct time_parse_context
     }
 };
 
+/**
+ * @lang{ZH}
+ * @brief 时间 I/O facet，提供日期/时间的格式化输出与 locale 感知解析。
+ *
+ * `timeio` 实现了 `strftime`/`strptime` 风格的日期时间格式化与解析，
+ * 支持完整的格式说明符集合（包括 `E`/`O` 修饰符与纪元扩展）。
+ * 从 `timeio_conf<CharT>` 加载 locale 数据（星期/月份名称、格式串、
+ * 替代数字、纪元条目），可选与 `ctype<CharT>` 配合使用以支持 locale
+ * 感知的空白字符识别。
+ *
+ * **格式化**（`put`）：接受 `std::chrono::year_month_day`、
+ * `std::chrono::hh_mm_ss`、`std::chrono::zoned_time` 或 `std::tm`，
+ * 将其按指定格式串写入输出迭代器。
+ *
+ * **解析**（`get`）：从输入迭代器按指定格式串解析时间字段，
+ * 将结果累积到 `time_parse_context` 中；解析完成后通过转换运算符
+ * 提取 `year_month_day`、`hh_mm_ss` 或 `zoned_time`。
+ *
+ * @note 格式串来自 locale 数据库（`nl_langinfo`），视为受信任输入；
+ *   含自引用格式串（如 `D_T_FMT == "%c"`）将导致无限递归。参见
+ *   `do_get` 中关于受信任 locale 假设的说明。
+ *
+ * @tparam CharT 字符类型（`char`、`wchar_t`、`char8_t`、`char32_t`）。
+ * @endif
+ *
+ * @lang{EN}
+ * @brief Time I/O facet providing locale-aware date/time formatting and parsing.
+ *
+ * `timeio` implements `strftime`/`strptime`-style date-time formatting and
+ * parsing, supporting the full set of format specifiers including `E`/`O`
+ * modifiers and era extensions. It loads locale data from `timeio_conf<CharT>`
+ * (weekday/month names, format strings, alternative digits, era entries) and
+ * optionally cooperates with `ctype<CharT>` for locale-aware whitespace
+ * recognition.
+ *
+ * **Formatting** (`put`): accepts `std::chrono::year_month_day`,
+ * `std::chrono::hh_mm_ss`, `std::chrono::zoned_time`, or `std::tm` and
+ * writes the result to an output iterator according to the given format string.
+ *
+ * **Parsing** (`get`): parses time fields from an input iterator according to
+ * a format string, accumulating results into a `time_parse_context`; after
+ * parsing, a conversion operator on the context extracts a `year_month_day`,
+ * `hh_mm_ss`, or `zoned_time`.
+ *
+ * @note Format strings sourced from the locale database (`nl_langinfo`) are
+ *   treated as trusted input; a self-referential format string (e.g.
+ *   `D_T_FMT == "%c"`) would cause unbounded recursion. See the note in
+ *   `do_get` regarding the trusted-locale assumption.
+ *
+ * @tparam CharT The character type (`char`, `wchar_t`, `char8_t`, `char32_t`).
+ * @endif
+ */
 template <typename CharT>
 class timeio
 {
@@ -474,6 +815,32 @@ public:
 
     using char_type = CharT;
 
+    /**
+     * @lang{ZH}
+     * @brief 构造函数，从 locale 配置和 ctype facet 初始化。
+     *
+     * 先委托给单参数构造函数完成 locale 数据加载，再保存 `ctype` 指针用于
+     * locale 感知的空白字符识别（`is_space`）。
+     * @tparam TConfPtr  指向 `timeio_conf<CharT>` 的 `shared_ptr` 类型。
+     * @tparam TCtypePtr 指向 `ctype<CharT>` 的 `shared_ptr` 类型。
+     * @param p_obj   locale 配置对象（不得为空）。
+     * @param p_ctype ctype facet（不得为空）。
+     * @throw std::runtime_error 若任一指针为空。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Constructor that initializes from a locale configuration and a ctype facet.
+     *
+     * Delegates to the single-argument constructor to load locale data, then
+     * stores the `ctype` pointer for locale-aware whitespace recognition in
+     * `is_space`.
+     * @tparam TConfPtr  A `shared_ptr` type pointing to `timeio_conf<CharT>`.
+     * @tparam TCtypePtr A `shared_ptr` type pointing to `ctype<CharT>`.
+     * @param p_obj   The locale configuration object (must not be null).
+     * @param p_ctype The ctype facet (must not be null).
+     * @throw std::runtime_error If either pointer is null.
+     * @endif
+     */
     template <shared_ptr_to<timeio_conf<CharT>> TConfPtr,
               shared_ptr_to<ctype<CharT>> TCtypePtr>
     timeio(TConfPtr p_obj, TCtypePtr p_ctype)
@@ -483,6 +850,32 @@ public:
         m_ctype = p_ctype;
     }
 
+    /**
+     * @lang{ZH}
+     * @brief 构造函数，从 locale 配置初始化。
+     *
+     * 从 `timeio_conf<CharT>` 复制所有 locale 数据（名称、格式串、纪元条目等），
+     * 验证名称表的唯一性，并构建用于高效解析的前缀树（星期、月份、AM/PM、
+     * 纪元名称、替代数字）。若未提供 ctype，空白字符识别使用基础 ASCII 判断。
+     * @tparam TConfPtr 指向 `timeio_conf<CharT>` 的 `shared_ptr` 类型。
+     * @param p_obj locale 配置对象（不得为空）。
+     * @throw std::runtime_error 若指针为空或 locale 名称表存在重复/空条目。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Constructor that initializes from a locale configuration.
+     *
+     * Copies all locale data from `timeio_conf<CharT>` (names, format strings,
+     * era entries, etc.), validates the name tables for uniqueness, and builds
+     * prefix tries for efficient parsing (weekday, month, AM/PM, era names,
+     * alternative digits). If no ctype is provided, whitespace recognition uses
+     * basic ASCII comparison.
+     * @tparam TConfPtr A `shared_ptr` type pointing to `timeio_conf<CharT>`.
+     * @param p_obj The locale configuration object (must not be null).
+     * @throw std::runtime_error If the pointer is null or the locale name tables
+     *        contain duplicates or empty entries.
+     * @endif
+     */
     template <shared_ptr_to<timeio_conf<CharT>> TConfPtr>
     timeio(TConfPtr p_obj)
     {
@@ -535,21 +928,162 @@ public:
     }
 
 public:
+    /**
+     * @lang{ZH}
+     * @brief 返回星期全称数组（索引 0 为星期日，索引 6 为星期六）。
+     * @endif
+     * @lang{EN}
+     * @brief Returns the full weekday name array (index 0 = Sunday, index 6 = Saturday).
+     * @endif
+     */
     const std::array<std::basic_string<CharT>, 7>& day_names() const noexcept { return m_day; }
+    /**
+     * @lang{ZH}
+     * @brief 返回星期缩写数组（索引 0 为星期日，索引 6 为星期六）。
+     * @endif
+     * @lang{EN}
+     * @brief Returns the abbreviated weekday name array (index 0 = Sunday, index 6 = Saturday).
+     * @endif
+     */
     const std::array<std::basic_string<CharT>, 7>& abbr_day_names() const noexcept { return m_abbr_day; }
+    /**
+     * @lang{ZH}
+     * @brief 返回月份全称数组（索引 0 为一月，索引 11 为十二月）。
+     * @endif
+     * @lang{EN}
+     * @brief Returns the full month name array (index 0 = January, index 11 = December).
+     * @endif
+     */
     const std::array<std::basic_string<CharT>, 12>& month_names() const noexcept { return m_month; }
+    /**
+     * @lang{ZH}
+     * @brief 返回月份缩写数组（索引 0 为一月，索引 11 为十二月）。
+     * @endif
+     * @lang{EN}
+     * @brief Returns the abbreviated month name array (index 0 = January, index 11 = December).
+     * @endif
+     */
     const std::array<std::basic_string<CharT>, 12>& abbr_month_names() const noexcept { return m_abbr_month; }
+    /**
+     * @lang{ZH}
+     * @brief 返回 locale 定义的替代数字字符串数组（最多 100 项）。
+     * @endif
+     * @lang{EN}
+     * @brief Returns the locale-defined alternative digit strings (up to 100 entries).
+     * @endif
+     */
     const std::array<std::basic_string<CharT>, 100>& alt_digit_names() const noexcept { return m_alt_digits; }
+    /**
+     * @lang{ZH}
+     * @brief 返回 AM 时段字符串。
+     * @endif
+     * @lang{EN}
+     * @brief Returns the AM period string.
+     * @endif
+     */
     const std::basic_string<CharT>& am_name() const noexcept { return m_am; }
+    /**
+     * @lang{ZH}
+     * @brief 返回 PM 时段字符串。
+     * @endif
+     * @lang{EN}
+     * @brief Returns the PM period string.
+     * @endif
+     */
     const std::basic_string<CharT>& pm_name() const noexcept { return m_pm; }
+    /**
+     * @lang{ZH}
+     * @brief 返回 locale 日期格式串（对应 `%x`）。
+     * @endif
+     * @lang{EN}
+     * @brief Returns the locale date format string (corresponding to `%x`).
+     * @endif
+     */
     const std::basic_string<CharT>& date_format() const noexcept { return m_date_format; }
+    /**
+     * @lang{ZH}
+     * @brief 返回 locale 纪元修饰日期格式串（对应 `%Ex`）。
+     * @endif
+     * @lang{EN}
+     * @brief Returns the locale era-modified date format string (corresponding to `%Ex`).
+     * @endif
+     */
     const std::basic_string<CharT>& era_date_format() const noexcept { return m_era_date_format; }
+    /**
+     * @lang{ZH}
+     * @brief 返回 locale 时间格式串（对应 `%X`）。
+     * @endif
+     * @lang{EN}
+     * @brief Returns the locale time format string (corresponding to `%X`).
+     * @endif
+     */
     const std::basic_string<CharT>& time_format() const noexcept { return m_time_format; }
+    /**
+     * @lang{ZH}
+     * @brief 返回 locale 纪元修饰时间格式串（对应 `%EX`）。
+     * @endif
+     * @lang{EN}
+     * @brief Returns the locale era-modified time format string (corresponding to `%EX`).
+     * @endif
+     */
     const std::basic_string<CharT>& era_time_format() const noexcept { return m_era_time_format; }
+    /**
+     * @lang{ZH}
+     * @brief 返回 locale 日期时间格式串（对应 `%c`）。
+     * @endif
+     * @lang{EN}
+     * @brief Returns the locale date-time format string (corresponding to `%c`).
+     * @endif
+     */
     const std::basic_string<CharT>& date_time_format() const noexcept { return m_date_time_format; }
+    /**
+     * @lang{ZH}
+     * @brief 返回 locale 纪元修饰日期时间格式串（对应 `%Ec`）。
+     * @endif
+     * @lang{EN}
+     * @brief Returns the locale era-modified date-time format string (corresponding to `%Ec`).
+     * @endif
+     */
     const std::basic_string<CharT>& era_date_time_format() const noexcept { return m_era_date_time_format; }
+    /**
+     * @lang{ZH}
+     * @brief 返回 AM/PM 时间格式串（对应 `%r`）。
+     * @endif
+     * @lang{EN}
+     * @brief Returns the AM/PM time format string (corresponding to `%r`).
+     * @endif
+     */
     const std::basic_string<CharT>& am_pm_format() const noexcept { return m_am_pm_format; }
 
+    /**
+     * @lang{ZH}
+     * @brief 按单个格式字符（可带修饰符）格式化时间值。
+     *
+     * 将 `format`（以及可选的 `modifier`）组合为 `%[modifier]format` 格式串后
+     * 委托给 `put(out, t, fmt)`。
+     * @tparam OutIt 输出迭代器类型。
+     * @tparam TVal  时间值类型（`year_month_day`、`hh_mm_ss`、`zoned_time` 或 `std::tm`）。
+     * @param out      输出迭代器。
+     * @param t        要格式化的时间值。
+     * @param format   格式字符（如 `'Y'`、`'m'`、`'d'`）。
+     * @param modifier 可选修饰符（`'E'`、`'O'` 或 `0` 表示无修饰符）。
+     * @return 写入后的输出迭代器。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Formats a time value using a single format character (with optional modifier).
+     *
+     * Combines `format` and the optional `modifier` into a `%[modifier]format`
+     * string, then delegates to `put(out, t, fmt)`.
+     * @tparam OutIt Output iterator type.
+     * @tparam TVal  Time value type (`year_month_day`, `hh_mm_ss`, `zoned_time`, or `std::tm`).
+     * @param out      The output iterator.
+     * @param t        The time value to format.
+     * @param format   The format character (e.g. `'Y'`, `'m'`, `'d'`).
+     * @param modifier Optional modifier (`'E'`, `'O'`, or `0` for none).
+     * @return The output iterator after writing.
+     * @endif
+     */
     template <typename OutIt, typename TVal>
     OutIt put(OutIt out, const TVal& t, char format, char modifier = 0) const // NOLINT(bugprone-easily-swappable-parameters)
     {
@@ -569,6 +1103,31 @@ public:
         return put(out, t, fmt);
     }
 
+    /**
+     * @lang{ZH}
+     * @brief 将 `std::chrono::zoned_time` 按格式串格式化到输出迭代器。
+     * @tparam OutIt       输出迭代器类型。
+     * @tparam Duration    `zoned_time` 的时间精度类型。
+     * @tparam TimeZonePtr `zoned_time` 的时区指针类型。
+     * @param out 输出迭代器。
+     * @param t   要格式化的带时区时间点。
+     * @param fmt 格式串（`strftime` 风格）。
+     * @return 写入后的输出迭代器。
+     * @throw stream_error 若 `zoned_time` 的日期超出范围。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Formats a `std::chrono::zoned_time` to an output iterator using a format string.
+     * @tparam OutIt       Output iterator type.
+     * @tparam Duration    Duration type of the `zoned_time`.
+     * @tparam TimeZonePtr Time-zone pointer type of the `zoned_time`.
+     * @param out The output iterator.
+     * @param t   The zoned time point to format.
+     * @param fmt The format string (`strftime`-style).
+     * @return The output iterator after writing.
+     * @throw stream_error If the date of the `zoned_time` is out of range.
+     * @endif
+     */
     template <typename OutIt, typename Duration, typename TimeZonePtr>
     OutIt put(OutIt out, const std::chrono::zoned_time<Duration, TimeZonePtr>& t, std::basic_string_view<CharT> fmt) const
     {
@@ -586,6 +1145,27 @@ public:
         return do_put(out, fmt, &ymd, &wd, &time_of_day, t.get_time_zone());
     }
 
+    /**
+     * @lang{ZH}
+     * @brief 将 `std::chrono::year_month_day` 按格式串格式化到输出迭代器。
+     * @tparam OutIt 输出迭代器类型。
+     * @param out 输出迭代器。
+     * @param t   要格式化的日历日期（必须是有效日期）。
+     * @param fmt 格式串（`strftime` 风格）。
+     * @return 写入后的输出迭代器。
+     * @throw stream_error 若 `t` 不是有效的日历日期。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Formats a `std::chrono::year_month_day` to an output iterator using a format string.
+     * @tparam OutIt Output iterator type.
+     * @param out The output iterator.
+     * @param t   The calendar date to format (must be a valid date).
+     * @param fmt The format string (`strftime`-style).
+     * @return The output iterator after writing.
+     * @throw stream_error If `t` is not a valid calendar date.
+     * @endif
+     */
     template <typename OutIt>
     OutIt put(OutIt out, const std::chrono::year_month_day& t, std::basic_string_view<CharT> fmt) const
     {
@@ -596,6 +1176,34 @@ public:
         return do_put(out, fmt, &t, &wd, nullptr, nullptr);
     }
 
+    /**
+     * @lang{ZH}
+     * @brief 将 `std::chrono::hh_mm_ss` 按格式串格式化到输出迭代器。
+     *
+     * 输入时间必须在 `[00:00:00, 23:59:59]` 范围内（不支持闰秒）。
+     * @tparam OutIt     输出迭代器类型。
+     * @tparam TDuration `hh_mm_ss` 的时间精度类型。
+     * @param out 输出迭代器。
+     * @param t   要格式化的一天中的时间。
+     * @param fmt 格式串（`strftime` 风格）。
+     * @return 写入后的输出迭代器。
+     * @throw stream_error 若 `t` 超出有效时间范围（负数或 ≥ 24 小时）。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Formats a `std::chrono::hh_mm_ss` to an output iterator using a format string.
+     *
+     * The input time must be in the range `[00:00:00, 23:59:59]`; leap seconds
+     * are not supported.
+     * @tparam OutIt     Output iterator type.
+     * @tparam TDuration Duration type of the `hh_mm_ss`.
+     * @param out The output iterator.
+     * @param t   The time-of-day to format.
+     * @param fmt The format string (`strftime`-style).
+     * @return The output iterator after writing.
+     * @throw stream_error If `t` is outside the valid range (negative or ≥ 24 hours).
+     * @endif
+     */
     template <typename OutIt, typename TDuration>
     OutIt put(OutIt out, const std::chrono::hh_mm_ss<TDuration>& t, std::basic_string_view<CharT> fmt) const
     {
@@ -609,6 +1217,36 @@ public:
         return do_put(out, fmt, nullptr, nullptr, &t_sec, nullptr);
     }
 
+    /**
+     * @lang{ZH}
+     * @brief 将 `std::tm` 按格式串格式化到输出迭代器。
+     *
+     * 在格式化前对 `std::tm` 的各字段进行范围验证，并拒绝闰秒（`tm_sec == 60`）。
+     * 具体检查项：月份 [0,11]、日期 [1,31]、时 [0,23]、分/秒 [0,59]，
+     * 以及年份需在 `std::chrono::year` 的有效范围内，且日期组合需构成有效日历日期。
+     * @tparam OutIt 输出迭代器类型。
+     * @param out 输出迭代器。
+     * @param t   要格式化的 `std::tm` 结构体。
+     * @param fmt 格式串（`strftime` 风格）。
+     * @return 写入后的输出迭代器。
+     * @throw stream_error 若任何字段超出范围或日期组合无效。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Formats a `std::tm` to an output iterator using a format string.
+     *
+     * Validates all `std::tm` fields before formatting and rejects leap seconds
+     * (`tm_sec == 60`). Checks include: month [0,11], day [1,31], hour [0,23],
+     * minute/second [0,59], year within the valid range of `std::chrono::year`,
+     * and that the date combination forms a valid calendar date.
+     * @tparam OutIt Output iterator type.
+     * @param out The output iterator.
+     * @param t   The `std::tm` struct to format.
+     * @param fmt The format string (`strftime`-style).
+     * @return The output iterator after writing.
+     * @throw stream_error If any field is out of range or the date combination is invalid.
+     * @endif
+     */
     template <typename OutIt>
     OutIt put(OutIt out, const std::tm& t, std::basic_string_view<CharT> fmt) const
     {
@@ -643,6 +1281,46 @@ public:
         return do_put(out, fmt, &ymd, &wd, &hms, nullptr);
     }
 
+    /**
+     * @lang{ZH}
+     * @brief 按单个格式字符（可带修饰符）从输入范围中解析时间字段。
+     *
+     * 将 `format` 与可选的 `modifier` 组合为 `%[modifier]format` 格式串后
+     * 委托给 `get(beg, end, ctx, fmt)`。
+     * @tparam TIter      双向迭代器或 `istreambuf_iterator` 类型。
+     * @tparam TSent      哨兵类型。
+     * @tparam HaveDate   是否解析日期字段。
+     * @tparam HaveTime   是否解析时间字段。
+     * @tparam HaveTimeZone 是否解析时区字段。
+     * @param beg      输入范围起始迭代器。
+     * @param end      输入范围结束哨兵。
+     * @param ctx      累积解析结果的上下文（in/out）。
+     * @param format   格式字符（如 `'Y'`、`'m'`、`'d'`）。
+     * @param modifier 可选修饰符（`'E'`、`'O'` 或 `0` 表示无修饰符）。
+     * @return 指向未被消费的第一个字符的迭代器。
+     * @throw stream_error 若解析失败。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Parses time fields from an input range using a single format character
+     *        (with optional modifier).
+     *
+     * Combines `format` and the optional `modifier` into a `%[modifier]format`
+     * string, then delegates to `get(beg, end, ctx, fmt)`.
+     * @tparam TIter      Bidirectional iterator or `istreambuf_iterator` type.
+     * @tparam TSent      Sentinel type.
+     * @tparam HaveDate   Whether date fields are parsed.
+     * @tparam HaveTime   Whether time fields are parsed.
+     * @tparam HaveTimeZone Whether timezone fields are parsed.
+     * @param beg      Beginning of the input range.
+     * @param end      End sentinel of the input range.
+     * @param ctx      Parse context accumulating results (in/out).
+     * @param format   The format character (e.g. `'Y'`, `'m'`, `'d'`).
+     * @param modifier Optional modifier (`'E'`, `'O'`, or `0` for none).
+     * @return Iterator pointing to the first unconsumed character.
+     * @throw stream_error If parsing fails.
+     * @endif
+     */
     template <typename TIter, std::sentinel_for<TIter> TSent, bool HaveDate, bool HaveTime, bool HaveTimeZone>
         requires (std::bidirectional_iterator<TIter> || is_istreambuf_iterator<TIter>)
     TIter get(TIter beg, TSent end, time_parse_context<char_type, HaveDate, HaveTime, HaveTimeZone>& ctx,
@@ -664,6 +1342,47 @@ public:
         }
     }
 
+    /**
+     * @lang{ZH}
+     * @brief 按格式串从输入范围中解析时间字段，将结果累积到 `ctx`。
+     *
+     * 各格式说明符与 POSIX `strptime` / `std::chrono::from_stream` 的语义一致。
+     * 复合说明符（`%c`、`%x`、`%X`、`%r`、`%EY`）会将 locale 提供的格式串
+     * 展开后递归处理，详见 `do_get` 中关于受信任 locale 假设的说明。
+     * @tparam TIter      双向迭代器或 `istreambuf_iterator` 类型。
+     * @tparam TSent      哨兵类型。
+     * @tparam HaveDate   是否解析日期字段。
+     * @tparam HaveTime   是否解析时间字段。
+     * @tparam HaveTimeZone 是否解析时区字段。
+     * @param rp     输入范围起始迭代器。
+     * @param rp_end 输入范围结束哨兵。
+     * @param ctx    累积解析结果的上下文（in/out）。
+     * @param _fmt   格式串（`strptime` 风格）。
+     * @return 指向未被消费的第一个字符的迭代器。
+     * @throw stream_error 若解析失败（格式不匹配或字段值超出范围）。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Parses time fields from an input range according to a format string,
+     *        accumulating results into `ctx`.
+     *
+     * Format specifiers follow the semantics of POSIX `strptime` /
+     * `std::chrono::from_stream`. Compound specifiers (`%c`, `%x`, `%X`, `%r`,
+     * `%EY`) expand locale-provided format strings and re-enter recursively;
+     * see the trusted-locale note in `do_get`.
+     * @tparam TIter      Bidirectional iterator or `istreambuf_iterator` type.
+     * @tparam TSent      Sentinel type.
+     * @tparam HaveDate   Whether date fields are parsed.
+     * @tparam HaveTime   Whether time fields are parsed.
+     * @tparam HaveTimeZone Whether timezone fields are parsed.
+     * @param rp     Beginning of the input range.
+     * @param rp_end End sentinel of the input range.
+     * @param ctx    Parse context accumulating results (in/out).
+     * @param _fmt   The format string (`strptime`-style).
+     * @return Iterator pointing to the first unconsumed character.
+     * @throw stream_error If parsing fails (format mismatch or field value out of range).
+     * @endif
+     */
     template <typename TIter, std::sentinel_for<TIter> TSent, bool HaveDate, bool HaveTime, bool HaveTimeZone>
         requires (std::bidirectional_iterator<TIter> || is_istreambuf_iterator<TIter>)
     TIter get(TIter rp, TSent rp_end, time_parse_context<char_type, HaveDate, HaveTime, HaveTimeZone>& ctx,
@@ -677,27 +1396,70 @@ public:
     }
 
 private:
-    // RECURSION / TRUSTED-LOCALE ASSUMPTION (applies to do_get and do_put):
-    //   Several compound specifiers expand a locale-provided format string and
-    //   re-enter this function recursively:
-    //     %c -> m_[era_]date_time[_zone]_format   %x -> m_[era_]date_format
-    //     %X -> m_[era_]time[_zone]_format        %r -> m_am_pm_format
-    //     %EY -> era->format (via m_era_formats)
-    //   Those strings come verbatim from the locale database (nl_langinfo / the
-    //   glibc era table) and are TRUSTED to be non self-referential: e.g.
-    //   D_T_FMT must not itself contain %c, an era format must not contain %EY,
-    //   and so on. No real locale violates this.
-    //
-    //   There is deliberately NO recursion-depth guard. The recursion is bounded
-    //   ONLY by that trust, NOT by the input: on these specifiers the recursive
-    //   call is made with the *same* rp (no input is consumed between dispatch
-    //   and recursion), so the `rp != rp_end` loop guard does not terminate a
-    //   self-referential format -- any non-empty input would recurse until the
-    //   stack overflows. A hand-crafted/corrupted locale is therefore the only
-    //   way to trigger unbounded recursion, and it is consciously left to the
-    //   same trust boundary as the rest of the locale data (see
-    //   timeio_details.h parse_glibc_era_entries INPUT CONTRACT). Hardening it
-    //   would require threading a depth budget through every recursive call site.
+    /**
+     * @lang{ZH}
+     * @brief 解析核心函数，按格式串逐字符处理输入，将结果写入 `ctx`。
+     *
+     * @note **递归与受信任 locale 假设**
+     *   以下复合说明符会将 locale 提供的格式串展开后递归调用此函数：
+     *   - `%c` → `m_[era_]date_time[_zone]_format`
+     *   - `%x` → `m_[era_]date_format`
+     *   - `%X` → `m_[era_]time[_zone]_format`
+     *   - `%r` → `m_am_pm_format`
+     *   - `%EY` → 纪元的 `format` 字符串
+     *
+     *   这些字符串来自 locale 数据库，视为受信任输入，假定不包含自引用
+     *   （如 `D_T_FMT` 不含 `%c`，纪元格式不含 `%EY`）。现实中不存在违反此
+     *   约定的 locale。**此处刻意不设置递归深度上限**：递归仅由受信任假设约束，
+     *   而非由输入约束——若 locale 存在自引用格式串，任意非空输入均会导致栈溢出。
+     *   手工构造或被篡改的 locale 是触发无限递归的唯一途径，其安全性与
+     *   `timeio_details.h` 中 `parse_glibc_era_entries` 的输入边界共用相同的
+     *   信任模型。若需加固，则需在所有递归调用点传递深度预算。
+     *
+     * @tparam TIter      双向迭代器或 `istreambuf_iterator` 类型。
+     * @tparam TSent      哨兵类型。
+     * @param rp     当前输入位置。
+     * @param rp_end 输入范围结束哨兵。
+     * @param ctx    累积解析结果的上下文（in/out）。
+     * @param succ   输出参数：解析成功时为 `true`，失败时置为 `false`。
+     * @param _fmt   格式串。
+     * @return 指向未被消费的第一个字符的迭代器。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Core parsing function that processes the input character by character
+     *        according to the format string, writing results to `ctx`.
+     *
+     * @note **Recursion and trusted-locale assumption**
+     *   The following compound specifiers expand a locale-provided format string
+     *   and re-enter this function recursively:
+     *   - `%c` → `m_[era_]date_time[_zone]_format`
+     *   - `%x` → `m_[era_]date_format`
+     *   - `%X` → `m_[era_]time[_zone]_format`
+     *   - `%r` → `m_am_pm_format`
+     *   - `%EY` → era `format` string
+     *
+     *   These strings come verbatim from the locale database and are TRUSTED to
+     *   be non-self-referential (e.g. `D_T_FMT` must not contain `%c`, an era
+     *   format must not contain `%EY`). No real locale violates this.
+     *   There is deliberately **NO recursion-depth guard**: the recursion is bounded
+     *   ONLY by that trust, not by the input — a self-referential format string
+     *   would recurse until the stack overflows on any non-empty input. A hand-crafted
+     *   or corrupted locale is the only way to trigger unbounded recursion, and this
+     *   is consciously left to the same trust boundary as `parse_glibc_era_entries`
+     *   in `timeio_details.h`. Hardening it would require threading a depth budget
+     *   through every recursive call site.
+     *
+     * @tparam TIter      Bidirectional iterator or `istreambuf_iterator` type.
+     * @tparam TSent      Sentinel type.
+     * @param rp     Current input position.
+     * @param rp_end End sentinel of the input range.
+     * @param ctx    Parse context accumulating results (in/out).
+     * @param succ   Output flag: set to `false` on parse failure.
+     * @param _fmt   The format string.
+     * @return Iterator pointing to the first unconsumed character.
+     * @endif
+     */
     template <typename TIter, std::sentinel_for<TIter> TSent, bool HaveDate, bool HaveTime, bool HaveTimeZone>
         requires (std::bidirectional_iterator<TIter> || is_istreambuf_iterator<TIter>)
     TIter do_get(TIter rp, TSent rp_end, time_parse_context<char_type, HaveDate, HaveTime, HaveTimeZone>& ctx,
@@ -1482,6 +2244,24 @@ private:
         return rp;
     }
 
+    /**
+     * @lang{ZH}
+     * @brief 判断字符是否为空白字符。
+     *
+     * 若已设置 `ctype` facet，则使用其 `space` 分类；否则回退为基础 ASCII 空白判断。
+     * @param c 要检查的字符。
+     * @return 若 `c` 为空白字符则返回 `true`。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Checks whether a character is a whitespace character.
+     *
+     * Uses the `ctype` facet's `space` classification if one is set; otherwise
+     * falls back to basic ASCII whitespace comparison.
+     * @param c The character to check.
+     * @return `true` if `c` is a whitespace character.
+     * @endif
+     */
     bool is_space(CharT c) const
     {
         if (m_ctype)
@@ -1491,9 +2271,30 @@ private:
                c == static_cast<CharT>('\f') || c == static_cast<CharT>('\r');
     }
 
-    // Throws std::runtime_error if any of the 2*N names is empty, or if one
-    // spelling is shared by two *different* indices. full[i] == abbr[i] (same
-    // index, e.g. "May" in en_US) is allowed.
+    /**
+     * @lang{ZH}
+     * @brief 验证名称数组中所有条目均非空，且不同索引的名称互不重复。
+     *
+     * 允许 `full[i] == abbr[i]`（同一索引的全称与缩写相同，如 en_US 的 "May"）。
+     * @tparam N 名称数组大小（7 或 12）。
+     * @param full 全称数组。
+     * @param abbr 缩写数组。
+     * @param what 名称类别描述（用于错误消息，如 `"day"` 或 `"month"`）。
+     * @throw std::runtime_error 若存在空名称或不同索引的名称重复。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Verifies that all entries in the name arrays are non-empty and that
+     *        no spelling is shared by two different indices.
+     *
+     * `full[i] == abbr[i]` (same index, e.g. "May" in en_US) is allowed.
+     * @tparam N Size of the name arrays (7 or 12).
+     * @param full The full-name array.
+     * @param abbr The abbreviated-name array.
+     * @param what A category label for error messages (e.g. `"day"` or `"month"`).
+     * @throw std::runtime_error If any name is empty or two different indices share a spelling.
+     * @endif
+     */
     template <size_t N>
     static void check_unique_nonempty(const std::array<std::basic_string<CharT>, N>& full,
                                       const std::array<std::basic_string<CharT>, N>& abbr,
@@ -1514,6 +2315,24 @@ private:
                     throw std::runtime_error(std::string("timeio: duplicate ") + what + " name in locale data");
     }
 
+    /**
+     * @lang{ZH}
+     * @brief 验证 locale 名称表的完整性。
+     *
+     * 检查星期和月份名称的非空性与唯一性；允许 AM/PM 为空（如 de_DE、fr_FR），
+     * 但若两者均非空且相同，则抛出异常。
+     * @throw std::runtime_error 若名称表存在无效条目。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Validates the integrity of the locale name tables.
+     *
+     * Checks weekday and month names for non-emptiness and uniqueness. AM/PM may
+     * legitimately be empty (e.g. de_DE, fr_FR); only a non-empty AM == PM
+     * collision is considered invalid.
+     * @throw std::runtime_error If the name tables contain invalid entries.
+     * @endif
+     */
     void validate_locale_names() const
     {
         check_unique_nonempty<7>(m_day, m_abbr_day, "day");
@@ -1526,6 +2345,15 @@ private:
             throw std::runtime_error("timeio: AM and PM designators are identical in locale data");
     }
 
+    /**
+     * @lang{ZH}
+     * @brief 从 `m_era_master` 构建纪元名称前缀树和纪元格式集合。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Builds the era name prefix trie and era format string set from `m_era_master`.
+     * @endif
+     */
     void create_era_name_tree()
     {
         for (size_t i = 0; i < m_era_master.size(); ++i)
@@ -1538,6 +2366,16 @@ private:
         }
     }
 
+    /**
+     * @lang{ZH}
+     * @brief 从 `m_alt_digits` 构建替代数字前缀树，用于 `%Od` 等说明符的解析。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Builds the alternative digits prefix trie from `m_alt_digits`,
+     *        used for parsing specifiers such as `%Od`.
+     * @endif
+     */
     void create_alt_digits_tree()
     {
         for (size_t i = 0; i < 100; ++i)
@@ -1547,11 +2385,43 @@ private:
         }
     }
 
-    // The compound specifiers %c / %x / %X / %r / %EY recurse into a
-    // locale-provided format string here, just as in do_get. The same
-    // trusted-locale, no-depth-guard assumption applies: a self-referential
-    // locale format string (e.g. D_T_FMT == "%c") would recurse without bound.
-    // See the RECURSION / TRUSTED-LOCALE ASSUMPTION note above do_get.
+    /**
+     * @lang{ZH}
+     * @brief 格式化核心函数，按格式串将日期/时间各分量写入输出迭代器。
+     *
+     * @note 复合说明符 `%c`、`%x`、`%X`、`%r`、`%EY` 会将 locale 提供的格式串
+     *   展开后递归调用此函数，与 `do_get` 共用相同的受信任 locale 假设：
+     *   自引用格式串（如 `D_T_FMT == "%c"`）将导致无限递归。
+     *
+     * @tparam OutIt 输出迭代器类型。
+     * @param out    输出迭代器。
+     * @param format 格式串（`strftime` 风格）。
+     * @param ymd    日期指针（若不含日期分量则为 `nullptr`）。
+     * @param wd     星期指针（若不含星期分量则为 `nullptr`）。
+     * @param hms    时间指针（若不含时间分量则为 `nullptr`）。
+     * @param tz     时区指针（若不含时区分量则为 `nullptr`）。
+     * @return 写入后的输出迭代器。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Core formatting function that writes date/time components to an output
+     *        iterator according to the format string.
+     *
+     * @note The compound specifiers `%c`, `%x`, `%X`, `%r`, `%EY` expand a
+     *   locale-provided format string and re-enter this function recursively,
+     *   sharing the same trusted-locale assumption as `do_get`: a self-referential
+     *   format string (e.g. `D_T_FMT == "%c"`) would recurse without bound.
+     *
+     * @tparam OutIt Output iterator type.
+     * @param out    The output iterator.
+     * @param format The format string (`strftime`-style).
+     * @param ymd    Date pointer (`nullptr` if no date components are needed).
+     * @param wd     Weekday pointer (`nullptr` if no weekday component is needed).
+     * @param hms    Time pointer (`nullptr` if no time components are needed).
+     * @param tz     Timezone pointer (`nullptr` if no timezone component is needed).
+     * @return The output iterator after writing.
+     * @endif
+     */
     template <typename OutIt>
     OutIt do_put(OutIt out, std::basic_string_view<CharT> format,
                  const std::chrono::year_month_day* ymd,
@@ -2041,6 +2911,19 @@ private:
     }
 
 private:
+    /**
+     * @lang{ZH}
+     * @brief 在 `m_era_master` 中查找包含指定日期的纪元条目。
+     * @param ymd 要查询的日历日期。
+     * @return 指向匹配的 `era_entry` 的指针；若无匹配则返回 `nullptr`。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Finds the era entry in `m_era_master` that contains the given date.
+     * @param ymd The calendar date to query.
+     * @return Pointer to the matching `era_entry`, or `nullptr` if none matches.
+     * @endif
+     */
     const era_entry* get_era_entry(const std::chrono::year_month_day& ymd) const
     {
         int year  = static_cast<int>(ymd.year());
@@ -2065,6 +2948,34 @@ private:
         return nullptr;
     }
 
+    /**
+     * @lang{ZH}
+     * @brief 将整数以十进制格式写入输出迭代器，支持替代数字。
+     *
+     * 若 `alt` 为 `true` 且 locale 为 `val` 定义了非空替代数字字符串，则输出该字符串；
+     * 否则委托给固定宽度的 `put_dec<n>(out, val)` 重载。
+     * @tparam n   最小宽度（不足时用 `def` 填充，`0` 表示不限宽度）。
+     * @tparam def 填充字符，默认为 `'0'`。
+     * @param out 输出迭代器。
+     * @param val 要输出的非负整数（断言 `[0, 99]`）。
+     * @param alt 若为 `true`，优先使用替代数字。
+     * @return 写入后的输出迭代器。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Writes an integer in decimal to the output iterator with alternative-digit support.
+     *
+     * If `alt` is `true` and the locale defines a non-empty alternative digit string for
+     * `val`, that string is emitted; otherwise delegates to the fixed-width
+     * `put_dec<n>(out, val)` overload.
+     * @tparam n   Minimum width (padded with `def`; `0` means no minimum).
+     * @tparam def Padding character, default `'0'`.
+     * @param out The output iterator.
+     * @param val The non-negative integer to output (asserted in `[0, 99]`).
+     * @param alt If `true`, prefer alternative digit strings.
+     * @return The output iterator after writing.
+     * @endif
+     */
     template <size_t n, CharT def = static_cast<CharT>('0'), typename OutIt>
     OutIt put_dec(OutIt out, int val, bool alt) const
     {
@@ -2081,6 +2992,32 @@ private:
         return out;
     }
 
+    /**
+     * @lang{ZH}
+     * @brief 将整数以最小宽度 `n` 的十进制格式写入输出迭代器。
+     *
+     * 若 `n == 0`，按实际位数输出（不限宽度）；否则最小输出 `n` 位，
+     * 前导位以 `def` 填充。永不截断（位数超过 `n` 时输出全部位数）。
+     * @tparam n   最小宽度（`0` 表示不限宽度）。
+     * @tparam def 前导填充字符，默认为 `'0'`。
+     * @param out 输出迭代器。
+     * @param val 要输出的整数。
+     * @return 写入后的输出迭代器。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Writes an integer in decimal with a minimum width of `n` to the output iterator.
+     *
+     * When `n == 0`, outputs the exact number of digits (no minimum). Otherwise,
+     * outputs at least `n` digits, padding leading positions with `def`. Never
+     * truncates (outputs all digits if the value exceeds `n` digits).
+     * @tparam n   Minimum width (`0` means no minimum).
+     * @tparam def Leading padding character, default `'0'`.
+     * @param out The output iterator.
+     * @param val The integer to output.
+     * @return The output iterator after writing.
+     * @endif
+     */
     template <size_t n, CharT def = static_cast<CharT>('0'), typename OutIt>
     OutIt put_dec(OutIt out, int val) const
     {
@@ -2116,6 +3053,42 @@ private:
         return out;
     }
 
+    /**
+     * @lang{ZH}
+     * @brief 从输入范围中解析最多 `len` 位的十进制整数，并写入 `member`。
+     *
+     * 解析成功（至少读取 1 位，且结果在 `[min_val, max_val]` 内）时更新 `member`；
+     * 否则将 `succ` 置为 `false`。
+     * @tparam TIter 输入迭代器类型。
+     * @tparam TSent 哨兵类型。
+     * @param beg     当前输入位置。
+     * @param end     输入范围结束哨兵。
+     * @param member  输出：解析结果。
+     * @param min_val 可接受的最小值（含）。
+     * @param max_val 可接受的最大值（含）。
+     * @param len     最多读取的位数。
+     * @param succ    输出标志：失败时置为 `false`。
+     * @return 指向未被消费的第一个字符的迭代器。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Parses up to `len` decimal digits from the input range and writes the
+     *        result into `member`.
+     *
+     * Updates `member` on success (at least one digit read and result within
+     * `[min_val, max_val]`); otherwise sets `succ` to `false`.
+     * @tparam TIter Input iterator type.
+     * @tparam TSent Sentinel type.
+     * @param beg     Current input position.
+     * @param end     End sentinel of the input range.
+     * @param member  Output: the parsed integer value.
+     * @param min_val Minimum acceptable value (inclusive).
+     * @param max_val Maximum acceptable value (inclusive).
+     * @param len     Maximum number of digits to read.
+     * @param succ    Output flag: set to `false` on failure.
+     * @return Iterator pointing to the first unconsumed character.
+     * @endif
+     */
     template <typename TIter, std::sentinel_for<TIter> TSent>
     static TIter extract_num(TIter beg, TSent end, int& member, int min_val, int max_val, size_t len, bool& succ) // NOLINT(bugprone-easily-swappable-parameters)
     {
@@ -2137,6 +3110,41 @@ private:
         return beg;
     }
 
+    /**
+     * @lang{ZH}
+     * @brief 从输入范围中解析十进制整数，优先匹配替代数字前缀树。
+     *
+     * 先用 `m_alt_digits_tree` 尝试最长匹配；若失败则回退到 `extract_num`。
+     * @tparam TIter 输入迭代器类型。
+     * @tparam TSent 哨兵类型。
+     * @param beg     当前输入位置。
+     * @param end     输入范围结束哨兵。
+     * @param member  输出：解析结果。
+     * @param min_val 可接受的最小值（含）。
+     * @param max_val 可接受的最大值（含）。
+     * @param len     回退到 ASCII 数字时最多读取的位数。
+     * @param succ    输出标志：失败时置为 `false`。
+     * @return 指向未被消费的第一个字符的迭代器。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Parses a decimal integer from the input range, preferring alternative
+     *        digits via the alt-digits prefix trie.
+     *
+     * Attempts a longest match against `m_alt_digits_tree` first; falls back to
+     * `extract_num` if no match is found.
+     * @tparam TIter Input iterator type.
+     * @tparam TSent Sentinel type.
+     * @param beg     Current input position.
+     * @param end     End sentinel of the input range.
+     * @param member  Output: the parsed integer value.
+     * @param min_val Minimum acceptable value (inclusive).
+     * @param max_val Maximum acceptable value (inclusive).
+     * @param len     Maximum digits to read when falling back to ASCII parsing.
+     * @param succ    Output flag: set to `false` on failure.
+     * @return Iterator pointing to the first unconsumed character.
+     * @endif
+     */
     template <typename TIter, std::sentinel_for<TIter> TSent>
     TIter extract_num_with_alt_digits(TIter beg, TSent end, int& member, int min_val, int max_val, size_t len, bool& succ) const
     {
@@ -2185,6 +3193,7 @@ private:
     std::shared_ptr<const ctype<CharT>>       m_ctype;
 };
 
+/// @cond
 template<typename TConfPtr, typename TCtypePtr>
     requires (std::is_same_v<typename TConfPtr::element_type::char_type,
                              typename TCtypePtr::element_type::char_type>)
@@ -2192,4 +3201,5 @@ timeio(TConfPtr, TCtypePtr) -> timeio<typename TConfPtr::element_type::char_type
 
 template<typename TConfPtr>
 timeio(TConfPtr) -> timeio<typename TConfPtr::element_type::char_type>;
+/// @endcond
 }

--- a/include/facet/timeio_details.h
+++ b/include/facet/timeio_details.h
@@ -1,3 +1,25 @@
+/**
+ * @file timeio_details.h
+ * @lang{ZH}
+ * `timeio` facet 的实现细节，包含：
+ * - `ft_basic<timeio<CharT>>`：`timeio` 的基类模板特化，持有时区前缀树与 facet 类型标识；
+ * - `TimeioHelper`：日历纪元日期比较的辅助工具函数；
+ * - `timeio_conf<CharT>`：各字符类型（`char`、`wchar_t`/`char32_t`、`char8_t`）的
+ *   locale 配置类，负责从系统 locale（通过 `nl_langinfo`）或 C/POSIX 硬编码默认值
+ *   中加载日期/时间格式串、星期/月份名称、AM/PM 字符串、替代数字及纪元数据。
+ * @endif
+ *
+ * @lang{EN}
+ * Implementation details for the `timeio` facet, comprising:
+ * - `ft_basic<timeio<CharT>>`: base class template specialization for `timeio`,
+ *   holding the timezone prefix trie and the facet type-identity token;
+ * - `TimeioHelper`: helper utilities for calendar era date comparison;
+ * - `timeio_conf<CharT>`: per-character-type locale configuration classes
+ *   (`char`, `wchar_t`/`char32_t`, `char8_t`) that load date/time format strings,
+ *   weekday/month names, AM/PM strings, alternative digits, and era data from the
+ *   system locale (via `nl_langinfo`) or from C/POSIX hard-coded defaults.
+ * @endif
+ */
 #pragma once
 #include <common/clocale_wrapper.h>
 #include <common/metafunctions.h>
@@ -24,37 +46,240 @@ namespace IOv2
 {
     template <typename CharT> class timeio;
 
+    /**
+     * @lang{ZH}
+     * @brief `timeio` facet 的基类模板特化。
+     *
+     * 为所有字符类型的 `timeio` facet 提供公共基础，包括：
+     * - `era_entry`：描述单个日历纪元的结构体；
+     * - 静态 `id()` 方法：返回 `timeio` facet 在 facet_store 中的唯一类型标识；
+     * - `s_timezone_tree`：静态前缀树，将时区缩写（如 `"EST"`）及 IANA 完整时区名称
+     *   映射到规范的时区名称，供 `%Z` 格式说明符解析时使用。
+     *
+     * @tparam CharT 字符类型。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Base class template specialization for the `timeio` facet.
+     *
+     * Provides the common foundation shared across all character types of the `timeio`
+     * facet, including:
+     * - `era_entry`: a struct describing a single calendar era;
+     * - static `id()`: returns the unique type-identity token of the `timeio` facet
+     *   within a facet_store;
+     * - `s_timezone_tree`: a static prefix trie mapping timezone abbreviations
+     *   (e.g. `"EST"`) and full IANA zone names to canonical timezone names,
+     *   used when parsing the `%Z` format specifier.
+     *
+     * @tparam CharT The character type.
+     * @endif
+     */
     template <typename CharT>
     class ft_basic<timeio<CharT>> : public base_ft<timeio>
     {
     public:
+        /**
+         * @lang{ZH}
+         * @brief 表示一个日历纪元（calendar era）的条目。
+         *
+         * 每个纪元条目对应 locale 数据中定义的一段历史时期（如公元 A.D.、某国皇纪）。
+         * 起止日期（`from_*` / `to_*`）定义了该纪元的日历范围，`offset` 与 `direction`
+         * 共同决定了如何将公历年份映射到纪元年份：
+         * @code
+         *   era_year = offset + (calendar_year - from_year) * direction
+         * @endcode
+         * @endif
+         *
+         * @lang{EN}
+         * @brief An entry representing a single calendar era.
+         *
+         * Each era entry corresponds to a historical period defined in locale data
+         * (e.g. A.D., a country-specific imperial era). The start and end dates
+         * (`from_*` / `to_*`) define the calendar range of the era; `offset` together
+         * with `direction` determine how a Gregorian year maps to the era year:
+         * @code
+         *   era_year = offset + (calendar_year - from_year) * direction
+         * @endcode
+         * @endif
+         */
         struct era_entry
         {
+            /**
+             * @lang{ZH}
+             * @brief 纪元名称（用于 `%EC` 格式输出）。
+             * @endif
+             *
+             * @lang{EN}
+             * @brief Era name (used for `%EC` format output).
+             * @endif
+             */
             std::basic_string<CharT> name;
+            /**
+             * @lang{ZH}
+             * @brief 纪元年份格式串（用于 `%EY` 格式输出）。
+             * @endif
+             *
+             * @lang{EN}
+             * @brief Era year format string (used for `%EY` format output).
+             * @endif
+             */
             std::basic_string<CharT> format;
+            /**
+             * @lang{ZH}
+             * @brief 纪元起始年份（公历）。
+             * @endif
+             *
+             * @lang{EN}
+             * @brief Era start year (Gregorian calendar).
+             * @endif
+             */
             int32_t from_year;
+            /**
+             * @lang{ZH}
+             * @brief 纪元起始月份（1–12）。
+             * @endif
+             *
+             * @lang{EN}
+             * @brief Era start month (1–12).
+             * @endif
+             */
             uint8_t from_month;
+            /**
+             * @lang{ZH}
+             * @brief 纪元起始日（1–31）。
+             * @endif
+             *
+             * @lang{EN}
+             * @brief Era start day (1–31).
+             * @endif
+             */
             uint8_t from_day;
+            /**
+             * @lang{ZH}
+             * @brief 纪元结束年份（公历）。开放结尾的纪元规范化为 `INT32_MAX`。
+             * @endif
+             *
+             * @lang{EN}
+             * @brief Era end year (Gregorian calendar). Open-ended eras are normalised to `INT32_MAX`.
+             * @endif
+             */
             int32_t to_year;
+            /**
+             * @lang{ZH}
+             * @brief 纪元结束月份（1–12）。
+             * @endif
+             *
+             * @lang{EN}
+             * @brief Era end month (1–12).
+             * @endif
+             */
             uint8_t to_month;
+            /**
+             * @lang{ZH}
+             * @brief 纪元结束日（1–31）。
+             * @endif
+             *
+             * @lang{EN}
+             * @brief Era end day (1–31).
+             * @endif
+             */
             uint8_t to_day;
+            /**
+             * @lang{ZH}
+             * @brief 纪元纪年偏移量，即纪元起始年（`from_year`）所对应的纪元年号。
+             * @endif
+             *
+             * @lang{EN}
+             * @brief Year offset for the era: the era year number assigned to `from_year`.
+             * @endif
+             */
             int32_t offset;
-            /* direction:
-                +1 indicates that year number is higher in the future. (like A.D.)
-                -1 indicates that year number is higher in the past. (like B.C.)  */
+            /**
+             * @lang{ZH}
+             * @brief 纪元年份增长方向。
+             *
+             * `+1` 表示年份数值随时间向未来方向增大（如公元 A.D.）；
+             * `-1` 表示年份数值随时间向过去方向增大（如公元前 B.C.）。
+             * @endif
+             *
+             * @lang{EN}
+             * @brief Direction in which era year numbers increase.
+             *
+             * `+1` indicates that the year number increases toward the future (e.g. A.D.);
+             * `-1` indicates that the year number increases toward the past (e.g. B.C.).
+             * @endif
+             */
             int8_t direction;
 
+            /// @cond
             bool operator==(const era_entry&) const = default; // for test.
+            /// @endcond
         };
     public:
+        /**
+         * @lang{ZH}
+         * @brief 默认构造函数，使用 `id()` 初始化基类。
+         * @endif
+         *
+         * @lang{EN}
+         * @brief Default constructor, initializes the base class with `id()`.
+         * @endif
+         */
         ft_basic()
             : base_ft<timeio>(id()) {}
 
         using char_type = CharT;
 
+        /**
+         * @lang{ZH}
+         * @brief 返回 `timeio` facet 的唯一类型标识。
+         *
+         * 通过将静态变量 `s_id` 的地址转换为 `size_t` 生成唯一标识，
+         * 与 `base_ft` 的类型分发机制配合使用。
+         * @return `timeio` facet 的唯一类型 ID。
+         * @endif
+         *
+         * @lang{EN}
+         * @brief Returns the unique type-identity token for the `timeio` facet.
+         *
+         * The identity is derived by casting the address of the static variable `s_id`
+         * to `size_t`, integrating with the type-dispatch mechanism of `base_ft`.
+         * @return The unique type ID for the `timeio` facet.
+         * @endif
+         */
         static size_t id() { return reinterpret_cast<size_t>(&s_id); }
 
     public:
+        /**
+         * @lang{ZH}
+         * @brief 时区缩写与 IANA 全名到规范时区名的静态前缀树。
+         *
+         * 在程序启动时通过 `std::chrono::get_tzdb()` 构建，将：
+         * - 时区缩写（如 `"EST"`）映射到其规范 IANA 名称（若 `locate_zone` 成功），
+         *   或映射到带 `"*"` 前缀的原始缩写（若无法定位对应的 IANA 时区）；
+         * - 与缩写不同的完整 IANA 时区名称映射到自身。
+         *
+         * 供 `%Z` 格式说明符的解析使用。若时区数据库在静态初始化期间不可用或格式
+         * 有误，树将为空或不完整，`%Z` 解析会在运行时产生可捕获的 `stream_error`
+         * 而非调用 `std::terminate`。
+         * @endif
+         *
+         * @lang{EN}
+         * @brief Static prefix trie mapping timezone abbreviations and IANA full names
+         *        to canonical timezone names.
+         *
+         * Built at program startup via `std::chrono::get_tzdb()`, mapping:
+         * - timezone abbreviations (e.g. `"EST"`) to their canonical IANA name (if
+         *   `locate_zone` succeeds), or to the abbreviation prefixed with `"*"` (if
+         *   no corresponding IANA zone is found);
+         * - full IANA timezone names (when different from their abbreviation) to themselves.
+         *
+         * Used by the `%Z` format specifier during parsing. If the timezone database is
+         * unavailable or malformed at static-initialization time, the trie is left empty
+         * or partial, and `%Z` parsing produces a catchable `stream_error` at runtime
+         * rather than calling `std::terminate`.
+         * @endif
+         */
         inline static const prefix_tree<CharT, std::string> s_timezone_tree =
         []()
         {
@@ -113,8 +338,50 @@ namespace IOv2
         inline static const void* s_id = nullptr;
     };
 
+/**
+ * @lang{ZH}
+ * @brief 供 `timeio` 内部使用的辅助工具命名空间。
+ *
+ * 包含用于日历纪元日期比较的内联函数，不属于 `timeio` 的公共接口。
+ * @endif
+ *
+ * @lang{EN}
+ * @brief Internal helper namespace for `timeio`.
+ *
+ * Contains inline functions for calendar era date comparison; these are
+ * not part of the public interface of `timeio`.
+ * @endif
+ */
 namespace TimeioHelper
 {
+    /**
+     * @lang{ZH}
+     * @brief 比较两个完整日期（年、月、日）的前后关系。
+     *
+     * 用于判断纪元起始日期是否早于或等于结束日期，从而确定纪元的方向。
+     * @param from_year  起始年份。
+     * @param from_month 起始月份（1–12）。
+     * @param from_day   起始日（1–31）。
+     * @param to_year    结束年份。
+     * @param to_month   结束月份（1–12）。
+     * @param to_day     结束日（1–31）。
+     * @return 若起始日期早于或等于结束日期，返回 `true`；否则返回 `false`。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Compares two full dates (year, month, day) for ordering.
+     *
+     * Used to determine whether an era's start date is no later than its end date,
+     * which in turn determines the era's direction.
+     * @param from_year  The starting year.
+     * @param from_month The starting month (1–12).
+     * @param from_day   The starting day (1–31).
+     * @param to_year    The ending year.
+     * @param to_month   The ending month (1–12).
+     * @param to_day     The ending day (1–31).
+     * @return `true` if the start date is earlier than or equal to the end date; `false` otherwise.
+     * @endif
+     */
     inline bool era_small_or_equal(int from_year, uint8_t from_month, uint8_t from_day, // NOLINT(bugprone-easily-swappable-parameters)
                                    int to_year, uint8_t to_month, uint8_t to_day)        // NOLINT(bugprone-easily-swappable-parameters)
     {
@@ -125,6 +392,29 @@ namespace TimeioHelper
         return from_day <= to_day;
     }
 
+    /**
+     * @lang{ZH}
+     * @brief 比较两个年月组合（不含日）的前后关系。
+     *
+     * 为 `era_small_or_equal` 的简化重载，仅比较年份和月份。
+     * @param from_year  起始年份。
+     * @param from_month 起始月份（1–12）。
+     * @param to_year    结束年份。
+     * @param to_month   结束月份（1–12）。
+     * @return 若起始年月早于或等于结束年月，返回 `true`；否则返回 `false`。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Compares two year-month pairs (without day) for ordering.
+     *
+     * A simplified overload of `era_small_or_equal` that compares only year and month.
+     * @param from_year  The starting year.
+     * @param from_month The starting month (1–12).
+     * @param to_year    The ending year.
+     * @param to_month   The ending month (1–12).
+     * @return `true` if the start year-month is earlier than or equal to the end year-month; `false` otherwise.
+     * @endif
+     */
     inline bool era_small_or_equal(int from_year, uint8_t from_month,                   // NOLINT(bugprone-easily-swappable-parameters)
                                    int to_year, uint8_t to_month)                        // NOLINT(bugprone-easily-swappable-parameters)
     {
@@ -136,10 +426,58 @@ namespace TimeioHelper
 
 template <typename CharT> class timeio_conf;
 
+/**
+ * @lang{ZH}
+ * @brief `timeio` facet 的 `char` 字符类型 locale 配置类。
+ *
+ * 这是 `timeio_conf` 的主特化，负责从系统 locale 或 C/POSIX 硬编码默认值中加载
+ * `timeio` facet 所需的全部 locale 数据，包括日期/时间格式串、星期与月份全称及
+ * 缩写、AM/PM 字符串及格式、替代数字，以及纪元（era）条目。
+ *
+ * 当 locale 名称为 `"C"` 或 `"POSIX"` 时，使用硬编码的英语默认值；
+ * 其他 locale 名称通过 `clocale_wrapper` 切换线程 locale 后，调用 `nl_langinfo`
+ * 获取系统提供的字符串，并调用 `parse_glibc_era_entries` 解码 glibc 纪元数据。
+ * @endif
+ *
+ * @lang{EN}
+ * @brief Locale configuration class for the `timeio` facet specialised for `char`.
+ *
+ * This is the primary specialization of `timeio_conf`, responsible for loading all
+ * locale data required by the `timeio` facet from the system locale or from C/POSIX
+ * hard-coded defaults. The loaded data includes: date/time format strings, full and
+ * abbreviated weekday and month names, AM/PM strings and format, alternative digits,
+ * and era entries.
+ *
+ * When the locale name is `"C"` or `"POSIX"`, hard-coded English defaults are used.
+ * For other locales, `clocale_wrapper` switches the thread locale and `nl_langinfo`
+ * is called to retrieve system-provided strings; `parse_glibc_era_entries` is then
+ * called to decode the glibc era binary data.
+ * @endif
+ */
 template <>
 class timeio_conf<char> : public ft_basic<timeio<char>>
 {
 public:
+    /**
+     * @lang{ZH}
+     * @brief 构造函数，根据 locale 名称加载日期时间 locale 数据。
+     *
+     * 若 `name` 为 `"C"` 或 `"POSIX"`，则使用硬编码的英语默认值（ISO C 标准格式）；
+     * 否则通过 `clocale_wrapper` 切换至指定 locale 后，调用 `nl_langinfo` 及
+     * `parse_glibc_era_entries` 从系统 locale 数据库中加载相应数据。
+     * @param name locale 名称（如 `"C"`、`"zh_CN.UTF-8"`）。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Constructor that loads date-time locale data for the given locale name.
+     *
+     * If `name` is `"C"` or `"POSIX"`, hard-coded English defaults (ISO C standard
+     * formats) are used. Otherwise, `clocale_wrapper` switches to the specified locale
+     * and `nl_langinfo` together with `parse_glibc_era_entries` are called to load
+     * the corresponding data from the system locale database.
+     * @param name The locale name (e.g. `"C"`, `"zh_CN.UTF-8"`).
+     * @endif
+     */
     timeio_conf(const std::string& name)
         : ft_basic<timeio<char>>()
     {
@@ -295,86 +633,354 @@ public:
         m_era_time_zone_format = m_era_time_format + " %Z";
     }
 
+    /**
+     * @lang{ZH}
+     * @brief 返回星期全称数组（索引 0 为星期日，索引 6 为星期六）。
+     * @return 包含 7 个星期全称字符串的数组的常量引用。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the array of full weekday names (index 0 = Sunday, index 6 = Saturday).
+     * @return A constant reference to the array of 7 full weekday name strings.
+     * @endif
+     */
     virtual const std::array<std::string, 7>& day_names() const { return m_day; }
+    /**
+     * @lang{ZH}
+     * @brief 返回星期缩写数组（索引 0 为星期日，索引 6 为星期六）。
+     * @return 包含 7 个星期缩写字符串的数组的常量引用。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the array of abbreviated weekday names (index 0 = Sunday, index 6 = Saturday).
+     * @return A constant reference to the array of 7 abbreviated weekday name strings.
+     * @endif
+     */
     virtual const std::array<std::string, 7>& abbr_day_names() const { return m_abbr_day; }
+    /**
+     * @lang{ZH}
+     * @brief 返回月份全称数组（索引 0 为一月，索引 11 为十二月）。
+     * @return 包含 12 个月份全称字符串的数组的常量引用。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the array of full month names (index 0 = January, index 11 = December).
+     * @return A constant reference to the array of 12 full month name strings.
+     * @endif
+     */
     virtual const std::array<std::string, 12>& month_names() const { return m_month; }
+    /**
+     * @lang{ZH}
+     * @brief 返回月份缩写数组（索引 0 为一月，索引 11 为十二月）。
+     * @return 包含 12 个月份缩写字符串的数组的常量引用。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the array of abbreviated month names (index 0 = January, index 11 = December).
+     * @return A constant reference to the array of 12 abbreviated month name strings.
+     * @endif
+     */
     virtual const std::array<std::string, 12>& abbr_month_names() const { return m_abbr_month; }
+    /**
+     * @lang{ZH}
+     * @brief 返回 locale 定义的替代数字字符串数组（最多 100 项）。
+     *
+     * 替代数字用于 `%Od`、`%Oe` 等替代格式说明符的输出与解析。
+     * 未被 locale 定义的条目为空字符串。
+     * @return 包含 100 个替代数字字符串的数组的常量引用。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the locale-defined alternative digit strings (up to 100 entries).
+     *
+     * Alternative digits are used for output and parsing of alternative format specifiers
+     * such as `%Od` and `%Oe`. Entries not defined by the locale are empty strings.
+     * @return A constant reference to the array of 100 alternative digit strings.
+     * @endif
+     */
     virtual const std::array<std::string, 100>& alt_digit_names() const { return m_alt_digits; }
+    /**
+     * @lang{ZH}
+     * @brief 返回 AM 时段字符串（如 `"AM"`）。
+     * @return AM 字符串的常量引用。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the AM period string (e.g. `"AM"`).
+     * @return A constant reference to the AM string.
+     * @endif
+     */
     virtual const std::string& am_name() const { return m_am; }
+    /**
+     * @lang{ZH}
+     * @brief 返回 PM 时段字符串（如 `"PM"`）。
+     * @return PM 字符串的常量引用。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the PM period string (e.g. `"PM"`).
+     * @return A constant reference to the PM string.
+     * @endif
+     */
     virtual const std::string& pm_name() const { return m_pm; }
+    /**
+     * @lang{ZH}
+     * @brief 返回 locale 日期格式串（对应 `%x`）。
+     * @return 日期格式串的常量引用。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the locale date format string (corresponding to `%x`).
+     * @return A constant reference to the date format string.
+     * @endif
+     */
     virtual const std::string& date_format() const { return m_date_format; }
+    /**
+     * @lang{ZH}
+     * @brief 返回 locale 纪元修饰日期格式串（对应 `%Ex`）。
+     *
+     * 若 locale 未定义纪元修饰格式，则回退为普通日期格式串。
+     * @return 纪元修饰日期格式串的常量引用。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the locale era-modified date format string (corresponding to `%Ex`).
+     *
+     * Falls back to the plain date format string if the locale does not define an
+     * era-modified variant.
+     * @return A constant reference to the era-modified date format string.
+     * @endif
+     */
     virtual const std::string& era_date_format() const { return m_era_date_format; }
+    /**
+     * @lang{ZH}
+     * @brief 返回 locale 时间格式串（对应 `%X`）。
+     * @return 时间格式串的常量引用。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the locale time format string (corresponding to `%X`).
+     * @return A constant reference to the time format string.
+     * @endif
+     */
     virtual const std::string& time_format() const { return m_time_format; }
+    /**
+     * @lang{ZH}
+     * @brief 返回 locale 纪元修饰时间格式串（对应 `%EX`）。
+     *
+     * 若 locale 未定义纪元修饰格式，则回退为普通时间格式串。
+     * @return 纪元修饰时间格式串的常量引用。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the locale era-modified time format string (corresponding to `%EX`).
+     *
+     * Falls back to the plain time format string if the locale does not define an
+     * era-modified variant.
+     * @return A constant reference to the era-modified time format string.
+     * @endif
+     */
     virtual const std::string& era_time_format() const { return m_era_time_format; }
+    /**
+     * @lang{ZH}
+     * @brief 返回时间加时区格式串（时间格式串后附加 `%Z`）。
+     * @return 时间加时区格式串的常量引用。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the time-plus-timezone format string (time format string with `%Z` appended).
+     * @return A constant reference to the time-plus-timezone format string.
+     * @endif
+     */
     virtual const std::string& time_zone_format() const { return m_time_zone_format; }
+    /**
+     * @lang{ZH}
+     * @brief 返回纪元修饰时间加时区格式串。
+     * @return 纪元修饰时间加时区格式串的常量引用。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the era-modified time-plus-timezone format string.
+     * @return A constant reference to the era-modified time-plus-timezone format string.
+     * @endif
+     */
     virtual const std::string& era_time_zone_format() const { return m_era_time_zone_format; }
+    /**
+     * @lang{ZH}
+     * @brief 返回 locale 日期时间格式串（对应 `%c`）。
+     * @return 日期时间格式串的常量引用。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the locale date-time format string (corresponding to `%c`).
+     * @return A constant reference to the date-time format string.
+     * @endif
+     */
     virtual const std::string& date_time_format() const { return m_date_time_format; }
+    /**
+     * @lang{ZH}
+     * @brief 返回 locale 纪元修饰日期时间格式串（对应 `%Ec`）。
+     *
+     * 若 locale 未定义纪元修饰格式，则回退为普通日期时间格式串。
+     * @return 纪元修饰日期时间格式串的常量引用。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the locale era-modified date-time format string (corresponding to `%Ec`).
+     *
+     * Falls back to the plain date-time format string if the locale does not define an
+     * era-modified variant.
+     * @return A constant reference to the era-modified date-time format string.
+     * @endif
+     */
     virtual const std::string& era_date_time_format() const { return m_era_date_time_format; }
+    /**
+     * @lang{ZH}
+     * @brief 返回日期时间加时区格式串（日期时间格式串后附加 `%Z`）。
+     * @return 日期时间加时区格式串的常量引用。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the date-time-plus-timezone format string (date-time format with `%Z` appended).
+     * @return A constant reference to the date-time-plus-timezone format string.
+     * @endif
+     */
     virtual const std::string& date_time_zone_format() const { return m_date_time_zone_format; }
+    /**
+     * @lang{ZH}
+     * @brief 返回纪元修饰日期时间加时区格式串。
+     * @return 纪元修饰日期时间加时区格式串的常量引用。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the era-modified date-time-plus-timezone format string.
+     * @return A constant reference to the era-modified date-time-plus-timezone format string.
+     * @endif
+     */
     virtual const std::string& era_date_time_zone_format() const { return m_era_date_time_zone_format; }
+    /**
+     * @lang{ZH}
+     * @brief 返回 AM/PM 时间格式串（对应 `%r`）。
+     * @return AM/PM 时间格式串的常量引用。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the AM/PM time format string (corresponding to `%r`).
+     * @return A constant reference to the AM/PM time format string.
+     * @endif
+     */
     virtual const std::string& am_pm_format() const { return m_am_pm_format; }
+    /**
+     * @lang{ZH}
+     * @brief 返回 locale 定义的纪元条目列表。
+     * @return 纪元条目列表的常量引用；若 locale 无纪元定义则为空 `vector`。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the list of locale-defined era entries.
+     * @return A constant reference to the era entry list; an empty `vector` if the locale
+     *         defines no eras.
+     * @endif
+     */
     virtual const std::vector<era_entry>& era_items() const { return m_era_items; }
 
 private:
-    // Parse the glibc-specific binary era table for the *currently active thread
-    // locale* and return the decoded entries.
-    //
-    // PRECONDITION
-    //   The caller must have made the target locale current on this thread
-    //   (e.g. via clocale_user / uselocale) before calling. nl_langinfo() reads
-    //   that active locale; the returned pointers are consumed before any further
-    //   nl_langinfo() call, so they stay valid for the duration of this function.
-    //
-    // INPUT CONTRACT (TRUSTED, NOT VALIDATED)
-    //   This is the single place where we trust the glibc era binary layout.
-    //   nl_langinfo(_NL_TIME_ERA_ENTRIES) is assumed to point at exactly
-    //   _NL_TIME_ERA_NUM_ENTRIES consecutive, well-formed records; the pointer
-    //   walk below is UNCHECKED, so malformed or truncated data (e.g. a tampered
-    //   locale database) can cause out-of-bounds reads. Data coming from the
-    //   system locale database is treated as trusted, so no defensive bounds
-    //   checking is performed. If era data could ever originate from an
-    //   untrusted source, this function is the one boundary to harden.
-    //
-    //   Each record, relative to its start (base_ptr), is laid out as:
-    //     - 8 x int32 header (read via memcpy):
-    //         [0] direction marker ('+' / '-')   [1] offset
-    //         [2] from_year - 1900  [3] from_month - 1  [4] from_day
-    //         [5] to_year   - 1900  [6] to_month   - 1  [7] to_day
-    //     - NUL-terminated narrow name, then NUL-terminated narrow format
-    //     - padding up to the next 4-byte boundary (relative to base_ptr)
-    //     - NUL-terminated wide name, then NUL-terminated wide format
-    //
-    // OUTPUT INVARIANTS
-    //   - from_year / to_year are clamped against int32 overflow on the +1900
-    //     addition (an open-ended "to" is normalised to Dec 31 of int32 max).
-    //   - direction is normalised to exactly +1 / -1 so that the linear formula
-    //
-    //       era_year = offset + (calendar_year - from_year) * direction
-    //
-    //     is uniformly valid for all era types.  The normalisation mirrors glibc
-    //     era.c (≈ line 98, https://github.com/lattera/glibc/blob/master/time/era.c):
-    //
-    //       if ERA_DATE_CMP(start, stop)   /* start < stop — forward era */
-    //           absolute_direction = ('+') ? +1 : -1;
-    //       else                           /* start ≥ stop — backward era */
-    //           absolute_direction = ('+') ? -1 : +1;   /* sign flipped */
-    //
-    //     For forward eras (from < to, e.g. AD / Japanese / Thai), the raw
-    //     direction marker maps directly: '+' → +1, '-' → -1.
-    //
-    //     For backward eras (from > to), the marker is intentionally inverted.
-    //     The reason: in a backward era (e.g. the hypothetical BC entry
-    //     "-:1:-0001/01/01:-*:BC:…"), from_year is the epoch (1 BC) and to_year
-    //     is a sentinel for "negative infinity".  As the calendar year moves away
-    //     from the epoch toward the past, (calendar - from_year) grows increasingly
-    //     negative.  Flipping the stored direction to +1 preserves the sign
-    //     convention that the same formula produces consistent era_year values
-    //     regardless of which direction the era flows.  Concretely, with
-    //     direction = +1 after the flip, delta = (calendar - from_year) × 1 is
-    //     negative for any BC year other than 1 BC, so %Ey emits 1, 0, −1, …
-    //     rather than the traditional 1, 2, 3, … counting.  This is a known
-    //     limitation shared with glibc: no real glibc locale defines a backward
-    //     era, so the path is never exercised in practice.
+    /**
+     * @lang{ZH}
+     * @brief 解析当前活动线程 locale 的 glibc 纪元二进制表，返回解码后的纪元条目列表。
+     *
+     * @pre 调用前，调用方必须通过 `clocale_user` / `uselocale` 等方式将目标 locale
+     *      激活于当前线程。`nl_langinfo()` 读取该活动 locale；返回的指针在下一次
+     *      `nl_langinfo()` 调用前保持有效，足以在本函数内完成消费。
+     *
+     * @note **输入布局（受信任，不做验证）**
+     *   此函数是唯一一处信任 glibc 纪元二进制布局的地方。
+     *   `nl_langinfo(_NL_TIME_ERA_ENTRIES)` 被假定为指向恰好
+     *   `_NL_TIME_ERA_NUM_ENTRIES` 条连续、格式完整的记录；指针遍历**未作越界检查**，
+     *   因此若 locale 数据库被篡改或截断，可能引发越界读取。
+     *   系统 locale 数据视为受信任数据；若纪元数据可能来自不可信来源，
+     *   应在此函数边界处增加防御性边界检查。
+     *
+     *   每条记录相对于其起始地址（base_ptr）的内存布局如下：
+     *   - 8 × int32 头部（通过 memcpy 读取）：
+     *       [0] 方向标记（'+' / '-'）  [1] 偏移量
+     *       [2] from_year - 1900       [3] from_month - 1   [4] from_day
+     *       [5] to_year   - 1900       [6] to_month   - 1   [7] to_day
+     *   - NUL 结尾的窄字符名称，随后是 NUL 结尾的窄字符格式串
+     *   - 填充至相对于 base_ptr 的 4 字节对齐边界
+     *   - NUL 结尾的宽字符名称，随后是 NUL 结尾的宽字符格式串
+     *
+     * @note **输出不变量**
+     *   - `from_year` / `to_year` 在加上 1900 时防止 int32 溢出（开放结尾的 "to"
+     *     被规范化为 int32 最大值的 12 月 31 日）。
+     *   - `direction` 被规范化为恰好 `+1` / `-1`，使得以下线性公式对所有纪元类型均一致有效：
+     *     @code
+     *       era_year = offset + (calendar_year - from_year) * direction
+     *     @endcode
+     *     规范化逻辑参照 glibc 的 era.c（约第 98 行，
+     *     https://github.com/lattera/glibc/blob/master/time/era.c）：
+     *     前向纪元（from ≤ to，如公元 AD、日本皇纪、泰国佛历）方向标记直接映射，
+     *     '+' → +1，'-' → -1；
+     *     后向纪元（from > to）方向标记取反，以保证公式一致性（详见 OUTPUT INVARIANTS 说明）。
+     *     此为与 glibc 共有的已知局限：实际上没有 glibc locale 定义后向纪元，
+     *     故该路径在实践中从未被执行。
+     *
+     * @return 解码后的 `era_entry` 列表；若无纪元数据则返回空 `vector`。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Parses the glibc era binary table of the currently active thread locale
+     *        and returns the decoded era entries.
+     *
+     * @pre The caller must have made the target locale current on the calling thread
+     *      (e.g. via `clocale_user` / `uselocale`) before invoking this function.
+     *      `nl_langinfo()` reads that active locale; the returned pointers are consumed
+     *      before any further `nl_langinfo()` call, so they remain valid for the
+     *      duration of this function.
+     *
+     * @note **Input layout (trusted, not validated)**
+     *   This is the single place where the glibc era binary layout is trusted.
+     *   `nl_langinfo(_NL_TIME_ERA_ENTRIES)` is assumed to point at exactly
+     *   `_NL_TIME_ERA_NUM_ENTRIES` consecutive, well-formed records; the pointer
+     *   walk is **unchecked**, so malformed or truncated locale data (e.g. a tampered
+     *   locale database) can cause out-of-bounds reads. System locale data is treated
+     *   as trusted; if era data could ever originate from an untrusted source, this
+     *   function is the boundary to harden.
+     *
+     *   Each record, relative to its start (base_ptr), is laid out as:
+     *   - 8 × int32 header (read via memcpy):
+     *       [0] direction marker ('+' / '-')   [1] offset
+     *       [2] from_year - 1900   [3] from_month - 1   [4] from_day
+     *       [5] to_year   - 1900   [6] to_month   - 1   [7] to_day
+     *   - NUL-terminated narrow name, then NUL-terminated narrow format string
+     *   - padding to the next 4-byte boundary (relative to base_ptr)
+     *   - NUL-terminated wide name, then NUL-terminated wide format string
+     *
+     * @note **Output invariants**
+     *   - `from_year` / `to_year` are clamped against int32 overflow on the +1900
+     *     addition (an open-ended "to" is normalised to Dec 31 of the int32 maximum).
+     *   - `direction` is normalised to exactly `+1` / `-1` so that the linear formula
+     *     @code
+     *       era_year = offset + (calendar_year - from_year) * direction
+     *     @endcode
+     *     is uniformly valid for all era types.
+     *     The normalisation mirrors glibc's era.c (≈ line 98,
+     *     https://github.com/lattera/glibc/blob/master/time/era.c):
+     *     for forward eras (from ≤ to, e.g. AD / Japanese / Thai), the marker maps
+     *     directly: '+' → +1, '-' → -1;
+     *     for backward eras (from > to), the marker is intentionally inverted.
+     *     The reason: in a backward era, from_year is the epoch and to_year is a
+     *     sentinel for "negative infinity". As the calendar year moves away from the
+     *     epoch toward the past, (calendar - from_year) grows increasingly negative.
+     *     Flipping the stored direction to +1 preserves the sign convention so that
+     *     the same formula produces consistent era_year values regardless of which
+     *     direction the era flows. This is a known limitation shared with glibc: no
+     *     real glibc locale defines a backward era, so the path is never exercised
+     *     in practice.
+     *
+     * @return A list of decoded `era_entry` objects; an empty vector if no era data exists.
+     * @endif
+     */
     static std::vector<era_entry> parse_glibc_era_entries()
     {
         std::vector<era_entry> items;
@@ -466,6 +1072,29 @@ private:
     std::vector<era_entry>       m_era_items;
 };
 
+/**
+ * @lang{ZH}
+ * @brief `timeio` facet 的宽字符（`wchar_t` / `char32_t` UTF-32）locale 配置类。
+ *
+ * 此特化适用于 `wchar_t`，以及在 `wchar_t` 为 UTF-32 的平台上的 `char32_t`。
+ * 通过内部构造 `timeio_conf<char>` 临时对象来加载 locale 数据，
+ * 再将所有窄字符串转换为对应的宽字符或 UTF-32 字符串。
+ *
+ * @tparam CharT 字符类型，限定为 `wchar_t` 或（在 `wchar_t` 为 UTF-32 的平台上）`char32_t`。
+ * @endif
+ *
+ * @lang{EN}
+ * @brief Locale configuration class for the `timeio` facet specialised for wide characters
+ *        (`wchar_t` / `char32_t` UTF-32).
+ *
+ * This specialization applies to `wchar_t`, and to `char32_t` on platforms where
+ * `wchar_t` is UTF-32. It loads locale data by internally constructing a
+ * `timeio_conf<char>` temporary, then converts all narrow strings to the
+ * corresponding wide or UTF-32 strings.
+ *
+ * @tparam CharT The character type, constrained to `wchar_t` or (on UTF-32 platforms) `char32_t`.
+ * @endif
+ */
 template <typename CharT>
     requires std::is_same_v<CharT, wchar_t> ||
             (std::is_same_v<CharT, char32_t> &&
@@ -475,6 +1104,18 @@ class timeio_conf<CharT> : public ft_basic<timeio<CharT>>
     using era_entry = typename ft_basic<timeio<CharT>>::era_entry;
 
 public:
+    /**
+     * @lang{ZH}
+     * @brief 构造函数，通过 `timeio_conf<char>` 加载 locale 数据并转换为宽字符串。
+     * @param name locale 名称（如 `"C"`、`"ja_JP.UTF-8"`）。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Constructor that loads locale data via `timeio_conf<char>` and converts
+     *        all strings to wide character strings.
+     * @param name The locale name (e.g. `"C"`, `"ja_JP.UTF-8"`).
+     * @endif
+     */
     timeio_conf(const std::string& name)
         : ft_basic<timeio<CharT>>()
     {
@@ -543,24 +1184,234 @@ public:
         m_era_date_time_zone_format = convert(tmp_obj.era_date_time_zone_format());
     }
 
+    /**
+     * @lang{ZH}
+     * @brief 返回星期全称数组（索引 0 为星期日，索引 6 为星期六）。
+     * @return 包含 7 个星期全称字符串的数组的常量引用。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the array of full weekday names (index 0 = Sunday, index 6 = Saturday).
+     * @return A constant reference to the array of 7 full weekday name strings.
+     * @endif
+     */
     virtual const std::array<std::basic_string<CharT>, 7>& day_names() const { return m_day; }
+    /**
+     * @lang{ZH}
+     * @brief 返回星期缩写数组（索引 0 为星期日，索引 6 为星期六）。
+     * @return 包含 7 个星期缩写字符串的数组的常量引用。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the array of abbreviated weekday names (index 0 = Sunday, index 6 = Saturday).
+     * @return A constant reference to the array of 7 abbreviated weekday name strings.
+     * @endif
+     */
     virtual const std::array<std::basic_string<CharT>, 7>& abbr_day_names() const { return m_abbr_day; }
+    /**
+     * @lang{ZH}
+     * @brief 返回月份全称数组（索引 0 为一月，索引 11 为十二月）。
+     * @return 包含 12 个月份全称字符串的数组的常量引用。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the array of full month names (index 0 = January, index 11 = December).
+     * @return A constant reference to the array of 12 full month name strings.
+     * @endif
+     */
     virtual const std::array<std::basic_string<CharT>, 12>& month_names() const { return m_month; }
+    /**
+     * @lang{ZH}
+     * @brief 返回月份缩写数组（索引 0 为一月，索引 11 为十二月）。
+     * @return 包含 12 个月份缩写字符串的数组的常量引用。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the array of abbreviated month names (index 0 = January, index 11 = December).
+     * @return A constant reference to the array of 12 abbreviated month name strings.
+     * @endif
+     */
     virtual const std::array<std::basic_string<CharT>, 12>& abbr_month_names() const { return m_abbr_month; }
+    /**
+     * @lang{ZH}
+     * @brief 返回 locale 定义的替代数字字符串数组（最多 100 项）。
+     * @return 包含 100 个替代数字字符串的数组的常量引用。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the locale-defined alternative digit strings (up to 100 entries).
+     * @return A constant reference to the array of 100 alternative digit strings.
+     * @endif
+     */
     virtual const std::array<std::basic_string<CharT>, 100>& alt_digit_names() const { return m_alt_digits; }
+    /**
+     * @lang{ZH}
+     * @brief 返回 AM 时段字符串。
+     * @return AM 字符串的常量引用。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the AM period string.
+     * @return A constant reference to the AM string.
+     * @endif
+     */
     virtual const std::basic_string<CharT>& am_name() const { return m_am; }
+    /**
+     * @lang{ZH}
+     * @brief 返回 PM 时段字符串。
+     * @return PM 字符串的常量引用。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the PM period string.
+     * @return A constant reference to the PM string.
+     * @endif
+     */
     virtual const std::basic_string<CharT>& pm_name() const { return m_pm; }
+    /**
+     * @lang{ZH}
+     * @brief 返回 locale 日期格式串（对应 `%x`）。
+     * @return 日期格式串的常量引用。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the locale date format string (corresponding to `%x`).
+     * @return A constant reference to the date format string.
+     * @endif
+     */
     virtual const std::basic_string<CharT>& date_format() const { return m_date_format; }
+    /**
+     * @lang{ZH}
+     * @brief 返回 locale 纪元修饰日期格式串（对应 `%Ex`）。
+     * @return 纪元修饰日期格式串的常量引用。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the locale era-modified date format string (corresponding to `%Ex`).
+     * @return A constant reference to the era-modified date format string.
+     * @endif
+     */
     virtual const std::basic_string<CharT>& era_date_format() const { return m_era_date_format; }
+    /**
+     * @lang{ZH}
+     * @brief 返回 locale 时间格式串（对应 `%X`）。
+     * @return 时间格式串的常量引用。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the locale time format string (corresponding to `%X`).
+     * @return A constant reference to the time format string.
+     * @endif
+     */
     virtual const std::basic_string<CharT>& time_format() const { return m_time_format; }
+    /**
+     * @lang{ZH}
+     * @brief 返回 locale 纪元修饰时间格式串（对应 `%EX`）。
+     * @return 纪元修饰时间格式串的常量引用。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the locale era-modified time format string (corresponding to `%EX`).
+     * @return A constant reference to the era-modified time format string.
+     * @endif
+     */
     virtual const std::basic_string<CharT>& era_time_format() const { return m_era_time_format; }
+    /**
+     * @lang{ZH}
+     * @brief 返回时间加时区格式串。
+     * @return 时间加时区格式串的常量引用。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the time-plus-timezone format string.
+     * @return A constant reference to the time-plus-timezone format string.
+     * @endif
+     */
     virtual const std::basic_string<CharT>& time_zone_format() const { return m_time_zone_format; }
+    /**
+     * @lang{ZH}
+     * @brief 返回纪元修饰时间加时区格式串。
+     * @return 纪元修饰时间加时区格式串的常量引用。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the era-modified time-plus-timezone format string.
+     * @return A constant reference to the era-modified time-plus-timezone format string.
+     * @endif
+     */
     virtual const std::basic_string<CharT>& era_time_zone_format() const { return m_era_time_zone_format; }
+    /**
+     * @lang{ZH}
+     * @brief 返回 locale 日期时间格式串（对应 `%c`）。
+     * @return 日期时间格式串的常量引用。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the locale date-time format string (corresponding to `%c`).
+     * @return A constant reference to the date-time format string.
+     * @endif
+     */
     virtual const std::basic_string<CharT>& date_time_format() const { return m_date_time_format; }
+    /**
+     * @lang{ZH}
+     * @brief 返回 locale 纪元修饰日期时间格式串（对应 `%Ec`）。
+     * @return 纪元修饰日期时间格式串的常量引用。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the locale era-modified date-time format string (corresponding to `%Ec`).
+     * @return A constant reference to the era-modified date-time format string.
+     * @endif
+     */
     virtual const std::basic_string<CharT>& era_date_time_format() const { return m_era_date_time_format; }
+    /**
+     * @lang{ZH}
+     * @brief 返回日期时间加时区格式串。
+     * @return 日期时间加时区格式串的常量引用。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the date-time-plus-timezone format string.
+     * @return A constant reference to the date-time-plus-timezone format string.
+     * @endif
+     */
     virtual const std::basic_string<CharT>& date_time_zone_format() const { return m_date_time_zone_format; }
+    /**
+     * @lang{ZH}
+     * @brief 返回纪元修饰日期时间加时区格式串。
+     * @return 纪元修饰日期时间加时区格式串的常量引用。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the era-modified date-time-plus-timezone format string.
+     * @return A constant reference to the era-modified date-time-plus-timezone format string.
+     * @endif
+     */
     virtual const std::basic_string<CharT>& era_date_time_zone_format() const { return m_era_date_time_zone_format; }
+    /**
+     * @lang{ZH}
+     * @brief 返回 AM/PM 时间格式串（对应 `%r`）。
+     * @return AM/PM 时间格式串的常量引用。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the AM/PM time format string (corresponding to `%r`).
+     * @return A constant reference to the AM/PM time format string.
+     * @endif
+     */
     virtual const std::basic_string<CharT>& am_pm_format() const { return m_am_pm_format; }
+    /**
+     * @lang{ZH}
+     * @brief 返回 locale 定义的纪元条目列表。
+     * @return 纪元条目列表的常量引用；若 locale 无纪元定义则为空 `vector`。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the list of locale-defined era entries.
+     * @return A constant reference to the era entry list; an empty `vector` if the locale
+     *         defines no eras.
+     * @endif
+     */
     virtual const std::vector<era_entry>& era_items() const { return m_era_items; }
 
 private:
@@ -585,24 +1436,57 @@ private:
     std::vector<era_entry>                    m_era_items;
 };
 
-// This specialization delegates to timeio_conf<char32_t> to populate its data
-// (see init_from_u32 below), so it requires timeio_conf<char32_t> to be a
-// complete type when a char8_t conf is constructed. That delegation lives in a
-// member function template whose reference to timeio_conf<char32_t> is dependent
-// on a template parameter, so it is checked only when actually instantiated
-// (never eagerly, hence not IFNDR): merely naming or default-constructing
-// timeio_conf<char8_t> stays well-formed even on platforms where
-// timeio_conf<char32_t> is unavailable (wchar_t is not UTF-32); there, only the
-// construction path fails to compile, which is intended.
-// The completeness requirement is deliberately NOT encoded as a constraint on
-// this class: a non-dependent sizeof(timeio_conf<char32_t>) in the
-// requires-clause is a hard error (not a soft constraint failure) and would
-// break partial-specialization resolution for unrelated timeio_conf<T>.
+/**
+ * @lang{ZH}
+ * @brief `timeio` facet 的 `char8_t`（UTF-8）locale 配置类。
+ *
+ * 此特化通过 `init_from_u32` 内部模板辅助函数委托给 `timeio_conf<char32_t>` 来加载数据，
+ * 再将所有 UTF-32 字符串转换为 UTF-8（`char8_t`）字符串。
+ *
+ * @note 对 `timeio_conf<char32_t>` 的引用位于成员函数模板 `init_from_u32` 内部（其类型
+ *   为依赖类型），因此仅在该函数被实例化时才进行检查，而不会在类定义解析时进行。
+ *   这意味着即使在 `timeio_conf<char32_t>` 不可用的平台上（`wchar_t` 非 UTF-32），
+ *   仅命名或默认构造 `timeio_conf<char8_t>` 也不会触发错误；实际的构造路径在这类
+ *   平台上会编译失败，此为预期行为。完整性要求未被刻意编码为此类的约束条件：
+ *   在 requires 子句中使用非依赖的 `sizeof(timeio_conf<char32_t>)` 是硬错误（而非软
+ *   约束失败），会破坏无关 `timeio_conf<T>` 的偏特化解析。
+ * @endif
+ *
+ * @lang{EN}
+ * @brief Locale configuration class for the `timeio` facet specialised for `char8_t` (UTF-8).
+ *
+ * This specialization delegates to `timeio_conf<char32_t>` via the `init_from_u32`
+ * internal template helper, then converts all UTF-32 strings to UTF-8 (`char8_t`) strings.
+ *
+ * @note The reference to `timeio_conf<char32_t>` resides inside the member function template
+ *   `init_from_u32` (where it is a dependent type), so it is only checked upon instantiation
+ *   of that helper — never eagerly at class-definition parse time. This means that merely
+ *   naming or default-constructing `timeio_conf<char8_t>` remains well-formed even on
+ *   platforms where `timeio_conf<char32_t>` is unavailable (`wchar_t` is not UTF-32); only
+ *   the construction path fails to compile there, which is intentional. The completeness
+ *   requirement is deliberately NOT encoded as a constraint on this class: a non-dependent
+ *   `sizeof(timeio_conf<char32_t>)` in the requires-clause is a hard error (not a soft
+ *   constraint failure) and would break partial-specialization resolution for unrelated
+ *   `timeio_conf<T>`.
+ * @endif
+ */
 template <typename CharT>
     requires std::is_same_v<CharT, char8_t>
 class timeio_conf<CharT> : public ft_basic<timeio<char8_t>>
 {
 public:
+    /**
+     * @lang{ZH}
+     * @brief 构造函数，通过 `timeio_conf<char32_t>` 加载 locale 数据并转换为 UTF-8 字符串。
+     * @param name locale 名称（如 `"C"`、`"zh_CN.UTF-8"`）。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Constructor that loads locale data via `timeio_conf<char32_t>` and converts
+     *        all strings to UTF-8 (`char8_t`) strings.
+     * @param name The locale name (e.g. `"C"`, `"zh_CN.UTF-8"`).
+     * @endif
+     */
     timeio_conf(const std::string& name)
         : ft_basic<timeio<char8_t>>()
     {
@@ -610,10 +1494,30 @@ public:
     }
 
 private:
-    // T is defaulted/constrained to char32_t; templating it makes the
-    // timeio_conf<T> reference below dependent, so the whole body is checked
-    // only upon instantiation of this helper (i.e. only on the construction
-    // path), never eagerly.
+    /**
+     * @lang{ZH}
+     * @brief 委托给 `timeio_conf<char32_t>` 加载数据，并将所有字符串转换为 UTF-8（内部辅助函数）。
+     *
+     * 将 `T`（默认为 `char32_t`）模板化，是为了使函数体内对 `timeio_conf<T>` 的引用成为
+     * 依赖类型，从而仅在该辅助函数被实例化时（即实际构造路径上）才进行检查，而不会在类
+     * 定义解析时进行，避免在 `timeio_conf<char32_t>` 不可用的平台上产生硬错误。
+     * @tparam T 固定为 `char32_t`；通过约束防止其他类型实例化。
+     * @param name locale 名称。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Delegates to `timeio_conf<char32_t>` to load data, then converts all strings
+     *        to UTF-8 (internal helper).
+     *
+     * Templating on `T` (defaulting to `char32_t`) makes the reference to `timeio_conf<T>`
+     * inside the function body a dependent type, so it is only checked when the helper is
+     * actually instantiated (i.e. on the construction path), not at class-definition parse
+     * time — preventing a hard error on platforms where `timeio_conf<char32_t>` is
+     * unavailable.
+     * @tparam T Fixed to `char32_t`; other types are prevented by the constraint.
+     * @param name The locale name.
+     * @endif
+     */
     template <typename T = char32_t>
         requires std::is_same_v<T, char32_t>
     void init_from_u32(const std::string& name)
@@ -676,24 +1580,234 @@ private:
     }
 
 public:
+    /**
+     * @lang{ZH}
+     * @brief 返回星期全称数组（索引 0 为星期日，索引 6 为星期六）。
+     * @return 包含 7 个星期全称字符串的数组的常量引用。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the array of full weekday names (index 0 = Sunday, index 6 = Saturday).
+     * @return A constant reference to the array of 7 full weekday name strings.
+     * @endif
+     */
     virtual const std::array<std::basic_string<char8_t>, 7>& day_names() const { return m_day; }
+    /**
+     * @lang{ZH}
+     * @brief 返回星期缩写数组（索引 0 为星期日，索引 6 为星期六）。
+     * @return 包含 7 个星期缩写字符串的数组的常量引用。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the array of abbreviated weekday names (index 0 = Sunday, index 6 = Saturday).
+     * @return A constant reference to the array of 7 abbreviated weekday name strings.
+     * @endif
+     */
     virtual const std::array<std::basic_string<char8_t>, 7>& abbr_day_names() const { return m_abbr_day; }
+    /**
+     * @lang{ZH}
+     * @brief 返回月份全称数组（索引 0 为一月，索引 11 为十二月）。
+     * @return 包含 12 个月份全称字符串的数组的常量引用。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the array of full month names (index 0 = January, index 11 = December).
+     * @return A constant reference to the array of 12 full month name strings.
+     * @endif
+     */
     virtual const std::array<std::basic_string<char8_t>, 12>& month_names() const { return m_month; }
+    /**
+     * @lang{ZH}
+     * @brief 返回月份缩写数组（索引 0 为一月，索引 11 为十二月）。
+     * @return 包含 12 个月份缩写字符串的数组的常量引用。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the array of abbreviated month names (index 0 = January, index 11 = December).
+     * @return A constant reference to the array of 12 abbreviated month name strings.
+     * @endif
+     */
     virtual const std::array<std::basic_string<char8_t>, 12>& abbr_month_names() const { return m_abbr_month; }
+    /**
+     * @lang{ZH}
+     * @brief 返回 locale 定义的替代数字字符串数组（最多 100 项）。
+     * @return 包含 100 个替代数字字符串的数组的常量引用。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the locale-defined alternative digit strings (up to 100 entries).
+     * @return A constant reference to the array of 100 alternative digit strings.
+     * @endif
+     */
     virtual const std::array<std::basic_string<char8_t>, 100>& alt_digit_names() const { return m_alt_digits; }
+    /**
+     * @lang{ZH}
+     * @brief 返回 AM 时段字符串。
+     * @return AM 字符串的常量引用。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the AM period string.
+     * @return A constant reference to the AM string.
+     * @endif
+     */
     virtual const std::basic_string<char8_t>& am_name() const { return m_am; }
+    /**
+     * @lang{ZH}
+     * @brief 返回 PM 时段字符串。
+     * @return PM 字符串的常量引用。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the PM period string.
+     * @return A constant reference to the PM string.
+     * @endif
+     */
     virtual const std::basic_string<char8_t>& pm_name() const { return m_pm; }
+    /**
+     * @lang{ZH}
+     * @brief 返回 locale 日期格式串（对应 `%x`）。
+     * @return 日期格式串的常量引用。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the locale date format string (corresponding to `%x`).
+     * @return A constant reference to the date format string.
+     * @endif
+     */
     virtual const std::basic_string<char8_t>& date_format() const { return m_date_format; }
+    /**
+     * @lang{ZH}
+     * @brief 返回 locale 纪元修饰日期格式串（对应 `%Ex`）。
+     * @return 纪元修饰日期格式串的常量引用。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the locale era-modified date format string (corresponding to `%Ex`).
+     * @return A constant reference to the era-modified date format string.
+     * @endif
+     */
     virtual const std::basic_string<char8_t>& era_date_format() const { return m_era_date_format; }
+    /**
+     * @lang{ZH}
+     * @brief 返回 locale 时间格式串（对应 `%X`）。
+     * @return 时间格式串的常量引用。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the locale time format string (corresponding to `%X`).
+     * @return A constant reference to the time format string.
+     * @endif
+     */
     virtual const std::basic_string<char8_t>& time_format() const { return m_time_format; }
+    /**
+     * @lang{ZH}
+     * @brief 返回 locale 纪元修饰时间格式串（对应 `%EX`）。
+     * @return 纪元修饰时间格式串的常量引用。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the locale era-modified time format string (corresponding to `%EX`).
+     * @return A constant reference to the era-modified time format string.
+     * @endif
+     */
     virtual const std::basic_string<char8_t>& era_time_format() const { return m_era_time_format; }
+    /**
+     * @lang{ZH}
+     * @brief 返回时间加时区格式串。
+     * @return 时间加时区格式串的常量引用。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the time-plus-timezone format string.
+     * @return A constant reference to the time-plus-timezone format string.
+     * @endif
+     */
     virtual const std::basic_string<char8_t>& time_zone_format() const { return m_time_zone_format; }
+    /**
+     * @lang{ZH}
+     * @brief 返回纪元修饰时间加时区格式串。
+     * @return 纪元修饰时间加时区格式串的常量引用。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the era-modified time-plus-timezone format string.
+     * @return A constant reference to the era-modified time-plus-timezone format string.
+     * @endif
+     */
     virtual const std::basic_string<char8_t>& era_time_zone_format() const { return m_era_time_zone_format; }
+    /**
+     * @lang{ZH}
+     * @brief 返回 locale 日期时间格式串（对应 `%c`）。
+     * @return 日期时间格式串的常量引用。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the locale date-time format string (corresponding to `%c`).
+     * @return A constant reference to the date-time format string.
+     * @endif
+     */
     virtual const std::basic_string<char8_t>& date_time_format() const { return m_date_time_format; }
+    /**
+     * @lang{ZH}
+     * @brief 返回 locale 纪元修饰日期时间格式串（对应 `%Ec`）。
+     * @return 纪元修饰日期时间格式串的常量引用。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the locale era-modified date-time format string (corresponding to `%Ec`).
+     * @return A constant reference to the era-modified date-time format string.
+     * @endif
+     */
     virtual const std::basic_string<char8_t>& era_date_time_format() const { return m_era_date_time_format; }
+    /**
+     * @lang{ZH}
+     * @brief 返回日期时间加时区格式串。
+     * @return 日期时间加时区格式串的常量引用。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the date-time-plus-timezone format string.
+     * @return A constant reference to the date-time-plus-timezone format string.
+     * @endif
+     */
     virtual const std::basic_string<char8_t>& date_time_zone_format() const { return m_date_time_zone_format; }
+    /**
+     * @lang{ZH}
+     * @brief 返回纪元修饰日期时间加时区格式串。
+     * @return 纪元修饰日期时间加时区格式串的常量引用。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the era-modified date-time-plus-timezone format string.
+     * @return A constant reference to the era-modified date-time-plus-timezone format string.
+     * @endif
+     */
     virtual const std::basic_string<char8_t>& era_date_time_zone_format() const { return m_era_date_time_zone_format; }
+    /**
+     * @lang{ZH}
+     * @brief 返回 AM/PM 时间格式串（对应 `%r`）。
+     * @return AM/PM 时间格式串的常量引用。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the AM/PM time format string (corresponding to `%r`).
+     * @return A constant reference to the AM/PM time format string.
+     * @endif
+     */
     virtual const std::basic_string<char8_t>& am_pm_format() const { return m_am_pm_format; }
+    /**
+     * @lang{ZH}
+     * @brief 返回 locale 定义的纪元条目列表。
+     * @return 纪元条目列表的常量引用；若 locale 无纪元定义则为空 `vector`。
+     * @endif
+     *
+     * @lang{EN}
+     * @brief Returns the list of locale-defined era entries.
+     * @return A constant reference to the era entry list; an empty `vector` if the locale
+     *         defines no eras.
+     * @endif
+     */
     virtual const std::vector<era_entry>& era_items() const { return m_era_items; }
 
 private:


### PR DESCRIPTION
为 timeio_details.h 添加完整中英文 Doxygen 注释，涵盖：
- ft_basic<timeio<CharT>> 基类特化（era_entry 各字段、id()、s_timezone_tree）
- TimeioHelper 命名空间及 era_small_or_equal 辅助函数
- timeio_conf<char/wchar_t/char32_t/char8_t> 三个特化版本的类、构造函数、 所有访问器，以及 parse_glibc_era_entries（将原有 // 注释块转换为 Doxygen）

为 timeio.h 添加完整中英文 Doxygen 注释，涵盖：
- 文件头注释
- date_parse_helper/time_parse_helper/time_zone_parse_helper 辅助结构 （空主模板用 @cond 隐藏，true 特化加类注释及关键方法注释）
- time_parse_context 完整类注释、reset()、转换运算符
- timeio 类注释、两个构造函数、所有公共访问器、四个 put 重载、两个 get 重载
- 私有方法：do_get（RECURSION 注释转为 @note）、do_put、is_space、 check_unique_nonempty、validate_locale_names、create_era_name_tree、 create_alt_digits_tree、get_era_entry、put_dec、extract_num、 extract_num_with_alt_digits
- CTAD 导引用 @cond/@endcond 隐藏

所有注释遵循 @lang{ZH}/@lang{EN}/@endif 双语格式，与 device/ 目录风格一致。